### PR TITLE
feat: register Navi as authorized NATS user (dev/staging/prod)

### DIFF
--- a/scripts/fetch-nats-certs.sh
+++ b/scripts/fetch-nats-certs.sh
@@ -100,6 +100,8 @@ PUBKEY_NOTIFIER=$(fetch_pubkey notifier)
 PUBKEY_PRESENCE=$(fetch_pubkey presence)
 PUBKEY_ADMIN=$(fetch_pubkey admin)
 PUBKEY_AUDIT_SINK=$(fetch_pubkey audit-sink)
+PUBKEY_NAVI_DEV=$(fetch_pubkey navi-dev)
+PUBKEY_NAVI_PROD=$(fetch_pubkey navi-prod)
 
 echo "[nats-init] Generating auth.conf..."
 
@@ -264,6 +266,32 @@ authorization {
           allow: [
             "_INBOX.>"
           ]
+        }
+      }
+    },
+
+    # Navi digest service (dev)
+    {
+      nkey: "${PUBKEY_NAVI_DEV}"
+      permissions: {
+        publish: {
+          allow: ["navi.dev.>", "\$JS.API.>", "\$JS.ACK.>"]
+        }
+        subscribe: {
+          allow: ["navi.dev.>", "_INBOX.>"]
+        }
+      }
+    },
+
+    # Navi digest service (prod/staging)
+    {
+      nkey: "${PUBKEY_NAVI_PROD}"
+      permissions: {
+        publish: {
+          allow: ["navi.prod.>", "navi.staging.>", "\$JS.API.>", "\$JS.ACK.>"]
+        }
+        subscribe: {
+          allow: ["navi.prod.>", "navi.staging.>", "_INBOX.>"]
         }
       }
     },

--- a/scripts/fetch-nats-certs.sh
+++ b/scripts/fetch-nats-certs.sh
@@ -101,6 +101,7 @@ PUBKEY_PRESENCE=$(fetch_pubkey presence)
 PUBKEY_ADMIN=$(fetch_pubkey admin)
 PUBKEY_AUDIT_SINK=$(fetch_pubkey audit-sink)
 PUBKEY_NAVI_DEV=$(fetch_pubkey navi-dev)
+PUBKEY_NAVI_STAGING=$(fetch_pubkey navi-staging)
 PUBKEY_NAVI_PROD=$(fetch_pubkey navi-prod)
 
 echo "[nats-init] Generating auth.conf..."
@@ -283,15 +284,28 @@ authorization {
       }
     },
 
-    # Navi digest service (prod/staging)
+    # Navi digest service (staging)
+    {
+      nkey: "${PUBKEY_NAVI_STAGING}"
+      permissions: {
+        publish: {
+          allow: ["navi.staging.>", "\$JS.API.>", "\$JS.ACK.>"]
+        }
+        subscribe: {
+          allow: ["navi.staging.>", "_INBOX.>"]
+        }
+      }
+    },
+
+    # Navi digest service (prod)
     {
       nkey: "${PUBKEY_NAVI_PROD}"
       permissions: {
         publish: {
-          allow: ["navi.prod.>", "navi.staging.>", "\$JS.API.>", "\$JS.ACK.>"]
+          allow: ["navi.prod.>", "\$JS.API.>", "\$JS.ACK.>"]
         }
         subscribe: {
-          allow: ["navi.prod.>", "navi.staging.>", "_INBOX.>"]
+          allow: ["navi.prod.>", "_INBOX.>"]
         }
       }
     },

--- a/scripts/fetch-nats-certs.sh
+++ b/scripts/fetch-nats-certs.sh
@@ -276,7 +276,7 @@ authorization {
       nkey: "${PUBKEY_NAVI_DEV}"
       permissions: {
         publish: {
-          allow: ["navi.dev.>", "\$JS.API.>", "\$JS.ACK.>"]
+          allow: ["navi.dev.>", "audit.navi.>", "\$JS.API.>", "\$JS.ACK.>"]
         }
         subscribe: {
           allow: ["navi.dev.>", "_INBOX.>"]
@@ -289,7 +289,7 @@ authorization {
       nkey: "${PUBKEY_NAVI_STAGING}"
       permissions: {
         publish: {
-          allow: ["navi.staging.>", "\$JS.API.>", "\$JS.ACK.>"]
+          allow: ["navi.staging.>", "audit.navi.>", "\$JS.API.>", "\$JS.ACK.>"]
         }
         subscribe: {
           allow: ["navi.staging.>", "_INBOX.>"]
@@ -302,7 +302,7 @@ authorization {
       nkey: "${PUBKEY_NAVI_PROD}"
       permissions: {
         publish: {
-          allow: ["navi.prod.>", "\$JS.API.>", "\$JS.ACK.>"]
+          allow: ["navi.prod.>", "audit.navi.>", "\$JS.API.>", "\$JS.ACK.>"]
         }
         subscribe: {
           allow: ["navi.prod.>", "_INBOX.>"]


### PR DESCRIPTION
## Summary

- Adds `navi-dev`, `navi-staging`, and `navi-prod` as distinct NKEY-authenticated users in the NATS `auth.conf` generation script (`fetch-nats-certs.sh`)
- Each environment has its own keypair, its own scoped subject namespace (`navi.{env}.>`), and `audit.navi.>` publish permission
- Staging and prod share the same NATS server (port 4223) but have separate identities — no subject or credential sharing

Credentials provisioned in Vault (outside this PR):
- `secret/navi/{dev,staging,prod}/nats` — seed + url
- `secret/navi/{dev,staging,prod}/nats/tls` — cert, key, ca
- `secret/ruby-core/nats/navi-{dev,staging,prod}` — public_key (read by nats-init)

## Permissions per entry

| Entry | Publish | Subscribe |
|---|---|---|
| navi-dev | `navi.dev.>`, `audit.navi.>`, `$JS.API.>`, `$JS.ACK.>` | `navi.dev.>`, `_INBOX.>` |
| navi-staging | `navi.staging.>`, `audit.navi.>`, `$JS.API.>`, `$JS.ACK.>` | `navi.staging.>`, `_INBOX.>` |
| navi-prod | `navi.prod.>`, `audit.navi.>`, `$JS.API.>`, `$JS.ACK.>` | `navi.prod.>`, `_INBOX.>` |

## Test plan

- [x] `nats-init` ran cleanly after restart (no errors in container logs)
- [x] Dev NATS healthy: `curl http://127.0.0.1:8222/healthz` → `{"status":"ok"}`
- [x] Prod NATS healthy: `curl http://127.0.0.1:8223/healthz` → `{"status":"ok"}`
- [x] All prod services came back up after restart
- [ ] Navi client connects successfully using provisioned credentials (verified by Navi team)

## Pre-PR Checklist

- [x] README: no changes needed (credentials script, not user-facing)
- [x] Runbook: no changes needed (operational procedure unchanged)
- [x] ADR: no new decision (follows ADR-0015/ADR-0017 patterns)
- [x] Plan: no plan document (ad-hoc provisioning task)
- [x] Pre-commit hooks passed cleanly on all commits
- [x] Branch is single-concern
- [x] No drift observations

🤖 Generated with [Claude Code](https://claude.com/claude-code)