### PR TITLE
fix: exclude system-generated HA users from caretaker sync (v0.8.2)

### DIFF
--- a/deploy/prod/.env.example
+++ b/deploy/prod/.env.example
@@ -46,7 +46,7 @@ ENVIRONMENT=production
 # Release Version
 # =============================================================================
 # Used by docker-compose to pull correct image tags
-VERSION=v0.8.1
+VERSION=v0.8.2
 
 # GitHub repository owner for GHCR image paths
 GITHUB_REPOSITORY_OWNER=your-org

--- a/deploy/staging/.env.example
+++ b/deploy/staging/.env.example
@@ -8,7 +8,7 @@
 #   make setup-staging-creds   # generates secret/ruby-core/staging/* in Vault
 #   make ghcr-login            # authenticates Docker with GHCR (persists)
 
-VERSION=v0.8.1
+VERSION=v0.8.2
 VAULT_TOKEN=
 VAULT_ADDR=https://127.0.0.1:8200
 VAULT_CACERT=/opt/foundation/vault/tls/vault-ca.crt

--- a/services/gateway/ha/client.go
+++ b/services/gateway/ha/client.go
@@ -51,10 +51,11 @@ type haEntityState struct {
 
 // haUserEntry is one HA user account from the config/auth/list WebSocket response.
 type haUserEntry struct {
-	ID       string `json:"id"`
-	Name     string `json:"name"`
-	Username string `json:"username"`
-	IsActive bool   `json:"is_active"`
+	ID              string `json:"id"`
+	Name            string `json:"name"`
+	Username        string `json:"username"`
+	IsActive        bool   `json:"is_active"`
+	SystemGenerated bool   `json:"system_generated"`
 }
 
 // Client connects to the Home Assistant WebSocket API, subscribes to
@@ -374,7 +375,7 @@ func (c *Client) syncUsers(ctx context.Context, conn *websocket.Conn, id int) er
 
 	users := make([]schemas.AdaHAUser, 0, len(haUsers))
 	for _, u := range haUsers {
-		if !u.IsActive {
+		if !u.IsActive || u.SystemGenerated {
 			continue
 		}
 		users = append(users, schemas.AdaHAUser{


### PR DESCRIPTION
## Summary

- HA's `config/auth/list` response includes service accounts (Home Assistant Cast, Cloud, Content) alongside real user accounts. These have `system_generated: true` and were appearing in the caretaker list unnecessarily.
- Added `SystemGenerated bool` to `haUserEntry` and filter them out alongside inactive users during sync.

## Pre-PR Checklist

- [x] README — no changes needed
- [x] Runbook — no operational impact; sync behavior change is transparent
- [x] ADR — no new architectural decision
- [x] No plan required for this scope
- [x] Pre-commit hooks pass clean
- [x] Branch is single-concern
- [x] Version bumped to v0.8.2 in all four references (prod/.env.example, staging/.env.example, prod/.env, staging/.env)

## Test Plan

- [x] CI passes
- [x] After deploy: fire `ada.sync_users` → confirm Cast, Cloud, and Content no longer appear in `sensor.ada_caretakers` attributes

🤖 Generated with [Claude Code](https://claude.com/claude-code)