### PR TITLE
fix: revert feeding history to fixed 24h window (v0.10.4)

### DIFF
--- a/deploy/prod/.env.example
+++ b/deploy/prod/.env.example
@@ -46,7 +46,7 @@ ENVIRONMENT=production
 # Release Version
 # =============================================================================
 # Used by docker-compose to pull correct image tags
-VERSION=v0.10.3
+VERSION=v0.10.4
 
 # GitHub repository owner for GHCR image paths
 GITHUB_REPOSITORY_OWNER=your-org

--- a/deploy/staging/.env.example
+++ b/deploy/staging/.env.example
@@ -8,7 +8,7 @@
 #   make setup-staging-creds   # generates secret/ruby-core/staging/* in Vault
 #   make ghcr-login            # authenticates Docker with GHCR (persists)
 
-VERSION=v0.10.3
+VERSION=v0.10.4
 VAULT_TOKEN=
 VAULT_ADDR=https://127.0.0.1:8200
 VAULT_CACERT=/opt/foundation/vault/tls/vault-ca.crt

--- a/services/engine/processors/ada/processor.go
+++ b/services/engine/processors/ada/processor.go
@@ -888,7 +888,7 @@ func (p *Processor) pushFeedingSensors(ctx context.Context) {
 		)
 	}
 	p.pushAll(ctx, pushes)
-	p.pushFeedingHistory(ctx, btz)
+	p.pushFeedingHistory(ctx)
 }
 
 // pushDiaperSensors pushes all diaper-related sensors after a diaper event.
@@ -933,7 +933,7 @@ func (p *Processor) pushSupplementOzSensor(ctx context.Context) {
 		{sensorTodayFeedingOz, strconv.FormatFloat(agg.TotalOz, 'f', 2, 64)},
 		{sensorLastFeedingSource, "supplemented"},
 	})
-	p.pushFeedingHistory(ctx, btz)
+	p.pushFeedingHistory(ctx)
 }
 
 // pushSleepStartedSensors pushes sensors after a sleep session starts.
@@ -1057,7 +1057,7 @@ func (p *Processor) pushDailyAggregates(ctx context.Context) {
 	} else {
 		p.log.Warn("ada: restore today feeding aggregates", slog.String("error", err.Error()))
 	}
-	p.pushFeedingHistory(ctx, btz)
+	p.pushFeedingHistory(ctx)
 
 	if agg, err := p.q.GetTodayDiaperAggregates(ctx, btz); err == nil {
 		p.pushAll(ctx, []struct{ id, state string }{
@@ -1404,10 +1404,12 @@ func buildFeedingHistory(rows []*store.GetLast24hFeedingsRow) []FeedingHistoryEn
 	return entries
 }
 
-// pushFeedingHistory queries feedings since @boundary and pushes them as
-// attributes on sensor.ada_feeding_history.
-func (p *Processor) pushFeedingHistory(ctx context.Context, btz pgtype.Timestamptz) {
-	rows, err := p.q.GetLast24hFeedings(ctx, btz)
+// pushFeedingHistory queries the last 24h of feedings and pushes them as
+// attributes on sensor.ada_feeding_history. Uses a fixed 24h window so the
+// history modal always shows recent context regardless of the bedtime boundary.
+func (p *Processor) pushFeedingHistory(ctx context.Context) {
+	window := pgtype.Timestamptz{Time: time.Now().UTC().Add(-24 * time.Hour), Valid: true}
+	rows, err := p.q.GetLast24hFeedings(ctx, window)
 	if err != nil {
 		p.log.Warn("ada: query feeding history failed", slog.String("error", err.Error()))
 		return


### PR DESCRIPTION
## Summary

`sensor.ada_feeding_history` was still filtered by the bedtime boundary after #36 — diaper and sleep history were fixed in that PR but feeding was missed. `pushFeedingHistory` now computes a fixed 24h window internally, consistent with `pushDiaperHistory` and `pushSleepHistory`.

## Test plan

- [x] `go build ./...` passes clean
- [x] `go test -tags=fast ./services/engine/processors/ada/...` passes clean
- [x] Pre-commit hooks pass
- [ ] After deploy: feeding history modal shows entries from the last 24h regardless of bedtime boundary

🤖 Generated with [Claude Code](https://claude.com/claude-code)