### PR TITLE
chore: Bump prod image fallback version to v0.3.0

### DIFF
--- a/deploy/prod/.env.example
+++ b/deploy/prod/.env.example
@@ -46,7 +46,7 @@ ENVIRONMENT=production
 # Release Version
 # =============================================================================
 # Used by docker-compose to pull correct image tags
-VERSION=v0.1.0
+VERSION=v0.3.0
 
 # GitHub repository owner for GHCR image paths
 GITHUB_REPOSITORY_OWNER=your-org

--- a/deploy/prod/compose.prod.yaml
+++ b/deploy/prod/compose.prod.yaml
@@ -68,7 +68,7 @@ services:
   # ADR-0020: Port NOT published to host — all HTTP access goes through Traefik.
   # Traefik validates JWTs before forwarding requests to the gateway.
   gateway:
-    image: ghcr.io/${GITHUB_REPOSITORY_OWNER}/ruby-core-gateway:${VERSION:-v0.1.0}
+    image: ghcr.io/${GITHUB_REPOSITORY_OWNER}/ruby-core-gateway:${VERSION:-v0.3.0}
     container_name: ruby-core-prod-gateway
     restart: unless-stopped
     read_only: true
@@ -109,7 +109,7 @@ services:
   # Engine Service
   # ==========================================================================
   engine:
-    image: ghcr.io/${GITHUB_REPOSITORY_OWNER}/ruby-core-engine:${VERSION:-v0.1.0}
+    image: ghcr.io/${GITHUB_REPOSITORY_OWNER}/ruby-core-engine:${VERSION:-v0.3.0}
     container_name: ruby-core-prod-engine
     restart: unless-stopped
     read_only: true
@@ -144,7 +144,7 @@ services:
   # Notifier Service
   # ==========================================================================
   notifier:
-    image: ghcr.io/${GITHUB_REPOSITORY_OWNER}/ruby-core-notifier:${VERSION:-v0.1.0}
+    image: ghcr.io/${GITHUB_REPOSITORY_OWNER}/ruby-core-notifier:${VERSION:-v0.3.0}
     container_name: ruby-core-prod-notifier
     restart: unless-stopped
     read_only: true
@@ -175,7 +175,7 @@ services:
   # ==========================================================================
   # Multi-source presence fusion with WiFi corroboration and debounce.
   presence:
-    image: ghcr.io/${GITHUB_REPOSITORY_OWNER}/ruby-core-presence:${VERSION:-v0.1.0}
+    image: ghcr.io/${GITHUB_REPOSITORY_OWNER}/ruby-core-presence:${VERSION:-v0.3.0}
     container_name: ruby-core-prod-presence
     restart: unless-stopped
     read_only: true
@@ -214,7 +214,7 @@ services:
   # Runs as root in container (see Dockerfile comment) to write to the host bind mount.
   # Host path: /var/lib/ruby-core/audit — include in automated backup schedule.
   audit-sink:
-    image: ghcr.io/${GITHUB_REPOSITORY_OWNER}/ruby-core-audit-sink:${VERSION:-v0.1.0}
+    image: ghcr.io/${GITHUB_REPOSITORY_OWNER}/ruby-core-audit-sink:${VERSION:-v0.3.0}
     container_name: ruby-core-prod-audit-sink
     restart: unless-stopped
     security_opt:


### PR DESCRIPTION
## Summary

- Updates `${VERSION:-v0.1.0}` fallback to `${VERSION:-v0.3.0}` for all 5 service images in `deploy/prod/compose.prod.yaml`
- Updates `VERSION=v0.1.0` to `VERSION=v0.3.0` in `deploy/prod/.env.example`

The fallback is only used when `VERSION` is not set in the environment (e.g. a manual `docker compose up` without a `.env` file). Normal deploys pass `VERSION` explicitly via the release workflow or `.env`. This keeps the fallback aligned with the current release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)