### PR TITLE
fix: boundary sensor attrs + diaper/sleep history boundary (Effort 4 companion)

### DIFF
--- a/deploy/prod/.env.example
+++ b/deploy/prod/.env.example
@@ -46,7 +46,7 @@ ENVIRONMENT=production
 # Release Version
 # =============================================================================
 # Used by docker-compose to pull correct image tags
-VERSION=v0.10.0
+VERSION=v0.10.1
 
 # GitHub repository owner for GHCR image paths
 GITHUB_REPOSITORY_OWNER=your-org

--- a/deploy/staging/.env.example
+++ b/deploy/staging/.env.example
@@ -8,7 +8,7 @@
 #   make setup-staging-creds   # generates secret/ruby-core/staging/* in Vault
 #   make ghcr-login            # authenticates Docker with GHCR (persists)
 
-VERSION=v0.10.0
+VERSION=v0.10.1
 VAULT_TOKEN=
 VAULT_ADDR=https://127.0.0.1:8200
 VAULT_CACERT=/opt/foundation/vault/tls/vault-ca.crt

--- a/services/engine/processors/ada/processor.go
+++ b/services/engine/processors/ada/processor.go
@@ -915,7 +915,7 @@ func (p *Processor) pushDiaperSensors(ctx context.Context, lastDiaperTime time.T
 		)
 	}
 	p.pushAll(ctx, pushes)
-	p.pushDiaperHistory(ctx)
+	p.pushDiaperHistory(ctx, btz)
 }
 
 // pushSupplementOzSensor pushes today_feeding_oz and last_feeding_source after
@@ -945,7 +945,8 @@ func (p *Processor) pushSleepStartedSensors(ctx context.Context, startTime time.
 		{sensorLastSleepChange, startTime.UTC().Format(time.RFC3339)},
 		{sensorSleepSessionMin, strconv.Itoa(sleepElapsedMin(startTime))},
 	})
-	p.pushSleepHistory(ctx)
+	btz := p.todayBoundaryTz(ctx)
+	p.pushSleepHistory(ctx, btz)
 }
 
 // pushSleepEndedSensors pushes sensors after a sleep session ends.
@@ -970,7 +971,7 @@ func (p *Processor) pushSleepEndedSensors(ctx context.Context, endTime time.Time
 		)
 	}
 	p.pushAll(ctx, pushes)
-	p.pushSleepHistory(ctx)
+	p.pushSleepHistory(ctx, btz)
 }
 
 // pushTummySensors pushes tummy time aggregate sensors.
@@ -1063,7 +1064,7 @@ func (p *Processor) pushDailyAggregates(ctx context.Context) {
 	} else {
 		p.log.Warn("ada: restore today diaper aggregates", slog.String("error", err.Error()))
 	}
-	p.pushDiaperHistory(ctx)
+	p.pushDiaperHistory(ctx, btz)
 
 	if agg, err := p.q.GetTodaySleepAggregates(ctx, btz); err == nil {
 		p.pushAll(ctx, []struct{ id, state string }{
@@ -1074,7 +1075,7 @@ func (p *Processor) pushDailyAggregates(ctx context.Context) {
 	} else {
 		p.log.Warn("ada: restore today sleep aggregates", slog.String("error", err.Error()))
 	}
-	p.pushSleepHistory(ctx)
+	p.pushSleepHistory(ctx, btz)
 
 	if agg, err := p.q.GetTodayTummyAggregates(ctx, btz); err == nil {
 		p.pushAll(ctx, []struct{ id, state string }{
@@ -1159,18 +1160,18 @@ func (p *Processor) todayBoundaryTz(ctx context.Context) pgtype.Timestamptz {
 	return pgtype.Timestamptz{Time: boundary, Valid: true}
 }
 
-// pushTodayBoundary pushes sensor.ada_today_boundary with the current boundary
-// time so the HA dashboard can display elapsed-time since the boundary.
+// pushTodayBoundary pushes sensor.ada_today_boundary so the HA dashboard can
+// display elapsed-time since the boundary and pre-populate the config sub-screen.
 func (p *Processor) pushTodayBoundary(ctx context.Context) {
-	bedtimeHHMM := "19:00"
-	if row, err := p.q.GetConfig(ctx, cfgKeyBedtimeHHMM); err == nil {
-		bedtimeHHMM = row.Value
-	}
-	boundary := computeTodayBoundary(bedtimeHHMM)
+	cfg := p.loadSleepConfig(ctx)
+	boundary := computeTodayBoundary(cfg.BedtimeHHMM)
 	if err := p.ha.PushState(ctx, sensorTodayBoundary,
 		boundary.UTC().Format(time.RFC3339),
 		map[string]any{
 			"boundary_local": boundary.Format("Jan 2, 2006 3:04 PM"),
+			"bedtime_hhmm":   cfg.BedtimeHHMM,
+			"daytime_hhmm":   cfg.DaytimeHHMM,
+			"grace_min":      cfg.GraceMin,
 		},
 	); err != nil {
 		p.log.Warn("ada: push today boundary", slog.String("error", err.Error()))
@@ -1427,26 +1428,27 @@ type DiaperHistoryEntry struct {
 	ID        string `json:"id"`
 	Timestamp string `json:"timestamp"`
 	Type      string `json:"type"`
+	LoggedBy  string `json:"logged_by"`
 }
 
 // buildDiaperHistory converts sqlc rows to JSON-serializable history entries.
-func buildDiaperHistory(rows []*store.GetLast24hDiapersRow) []DiaperHistoryEntry {
+func buildDiaperHistory(rows []*store.GetTodayDiapersRow) []DiaperHistoryEntry {
 	entries := make([]DiaperHistoryEntry, 0, len(rows))
 	for _, r := range rows {
 		entries = append(entries, DiaperHistoryEntry{
 			ID:        uuid.UUID(r.ID.Bytes).String(),
 			Timestamp: r.Timestamp.Time.UTC().Format(time.RFC3339),
 			Type:      r.Type,
+			LoggedBy:  r.LoggedBy,
 		})
 	}
 	return entries
 }
 
-// pushDiaperHistory queries the last 24h of diaper events and pushes them as
-// attributes on sensor.ada_diaper_history. Uses a fixed 24h window (not boundary)
-// so the history modal always shows recent context regardless of when Today started.
-func (p *Processor) pushDiaperHistory(ctx context.Context) {
-	rows, err := p.q.GetLast24hDiapers(ctx)
+// pushDiaperHistory queries diaper events since the bedtime boundary and pushes
+// them as attributes on sensor.ada_diaper_history.
+func (p *Processor) pushDiaperHistory(ctx context.Context, btz pgtype.Timestamptz) {
+	rows, err := p.q.GetTodayDiapers(ctx, btz)
 	if err != nil {
 		p.log.Warn("ada: query diaper history", slog.String("error", err.Error()))
 		return
@@ -1470,20 +1472,24 @@ type SleepHistoryEntry struct {
 	StartTime string  `json:"start_time"`
 	EndTime   *string `json:"end_time,omitempty"`
 	SleepType string  `json:"sleep_type"`
+	LoggedBy  string  `json:"logged_by"`
 	DurationS *int    `json:"duration_s,omitempty"`
 }
 
 // buildSleepHistory converts sqlc rows to JSON-serializable history entries.
-// Active sessions (EndTime.Valid=false) are included with EndTime and DurationS omitted.
-func buildSleepHistory(rows []*store.GetLast24hSleepSessionsRow) []SleepHistoryEntry {
+// Active sessions (IsComplete=false) are included with EndTime and DurationS omitted.
+// end_time is always populated by COALESCE in the query; IsComplete distinguishes
+// a real end_time from the NOW() placeholder used for active sessions.
+func buildSleepHistory(rows []*store.GetTodaySleepSessionsRow) []SleepHistoryEntry {
 	entries := make([]SleepHistoryEntry, 0, len(rows))
 	for _, r := range rows {
 		e := SleepHistoryEntry{
 			ID:        uuid.UUID(r.ID.Bytes).String(),
 			StartTime: r.StartTime.Time.UTC().Format(time.RFC3339),
 			SleepType: r.SleepType,
+			LoggedBy:  r.LoggedBy,
 		}
-		if r.EndTime.Valid {
+		if r.IsComplete {
 			s := r.EndTime.Time.UTC().Format(time.RFC3339)
 			e.EndTime = &s
 			d := int(r.EndTime.Time.Sub(r.StartTime.Time).Seconds())
@@ -1494,11 +1500,10 @@ func buildSleepHistory(rows []*store.GetLast24hSleepSessionsRow) []SleepHistoryE
 	return entries
 }
 
-// pushSleepHistory queries the last 24h of sleep sessions and pushes them as
-// attributes on sensor.ada_sleep_history. Uses a fixed 24h window (not boundary)
-// so the history modal always shows recent context regardless of when Today started.
-func (p *Processor) pushSleepHistory(ctx context.Context) {
-	rows, err := p.q.GetLast24hSleepSessions(ctx)
+// pushSleepHistory queries sleep sessions since the bedtime boundary and pushes
+// them as attributes on sensor.ada_sleep_history.
+func (p *Processor) pushSleepHistory(ctx context.Context, btz pgtype.Timestamptz) {
+	rows, err := p.q.GetTodaySleepSessions(ctx, btz)
 	if err != nil {
 		p.log.Warn("ada: query sleep history", slog.String("error", err.Error()))
 		return

--- a/services/engine/processors/ada/processor_test.go
+++ b/services/engine/processors/ada/processor_test.go
@@ -356,11 +356,12 @@ func TestBuildDiaperHistory_Empty(t *testing.T) {
 }
 
 func TestBuildDiaperHistory_Single(t *testing.T) {
-	rows := []*store.GetLast24hDiapersRow{
+	rows := []*store.GetTodayDiapersRow{
 		{
 			ID:        mustUUID("bbbbbbbb-0000-0000-0000-000000000001"),
 			Timestamp: mustTimestamptz("2026-04-01T10:00:00Z"),
 			Type:      "wet",
+			LoggedBy:  "test",
 		},
 	}
 	entries := buildDiaperHistory(rows)
@@ -386,12 +387,14 @@ func TestBuildSleepHistory_Empty(t *testing.T) {
 }
 
 func TestBuildSleepHistory_CompletedSession(t *testing.T) {
-	rows := []*store.GetLast24hSleepSessionsRow{
+	rows := []*store.GetTodaySleepSessionsRow{
 		{
-			ID:        mustUUID("cccccccc-0000-0000-0000-000000000001"),
-			StartTime: mustTimestamptz("2026-04-01T08:00:00Z"),
-			EndTime:   mustTimestamptz("2026-04-01T09:30:00Z"),
-			SleepType: "nap",
+			ID:         mustUUID("cccccccc-0000-0000-0000-000000000001"),
+			StartTime:  mustTimestamptz("2026-04-01T08:00:00Z"),
+			EndTime:    mustTimestamptz("2026-04-01T09:30:00Z"),
+			SleepType:  "nap",
+			LoggedBy:   "test",
+			IsComplete: true,
 		},
 	}
 	entries := buildSleepHistory(rows)
@@ -417,13 +420,17 @@ func TestBuildSleepHistory_CompletedSession(t *testing.T) {
 }
 
 func TestBuildSleepHistory_ActiveSession(t *testing.T) {
-	// Active sessions have EndTime.Valid=false; EndTime and DurationS must be omitted.
-	rows := []*store.GetLast24hSleepSessionsRow{
+	// Active sessions have IsComplete=false; EndTime and DurationS must be omitted.
+	// end_time is always populated by COALESCE(end_time, NOW()) in the query, so
+	// EndTime is always valid — IsComplete is the sole active-session discriminator.
+	rows := []*store.GetTodaySleepSessionsRow{
 		{
-			ID:        mustUUID("dddddddd-0000-0000-0000-000000000001"),
-			StartTime: mustTimestamptz("2026-04-01T22:00:00Z"),
-			EndTime:   pgtype.Timestamptz{Valid: false},
-			SleepType: "night",
+			ID:         mustUUID("dddddddd-0000-0000-0000-000000000001"),
+			StartTime:  mustTimestamptz("2026-04-01T22:00:00Z"),
+			EndTime:    mustTimestamptz("2026-04-01T22:45:00Z"), // simulates NOW() from COALESCE
+			SleepType:  "night",
+			LoggedBy:   "test",
+			IsComplete: false,
 		},
 	}
 	entries := buildSleepHistory(rows)

--- a/services/engine/processors/ada/store/diapers.sql.go
+++ b/services/engine/processors/ada/store/diapers.sql.go
@@ -11,41 +11,6 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-const getLast24hDiapers = `-- name: GetLast24hDiapers :many
-SELECT id, timestamp, type
-FROM diapers
-WHERE deleted_at IS NULL
-  AND timestamp >= NOW() - INTERVAL '24 hours'
-ORDER BY timestamp DESC
-`
-
-type GetLast24hDiapersRow struct {
-	ID        pgtype.UUID
-	Timestamp pgtype.Timestamptz
-	Type      string
-}
-
-// Returns all diaper events in the last 24 hours ordered newest-first.
-func (q *Queries) GetLast24hDiapers(ctx context.Context) ([]*GetLast24hDiapersRow, error) {
-	rows, err := q.db.Query(ctx, getLast24hDiapers)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*GetLast24hDiapersRow
-	for rows.Next() {
-		var i GetLast24hDiapersRow
-		if err := rows.Scan(&i.ID, &i.Timestamp, &i.Type); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const getLastDiaper = `-- name: GetLastDiaper :one
 SELECT timestamp, type FROM diapers
 WHERE deleted_at IS NULL
@@ -92,6 +57,47 @@ func (q *Queries) GetTodayDiaperAggregates(ctx context.Context, boundary pgtype.
 		&i.Mixed,
 	)
 	return &i, err
+}
+
+const getTodayDiapers = `-- name: GetTodayDiapers :many
+SELECT id, timestamp, type, logged_by
+FROM diapers
+WHERE deleted_at IS NULL
+  AND timestamp >= $1
+ORDER BY timestamp DESC
+`
+
+type GetTodayDiapersRow struct {
+	ID        pgtype.UUID
+	Timestamp pgtype.Timestamptz
+	Type      string
+	LoggedBy  string
+}
+
+// Returns all diaper events since the bedtime boundary, ordered newest-first.
+func (q *Queries) GetTodayDiapers(ctx context.Context, boundary pgtype.Timestamptz) ([]*GetTodayDiapersRow, error) {
+	rows, err := q.db.Query(ctx, getTodayDiapers, boundary)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*GetTodayDiapersRow
+	for rows.Next() {
+		var i GetTodayDiapersRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.Timestamp,
+			&i.Type,
+			&i.LoggedBy,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const insertDiaper = `-- name: InsertDiaper :exec

--- a/services/engine/processors/ada/store/queries/diapers.sql
+++ b/services/engine/processors/ada/store/queries/diapers.sql
@@ -17,10 +17,10 @@ FROM diapers
 WHERE deleted_at IS NULL
   AND timestamp >= @boundary;
 
--- name: GetLast24hDiapers :many
--- Returns all diaper events in the last 24 hours ordered newest-first.
-SELECT id, timestamp, type
+-- name: GetTodayDiapers :many
+-- Returns all diaper events since the bedtime boundary, ordered newest-first.
+SELECT id, timestamp, type, logged_by
 FROM diapers
 WHERE deleted_at IS NULL
-  AND timestamp >= NOW() - INTERVAL '24 hours'
+  AND timestamp >= @boundary
 ORDER BY timestamp DESC;

--- a/services/engine/processors/ada/store/queries/sleep.sql
+++ b/services/engine/processors/ada/store/queries/sleep.sql
@@ -37,13 +37,18 @@ FROM sleep_sessions
 WHERE deleted_at IS NULL
   AND (end_time IS NULL OR end_time > @boundary);
 
--- name: GetLast24hSleepSessions :many
--- Returns sleep sessions that started in the last 24 hours, newest-first.
--- end_time is zero-value (Valid=false) for active sessions. duration_s is
--- computed in Go from start_time and end_time to avoid a CASE expression
--- that sqlc cannot type statically.
-SELECT id, start_time, end_time, sleep_type
+-- name: GetTodaySleepSessions :many
+-- Returns sleep sessions active since the bedtime boundary, newest-first.
+-- COALESCE ensures end_time is always non-null; is_complete distinguishes
+-- active sessions (end_time IS NULL) from completed ones.
+SELECT
+    id,
+    start_time,
+    COALESCE(end_time, NOW()) AS end_time,
+    sleep_type,
+    logged_by,
+    (end_time IS NOT NULL)::bool AS is_complete
 FROM sleep_sessions
 WHERE deleted_at IS NULL
-  AND start_time >= NOW() - INTERVAL '24 hours'
+  AND (end_time IS NULL OR end_time > @boundary)
 ORDER BY start_time DESC;

--- a/services/engine/processors/ada/store/sleep.sql.go
+++ b/services/engine/processors/ada/store/sleep.sql.go
@@ -24,50 +24,6 @@ func (q *Queries) GetActiveSleepSession(ctx context.Context) (pgtype.Timestamptz
 	return start_time, err
 }
 
-const getLast24hSleepSessions = `-- name: GetLast24hSleepSessions :many
-SELECT id, start_time, end_time, sleep_type
-FROM sleep_sessions
-WHERE deleted_at IS NULL
-  AND start_time >= NOW() - INTERVAL '24 hours'
-ORDER BY start_time DESC
-`
-
-type GetLast24hSleepSessionsRow struct {
-	ID        pgtype.UUID
-	StartTime pgtype.Timestamptz
-	EndTime   pgtype.Timestamptz
-	SleepType string
-}
-
-// Returns sleep sessions that started in the last 24 hours, newest-first.
-// end_time is zero-value (Valid=false) for active sessions. duration_s is
-// computed in Go from start_time and end_time to avoid a CASE expression
-// that sqlc cannot type statically.
-func (q *Queries) GetLast24hSleepSessions(ctx context.Context) ([]*GetLast24hSleepSessionsRow, error) {
-	rows, err := q.db.Query(ctx, getLast24hSleepSessions)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*GetLast24hSleepSessionsRow
-	for rows.Next() {
-		var i GetLast24hSleepSessionsRow
-		if err := rows.Scan(
-			&i.ID,
-			&i.StartTime,
-			&i.EndTime,
-			&i.SleepType,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
 const getLastSleepEnd = `-- name: GetLastSleepEnd :one
 SELECT end_time FROM sleep_sessions
 WHERE end_time IS NOT NULL AND deleted_at IS NULL
@@ -104,6 +60,59 @@ func (q *Queries) GetTodaySleepAggregates(ctx context.Context, boundary pgtype.T
 	var i GetTodaySleepAggregatesRow
 	err := row.Scan(&i.TotalHours, &i.NightCount, &i.NapCount)
 	return &i, err
+}
+
+const getTodaySleepSessions = `-- name: GetTodaySleepSessions :many
+SELECT
+    id,
+    start_time,
+    COALESCE(end_time, NOW()) AS end_time,
+    sleep_type,
+    logged_by,
+    (end_time IS NOT NULL)::bool AS is_complete
+FROM sleep_sessions
+WHERE deleted_at IS NULL
+  AND (end_time IS NULL OR end_time > $1)
+ORDER BY start_time DESC
+`
+
+type GetTodaySleepSessionsRow struct {
+	ID         pgtype.UUID
+	StartTime  pgtype.Timestamptz
+	EndTime    pgtype.Timestamptz
+	SleepType  string
+	LoggedBy   string
+	IsComplete bool
+}
+
+// Returns sleep sessions active since the bedtime boundary, newest-first.
+// COALESCE ensures end_time is always non-null; is_complete distinguishes
+// active sessions (end_time IS NULL) from completed ones.
+func (q *Queries) GetTodaySleepSessions(ctx context.Context, boundary pgtype.Timestamptz) ([]*GetTodaySleepSessionsRow, error) {
+	rows, err := q.db.Query(ctx, getTodaySleepSessions, boundary)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*GetTodaySleepSessionsRow
+	for rows.Next() {
+		var i GetTodaySleepSessionsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.StartTime,
+			&i.EndTime,
+			&i.SleepType,
+			&i.LoggedBy,
+			&i.IsComplete,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
 }
 
 const insertSleepSession = `-- name: InsertSleepSession :exec


### PR DESCRIPTION
## Summary

Two fixes required before the HA Effort 4 brief can execute:

- **`sensor.ada_today_boundary` attributes**: `pushTodayBoundary` now includes `bedtime_hhmm`, `daytime_hhmm`, and `grace_min` as sensor attributes via `loadSleepConfig`. The HA bedtime config sub-screen needs `daytime_hhmm` to pre-populate the daytime field, and `inferSleepType` needs `grace_min` to hint auto-categorization.
- **Diaper and sleep history now use the bedtime boundary**: `GetLast24hDiapers` → `GetTodayDiapers` and `GetLast24hSleepSessions` → `GetTodaySleepSessions`; both accept `@boundary` so history modals match the Today aggregates instead of a fixed 24h window.

## Implementation notes

- Used `loadSleepConfig` in `pushTodayBoundary` rather than three separate `GetConfig` calls — reads all three keys in one pass.
- `GetTodaySleepSessions` uses `COALESCE(end_time, NOW()) AS end_time` so `end_time` is always non-null. `(end_time IS NOT NULL)::bool AS is_complete` is the active-session discriminator — required the explicit `::bool` cast for sqlc to type it statically rather than `interface{}`.
- `pushSleepStartedSensors` had no boundary in scope — added `btz := p.todayBoundaryTz(ctx)` before the `pushSleepHistory` call. All other call sites already had `btz` computed.
- `DiaperHistoryEntry` and `SleepHistoryEntry` both gain `logged_by`.

## Test plan

- [x] `go build ./...` passes clean
- [x] `go test -tags=fast ./services/engine/processors/ada/...` passes clean
- [x] Pre-commit hooks pass (golangci-lint, gitleaks, fast unit tests)
- [x] After deploy: `sensor.ada_today_boundary` attributes in HA Developer Tools contain `bedtime_hhmm`, `daytime_hhmm`, and `grace_min`
- [x] After deploy: `sensor.ada_diaper_history` and `sensor.ada_sleep_history` attributes contain only entries since the boundary

## Checklist

- No plan document — this was a companion brief, not a standalone roadmap item
- No ADR — no architectural decision; query rename + attribute addition
- No runbook changes required

🤖 Generated with [Claude Code](https://claude.com/claude-code)