### PR TITLE
fix: restore tummy time target sensor on HA restart (v0.10.2)

### DIFF
--- a/deploy/prod/.env.example
+++ b/deploy/prod/.env.example
@@ -46,7 +46,7 @@ ENVIRONMENT=production
 # Release Version
 # =============================================================================
 # Used by docker-compose to pull correct image tags
-VERSION=v0.10.1
+VERSION=v0.10.2
 
 # GitHub repository owner for GHCR image paths
 GITHUB_REPOSITORY_OWNER=your-org

--- a/deploy/staging/.env.example
+++ b/deploy/staging/.env.example
@@ -8,7 +8,7 @@
 #   make setup-staging-creds   # generates secret/ruby-core/staging/* in Vault
 #   make ghcr-login            # authenticates Docker with GHCR (persists)
 
-VERSION=v0.10.1
+VERSION=v0.10.2
 VAULT_TOKEN=
 VAULT_ADDR=https://127.0.0.1:8200
 VAULT_CACERT=/opt/foundation/vault/tls/vault-ca.crt

--- a/services/engine/processors/ada/processor.go
+++ b/services/engine/processors/ada/processor.go
@@ -1037,6 +1037,12 @@ func (p *Processor) pushLastEventSensors(ctx context.Context) {
 	} else if !errors.Is(err, pgx.ErrNoRows) {
 		p.log.Warn("ada: restore last diaper", slog.String("error", err.Error()))
 	}
+
+	if cfg, err := p.q.GetConfig(ctx, "tummy_time_target_min"); err == nil {
+		p.pushAll(ctx, []struct{ id, state string }{{"sensor.ada_tummy_time_target_min", cfg.Value}})
+	} else if !errors.Is(err, pgx.ErrNoRows) {
+		p.log.Warn("ada: restore tummy target", slog.String("error", err.Error()))
+	}
 }
 
 // pushDailyAggregates pushes all today_* aggregate sensors from Postgres.


### PR DESCRIPTION
## Summary

- `sensor.ada_tummy_time_target_min` was lost after every HA restart. `handleTummyTarget` correctly persisted the value to `ada_config` KV, but `refreshAllSensors` never read it back on startup/reconnect.
- Added a `GetConfig` read for `tummy_time_target_min` in `pushLastEventSensors`, following the same pattern as `next_feeding_target` restore already in that function.

## Test plan

- [x] `go build ./...` passes clean
- [x] `go test -tags=fast ./services/engine/processors/ada/...` passes clean
- [x] Pre-commit hooks pass
- [x] After deploy: set a tummy time target, restart HA, confirm `sensor.ada_tummy_time_target_min` is still present

🤖 Generated with [Claude Code](https://claude.com/claude-code)