### PR TITLE
fix(ada): derive last-fed sensors from DB rather than event time

### DIFF
--- a/deploy/prod/.env.example
+++ b/deploy/prod/.env.example
@@ -46,7 +46,7 @@ ENVIRONMENT=production
 # Release Version
 # =============================================================================
 # Used by docker-compose to pull correct image tags
-VERSION=v0.5.8
+VERSION=v0.5.9
 
 # GitHub repository owner for GHCR image paths
 GITHUB_REPOSITORY_OWNER=your-org

--- a/deploy/prod/compose.prod.yaml
+++ b/deploy/prod/compose.prod.yaml
@@ -71,7 +71,7 @@ services:
   # ADR-0020: Port NOT published to host — all HTTP access goes through Traefik.
   # Traefik validates JWTs before forwarding requests to the gateway.
   gateway:
-    image: ghcr.io/${GITHUB_REPOSITORY_OWNER}/ruby-core-gateway:${VERSION:-v0.5.8}
+    image: ghcr.io/${GITHUB_REPOSITORY_OWNER}/ruby-core-gateway:${VERSION:-v0.5.9}
     container_name: ruby-core-prod-gateway
     restart: unless-stopped
     read_only: true
@@ -112,7 +112,7 @@ services:
   # Engine Service
   # ==========================================================================
   engine:
-    image: ghcr.io/${GITHUB_REPOSITORY_OWNER}/ruby-core-engine:${VERSION:-v0.5.8}
+    image: ghcr.io/${GITHUB_REPOSITORY_OWNER}/ruby-core-engine:${VERSION:-v0.5.9}
     container_name: ruby-core-prod-engine
     restart: unless-stopped
     read_only: true
@@ -146,7 +146,7 @@ services:
   # Notifier Service
   # ==========================================================================
   notifier:
-    image: ghcr.io/${GITHUB_REPOSITORY_OWNER}/ruby-core-notifier:${VERSION:-v0.5.8}
+    image: ghcr.io/${GITHUB_REPOSITORY_OWNER}/ruby-core-notifier:${VERSION:-v0.5.9}
     container_name: ruby-core-prod-notifier
     restart: unless-stopped
     read_only: true
@@ -177,7 +177,7 @@ services:
   # ==========================================================================
   # Multi-source presence fusion with WiFi corroboration and debounce.
   presence:
-    image: ghcr.io/${GITHUB_REPOSITORY_OWNER}/ruby-core-presence:${VERSION:-v0.5.8}
+    image: ghcr.io/${GITHUB_REPOSITORY_OWNER}/ruby-core-presence:${VERSION:-v0.5.9}
     container_name: ruby-core-prod-presence
     restart: unless-stopped
     read_only: true
@@ -216,7 +216,7 @@ services:
   # Runs as root in container (see Dockerfile comment) to write to the host bind mount.
   # Host path: /var/lib/ruby-core/audit — include in automated backup schedule.
   audit-sink:
-    image: ghcr.io/${GITHUB_REPOSITORY_OWNER}/ruby-core-audit-sink:${VERSION:-v0.5.8}
+    image: ghcr.io/${GITHUB_REPOSITORY_OWNER}/ruby-core-audit-sink:${VERSION:-v0.5.9}
     container_name: ruby-core-prod-audit-sink
     restart: unless-stopped
     security_opt:

--- a/deploy/staging/.env.example
+++ b/deploy/staging/.env.example
@@ -8,7 +8,7 @@
 #   make setup-staging-creds   # generates secret/ruby-core/staging/* in Vault
 #   make ghcr-login            # authenticates Docker with GHCR (persists)
 
-VERSION=v0.5.8
+VERSION=v0.5.9
 VAULT_TOKEN=
 VAULT_ADDR=https://127.0.0.1:8200
 VAULT_CACERT=/opt/foundation/vault/tls/vault-ca.crt

--- a/deploy/staging/compose.staging.yaml
+++ b/deploy/staging/compose.staging.yaml
@@ -15,7 +15,7 @@
 # Usage:
 #   make staging-up            # start stack
 #   make staging-down          # stop and remove volumes
-#   make deploy-staging VERSION=v0.5.8   # pull + start + smoke test + tear down
+#   make deploy-staging VERSION=v0.5.9   # pull + start + smoke test + tear down
 
 services:
   # ==========================================================================

--- a/services/engine/processors/ada/processor.go
+++ b/services/engine/processors/ada/processor.go
@@ -230,7 +230,7 @@ func (p *Processor) handleFeedingEnded(ctx context.Context, evt schemas.CloudEve
 		segStart = segEnd
 	}
 
-	p.pushFeedingSensors(ctx, sessionStart, source, false)
+	p.pushFeedingSensors(ctx)
 	return nil
 }
 
@@ -269,7 +269,7 @@ func (p *Processor) handleFeedingLogged(ctx context.Context, evt schemas.CloudEv
 		}
 	}
 
-	p.pushFeedingSensors(ctx, startTime, source, false)
+	p.pushFeedingSensors(ctx)
 	return nil
 }
 
@@ -360,7 +360,7 @@ func (p *Processor) handleFeedingLoggedPast(ctx context.Context, evt schemas.Clo
 		}
 	}
 
-	p.pushFeedingSensors(ctx, startTime, source, hasBottle)
+	p.pushFeedingSensors(ctx)
 	return nil
 }
 
@@ -580,11 +580,18 @@ func (p *Processor) handleThresholdChange(ctx context.Context, evt schemas.Cloud
 // ── Sensor push helpers ───────────────────────────────────────────────────────
 
 // pushFeedingSensors pushes all feeding-related sensors after a feeding event.
-// lastFeedingTime is the actual event time (never time.Now()).
-// source is the raw DB source value; it is mapped to a display label before pushing.
-// hasBottleDetail is true when a feeding_bottle_detail row was written for this event
-// (affects the display label for breast feedings that also have a supplement).
-func (p *Processor) pushFeedingSensors(ctx context.Context, lastFeedingTime time.Time, source string, hasBottleDetail bool) {
+// It queries GetLastFeeding to determine the actual most-recent feeding by timestamp,
+// so backdated entries never displace a later feeding from the last-fed display.
+func (p *Processor) pushFeedingSensors(ctx context.Context) {
+	last, err := p.q.GetLastFeeding(ctx)
+	if err != nil {
+		if !errors.Is(err, pgx.ErrNoRows) {
+			p.log.Warn("ada: get last feeding for sensor push", slog.String("error", err.Error()))
+		}
+		return
+	}
+
+	lastFeedingTime := last.Timestamp.Time
 	lastTimeStr := lastFeedingTime.UTC().Format(time.RFC3339)
 
 	// Compute next feeding target using stored interval (or default).
@@ -607,7 +614,7 @@ func (p *Processor) pushFeedingSensors(ctx context.Context, lastFeedingTime time
 
 	pushes := []struct{ id, state string }{
 		{sensorLastFeedingTime, lastTimeStr},
-		{sensorLastFeedingSource, feedingDisplaySource(source, hasBottleDetail)},
+		{sensorLastFeedingSource, feedingDisplaySource(last.Source, last.HasBottleDetail)},
 		{sensorNextFeedingTarget, nextTargetStr},
 	}
 	if agg != nil {


### PR DESCRIPTION
## Summary

- Fixes "last fed" countdown resetting to an earlier time when a backdated feeding is logged
- `pushFeedingSensors` now queries `GetLastFeeding` (ordered by `timestamp DESC`) to determine what to push, rather than blindly pushing the just-logged event's timestamp
- Bumps version to v0.5.9

## Root cause

`pushFeedingSensors` previously accepted `startTime`, `source`, and `hasBottleDetail` as arguments and pushed them directly as `sensor.ada_last_feeding_time` / `sensor.ada_last_feeding_source`. Logging a past feeding at 8am after an existing noon feeding would overwrite the sensor with 8am, making the countdown appear to reset backwards. `nextTarget` was also computed off the wrong anchor.

## Fix

Removed the three parameters. The function now calls `GetLastFeeding` internally — the sensor always reflects the most-recent feeding by event timestamp, regardless of insertion order. All three call sites (`handleFeedingEnded`, `handleFeedingLogged`, `handleFeedingLoggedPast`) updated.

## Related

Three companion HomeAssistant frontend bugs filed separately:
- rutabageldev/homeassistant#9 — sleep button lags status strip by up to 1 minute
- rutabageldev/homeassistant#10 — breast feed source label missing from history modal
- rutabageldev/homeassistant#11 — past bottle feedings gain 0.01 oz from `Math.round()`

## Test plan

- [x] `go test -tags=fast -race ./...` — 13/13 passing, no races
- [ ] Log a feeding at noon, then log a past feeding at 8am — confirm `sensor.ada_last_feeding_time` stays at noon
- [ ] Confirm `sensor.ada_next_feeding_target` is computed from noon, not 8am

🤖 Generated with [Claude Code](https://claude.com/claude-code)