### PR TITLE
fix: breast feed duration always zero (v0.10.6)

### DIFF
--- a/deploy/prod/.env.example
+++ b/deploy/prod/.env.example
@@ -46,7 +46,7 @@ ENVIRONMENT=production
 # Release Version
 # =============================================================================
 # Used by docker-compose to pull correct image tags
-VERSION=v0.10.5
+VERSION=v0.10.6
 
 # GitHub repository owner for GHCR image paths
 GITHUB_REPOSITORY_OWNER=your-org

--- a/deploy/staging/.env.example
+++ b/deploy/staging/.env.example
@@ -8,7 +8,7 @@
 #   make setup-staging-creds   # generates secret/ruby-core/staging/* in Vault
 #   make ghcr-login            # authenticates Docker with GHCR (persists)
 
-VERSION=v0.10.5
+VERSION=v0.10.6
 VAULT_TOKEN=
 VAULT_ADDR=https://127.0.0.1:8200
 VAULT_CACERT=/opt/foundation/vault/tls/vault-ca.crt

--- a/pkg/schemas/ada.go
+++ b/pkg/schemas/ada.go
@@ -23,19 +23,22 @@ const (
 )
 
 // AdaFeedingEndedData is the CloudEvent Data payload for a breast feeding session end.
-// Segments hold per-side timing; totals are pre-computed by the dashboard.
+// Segments hold per-side timing; totals are pre-computed by the dashboard as a fallback.
+// StartTime is the RFC3339 session start provided by the frontend clock; if absent, the
+// processor falls back to evtTime - TotalDurationS.
 type AdaFeedingEndedData struct {
 	Segments       []AdaFeedingSegment `json:"segments"`
 	TotalDurationS int                 `json:"total_duration_s"`
 	LeftTotalS     int                 `json:"left_total_s"`
 	RightTotalS    int                 `json:"right_total_s"`
+	StartTime      string              `json:"start_time,omitempty"`
 	LoggedBy       string              `json:"logged_by,omitempty"`
 }
 
 // AdaFeedingSegment is a single side + duration record within a breast feeding session.
 type AdaFeedingSegment struct {
 	Side      string `json:"side"`
-	DurationS int    `json:"dur"`
+	DurationS int    `json:"duration_s"`
 }
 
 // AdaFeedingLoggedData is the payload for a logged bottle or past breast feeding.

--- a/services/engine/processors/ada/processor.go
+++ b/services/engine/processors/ada/processor.go
@@ -63,6 +63,7 @@ const (
 	sensorSleepSessionMin      = "sensor.ada_sleep_session_min"
 	sensorDiaperHistory        = "sensor.ada_diaper_history"
 	sensorSleepHistory         = "sensor.ada_sleep_history"
+	sensorFeedingHistory       = "sensor.ada_feeding_history"
 	sensorTodayBoundary        = "sensor.ada_today_boundary"
 )
 
@@ -243,14 +244,24 @@ func (p *Processor) handleFeedingEnded(ctx context.Context, evt schemas.CloudEve
 		return fmt.Errorf("ada: decode feeding_ended: %w", err)
 	}
 
-	evtTime, err := parseRFC3339(evt.Time)
-	if err != nil {
-		return fmt.Errorf("ada: parse event time: %w", err)
+	// Use the frontend-provided start_time when available — it's the authoritative
+	// session start from the browser clock and avoids gateway-receive-time drift.
+	// Fall back to evtTime - totalDurationS for older clients that omit start_time.
+	var sessionStart time.Time
+	if d.StartTime != "" {
+		t, err := parseRFC3339(d.StartTime)
+		if err != nil {
+			return fmt.Errorf("ada: parse feeding start_time: %w", err)
+		}
+		sessionStart = t
+	} else {
+		evtTime, err := parseRFC3339(evt.Time)
+		if err != nil {
+			return fmt.Errorf("ada: parse event time: %w", err)
+		}
+		sessionStart = evtTime.Add(-time.Duration(d.TotalDurationS) * time.Second)
 	}
 
-	sessionStart := evtTime.Add(-time.Duration(d.TotalDurationS) * time.Second)
-
-	// Determine source from segments
 	source := breastSource(d.Segments)
 
 	feedingID, err := p.q.InsertFeeding(ctx, &store.InsertFeedingParams{
@@ -262,20 +273,63 @@ func (p *Processor) handleFeedingEnded(ctx context.Context, evt schemas.CloudEve
 		return fmt.Errorf("ada: insert feeding_ended: %w", err)
 	}
 
-	// Insert segments with reconstructed absolute timestamps (forward from start)
-	segStart := sessionStart
+	// Sum segment durations to detect zero-duration segments. When all segments
+	// report zero duration but pre-computed per-side totals are non-zero, the
+	// segment payload is malformed and we fall back to inserting synthetic segments
+	// from LeftTotalS / RightTotalS.
+	segDurSum := 0
 	for _, seg := range d.Segments {
-		segEnd := segStart.Add(time.Duration(seg.DurationS) * time.Second)
-		if err := p.q.InsertFeedingSegment(ctx, &store.InsertFeedingSegmentParams{
-			FeedingID: feedingID,
-			Side:      seg.Side,
-			StartedAt: toTimestamptz(segStart),
-			EndedAt:   toTimestamptz(segEnd),
-			DurationS: int32(seg.DurationS), //nolint:gosec // G115: bounded by session duration in seconds, never near int32 max
-		}); err != nil {
-			return fmt.Errorf("ada: insert feeding segment: %w", err)
+		segDurSum += seg.DurationS
+	}
+
+	segCursor := sessionStart
+	if segDurSum == 0 && (d.LeftTotalS > 0 || d.RightTotalS > 0) {
+		// Segments carried zero duration despite non-zero pre-computed totals.
+		// Insert one synthetic segment per non-zero side using the totals.
+		p.log.Warn("ada: segment durations all zero — falling back to pre-computed totals",
+			slog.Int("left_total_s", d.LeftTotalS),
+			slog.Int("right_total_s", d.RightTotalS),
+		)
+		if d.LeftTotalS > 0 {
+			segEnd := segCursor.Add(time.Duration(d.LeftTotalS) * time.Second)
+			if err := p.q.InsertFeedingSegment(ctx, &store.InsertFeedingSegmentParams{
+				FeedingID: feedingID,
+				Side:      "left",
+				StartedAt: toTimestamptz(segCursor),
+				EndedAt:   toTimestamptz(segEnd),
+				DurationS: int32(d.LeftTotalS), //nolint:gosec // G115: bounded by session duration in seconds
+			}); err != nil {
+				return fmt.Errorf("ada: insert fallback left segment: %w", err)
+			}
+			segCursor = segEnd
 		}
-		segStart = segEnd
+		if d.RightTotalS > 0 {
+			segEnd := segCursor.Add(time.Duration(d.RightTotalS) * time.Second)
+			if err := p.q.InsertFeedingSegment(ctx, &store.InsertFeedingSegmentParams{
+				FeedingID: feedingID,
+				Side:      "right",
+				StartedAt: toTimestamptz(segCursor),
+				EndedAt:   toTimestamptz(segEnd),
+				DurationS: int32(d.RightTotalS), //nolint:gosec // G115: bounded by session duration in seconds
+			}); err != nil {
+				return fmt.Errorf("ada: insert fallback right segment: %w", err)
+			}
+		}
+	} else {
+		// Normal path: insert segments with reconstructed absolute timestamps.
+		for _, seg := range d.Segments {
+			segEnd := segCursor.Add(time.Duration(seg.DurationS) * time.Second)
+			if err := p.q.InsertFeedingSegment(ctx, &store.InsertFeedingSegmentParams{
+				FeedingID: feedingID,
+				Side:      seg.Side,
+				StartedAt: toTimestamptz(segCursor),
+				EndedAt:   toTimestamptz(segEnd),
+				DurationS: int32(seg.DurationS), //nolint:gosec // G115: bounded by session duration in seconds
+			}); err != nil {
+				return fmt.Errorf("ada: insert feeding segment: %w", err)
+			}
+			segCursor = segEnd
+		}
 	}
 
 	p.pushFeedingSensors(ctx)
@@ -1011,6 +1065,9 @@ func (p *Processor) refreshAllSensors(ctx context.Context) {
 	p.pushPeopleList(ctx)
 	p.restoreAlertTimer(ctx)
 	p.pushTodayBoundary(ctx)
+	p.pushFeedingHistory(ctx)
+	p.pushDiaperHistory(ctx)
+	p.pushSleepHistory(ctx)
 }
 
 // pushLastEventSensors pushes sensors derived from the most recent event of each
@@ -1428,7 +1485,7 @@ func (p *Processor) pushFeedingHistory(ctx context.Context) {
 		"last_updated": time.Now().UTC().Format(time.RFC3339),
 	}
 
-	if err := p.ha.PushState(ctx, "sensor.ada_feeding_history", strconv.Itoa(len(entries)), attributes); err != nil {
+	if err := p.ha.PushState(ctx, sensorFeedingHistory, strconv.Itoa(len(entries)), attributes); err != nil {
 		p.log.Warn("ada: push feeding history failed", slog.String("error", err.Error()))
 	}
 }

--- a/services/engine/processors/ada/processor_test.go
+++ b/services/engine/processors/ada/processor_test.go
@@ -8,6 +8,7 @@ import (
 
 	"github.com/jackc/pgx/v5/pgtype"
 
+	"github.com/primaryrutabaga/ruby-core/pkg/schemas"
 	"github.com/primaryrutabaga/ruby-core/services/engine/processors/ada/store"
 )
 
@@ -443,5 +444,58 @@ func TestBuildSleepHistory_ActiveSession(t *testing.T) {
 	}
 	if e.DurationS != nil {
 		t.Errorf("DurationS should be nil for active session, got %v", e.DurationS)
+	}
+}
+
+// ── breastSource ──────────────────────────────────────────────────────────────
+
+func TestBreastSource_LeftOnly(t *testing.T) {
+	segs := []schemas.AdaFeedingSegment{{Side: "left", DurationS: 600}}
+	if got := breastSource(segs); got != "breast_left" {
+		t.Errorf("breastSource(left only) = %q, want %q", got, "breast_left")
+	}
+}
+
+func TestBreastSource_RightOnly(t *testing.T) {
+	segs := []schemas.AdaFeedingSegment{{Side: "right", DurationS: 480}}
+	if got := breastSource(segs); got != "breast_right" {
+		t.Errorf("breastSource(right only) = %q, want %q", got, "breast_right")
+	}
+}
+
+func TestBreastSource_BothSides(t *testing.T) {
+	segs := []schemas.AdaFeedingSegment{
+		{Side: "left", DurationS: 600},
+		{Side: "right", DurationS: 420},
+	}
+	if got := breastSource(segs); got != "breast" {
+		t.Errorf("breastSource(both sides) = %q, want %q", got, "breast")
+	}
+}
+
+func TestBreastSource_MultipleSwitches(t *testing.T) {
+	// Multiple segments but only one unique side — should still be breast_left.
+	segs := []schemas.AdaFeedingSegment{
+		{Side: "left", DurationS: 300},
+		{Side: "left", DurationS: 300},
+	}
+	if got := breastSource(segs); got != "breast_left" {
+		t.Errorf("breastSource(left×2) = %q, want %q", got, "breast_left")
+	}
+}
+
+func TestBreastSource_ZeroDurationSidesStillClassify(t *testing.T) {
+	// Side classification must work even when DurationS=0 (pre-fix tag mismatch scenario).
+	// breastSource reads Side only — duration does not affect the result.
+	segs := []schemas.AdaFeedingSegment{{Side: "left", DurationS: 0}}
+	if got := breastSource(segs); got != "breast_left" {
+		t.Errorf("breastSource(left, dur=0) = %q, want %q", got, "breast_left")
+	}
+}
+
+func TestBreastSource_EmptySegments(t *testing.T) {
+	// No segments — default to "breast" rather than panicking.
+	if got := breastSource(nil); got != "breast" {
+		t.Errorf("breastSource(nil) = %q, want %q", got, "breast")
 	}
 }


### PR DESCRIPTION
## Summary

- **Root cause fixed:** `AdaFeedingSegment.DurationS` had JSON tag `"dur"` but the frontend sends `"duration_s"`. Every breast feed segment deserialized with duration 0 since the feature shipped — causing "Duration not recorded" in the HA feeding history modal for all breast feeds.
- **Hardening:** Added `StartTime` field to `AdaFeedingEndedData` so the processor uses the frontend's authoritative session start timestamp instead of back-computing it from gateway receive time.
- **Fallback guard:** When all segment durations are zero but pre-computed `left_total_s`/`right_total_s` are non-zero, the processor logs a warning and inserts synthetic segments from the totals. Guards against future payload format drift.
- **Restart resilience:** `refreshAllSensors` now calls `pushFeedingHistory`, `pushDiaperHistory`, and `pushSleepHistory`. Previously history sensors were stale after any engine restart until the next new event; the 4-hour safety net also now refreshes them.
- **Minor cleanup:** Added `sensorFeedingHistory` constant; replaced hardcoded string literal in `pushFeedingHistory`.
- **Tests:** 6 new `breastSource` unit tests covering left-only, right-only, both-sides, multiple-switches, zero-duration classification, and empty-segments edge case.
- **Data repair:** Manually corrected the `duration_s` for the 12:49 PM breast feed on 2026-04-27 (feeding ID `941d58c2`) from 0 → 3120s (52 min) directly in the DB; engine restart confirmed the repaired value is now pushed to HA.

## Files changed

| File | Change |
|------|--------|
| `pkg/schemas/ada.go` | JSON tag `"dur"` → `"duration_s"`; add `StartTime` field |
| `services/engine/processors/ada/processor.go` | `handleFeedingEnded` uses `StartTime`, adds fallback segment insertion; `refreshAllSensors` pushes history; `sensorFeedingHistory` constant |
| `services/engine/processors/ada/processor_test.go` | 6 new `breastSource` tests |
| `deploy/{prod,staging}/.env.example` | Version bump v0.10.5 → v0.10.6 |

## Note on frontend change

`ada-active-breast-card.ts` (`/opt/homeassistant`) should have `start_time: startTime.toISOString()` added to `_buildEndPayload()`. The processor handles its absence gracefully (falls back to evtTime − totalDurationS), so the backend fix is fully independent. The HA-side change is a follow-up.

## Test plan

- [ ] Push branch; CI lint + unit-tests + integration-tests pass
- [ ] Deploy to staging; smoke test passes
- [ ] After merge and prod deploy, log a new breast feed — confirm HA history modal shows correct per-side duration
- [ ] Restart engine — confirm `sensor.ada_feeding_history` is populated immediately (no wait for next event)

## Drift Observations

None observed this session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)