### PR TITLE
feat: add event-bus-prod/dev shared networks for external NATS access

### DIFF
--- a/deploy/dev/compose.dev.yaml
+++ b/deploy/dev/compose.dev.yaml
@@ -50,6 +50,9 @@ services:
       # TLS certificates and auth.conf (fetched/generated from Vault by nats-init)
       - nats-certs:/etc/nats/certs:ro
     command: ["-c", "/etc/nats/nats.conf"]
+    networks:
+      - default
+      - event-bus-dev
     healthcheck:
       # Health check via HTTP monitoring endpoint
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:8222/healthz"]
@@ -232,6 +235,12 @@ networks:
   vault-ruby-core-dev:
     external: true
     name: vault-ruby-core-dev
+  # Shared event-bus network — external services (e.g. Navi) join this to reach NATS
+  # without coupling to ruby-core's internal compose network.
+  # Create with: docker network create event-bus-dev
+  event-bus-dev:
+    external: true
+    name: event-bus-dev
 
 # ==========================================================================
 # Named Volumes

--- a/deploy/prod/compose.prod.yaml
+++ b/deploy/prod/compose.prod.yaml
@@ -51,6 +51,9 @@ services:
       # TLS certificates and auth.conf (fetched/generated from Vault by nats-init)
       - nats-certs:/etc/nats/certs:ro
     command: ["-c", "/etc/nats/nats.conf"]
+    networks:
+      - default
+      - event-bus-prod
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:8222/healthz"]
       interval: 30s
@@ -251,6 +254,12 @@ networks:
   vault-ruby-core-prod:
     external: true
     name: vault-ruby-core-prod
+  # Shared event-bus network — external services (e.g. Navi) join this to reach NATS
+  # without coupling to ruby-core's internal compose network.
+  # Create with: docker network create event-bus-prod
+  event-bus-prod:
+    external: true
+    name: event-bus-prod
   # Traefik proxy network (ADR-0020). Create with: docker network create traefik_proxy
   traefik_proxy:
     external: true


### PR DESCRIPTION
## Summary

- Adds NATS containers (dev and prod) to external `event-bus-dev` / `event-bus-prod` Docker networks so services outside the ruby-core compose stack (e.g. Navi) can reach JetStream without coupling to ruby-core's internal default network
- Follows the same pattern as the existing `vault-ruby-core-{env}` external networks
- Internal ruby-core services are unaffected — they continue using `tls://nats:4222` on the default network

## Details

Both `event-bus-dev` and `event-bus-prod` networks already exist on the host. The compose change is purely additive — NATS joins an additional network, no existing connectivity changes.

Network creation (if needed on a fresh host):
```
docker network create event-bus-dev
docker network create event-bus-prod
```

## Drift Observations

- No `make` target exists for creating the `event-bus-{dev,prod}` networks. Currently documented only in the compose file comment. A `make setup-networks` or similar target would make fresh host setup more reliable.

## Test plan

- [x] `event-bus-dev` and `event-bus-prod` networks confirmed present on host
- [ ] Deploy to dev — confirm NATS container starts cleanly and joins both networks (`docker inspect ruby-core-dev-nats-1 | grep -A5 Networks`)
- [ ] Confirm existing ruby-core services unaffected (engine, gateway connect normally)
- [ ] Confirm Navi can reach JetStream via `event-bus-dev` after joining that network

🤖 Generated with [Claude Code](https://claude.com/claude-code)