### PR TITLE
fix: growth sensor values always 0.00 (numericToFloat using Scan incorrectly)

### DIFF
--- a/deploy/prod/.env.example
+++ b/deploy/prod/.env.example
@@ -46,7 +46,7 @@ ENVIRONMENT=production
 # Release Version
 # =============================================================================
 # Used by docker-compose to pull correct image tags
-VERSION=v0.11.0
+VERSION=v0.11.1
 
 # GitHub repository owner for GHCR image paths
 GITHUB_REPOSITORY_OWNER=your-org

--- a/deploy/staging/.env.example
+++ b/deploy/staging/.env.example
@@ -8,7 +8,7 @@
 #   make setup-staging-creds   # generates secret/ruby-core/staging/* in Vault
 #   make ghcr-login            # authenticates Docker with GHCR (persists)
 
-VERSION=v0.11.0
+VERSION=v0.11.1
 VAULT_TOKEN=
 VAULT_ADDR=https://127.0.0.1:8200
 VAULT_CACERT=/opt/foundation/vault/tls/vault-ca.crt

--- a/pkg/natsx/consumer_integration_test.go
+++ b/pkg/natsx/consumer_integration_test.go
@@ -39,7 +39,17 @@ func startNATS(t *testing.T) *natsgo.Conn {
 		t.Fatalf("startNATS: connection string: %v", err)
 	}
 
-	nc, err := natsgo.Connect(connStr)
+	// Retry the connection: testcontainers marks the NATS container ready when
+	// port 4222 is open, but the server may not have completed its startup
+	// handshake yet. A short retry loop avoids the resulting EOF on first connect.
+	var nc *natsgo.Conn
+	for range 10 {
+		nc, err = natsgo.Connect(connStr, natsgo.MaxReconnects(0))
+		if err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
 	if err != nil {
 		t.Fatalf("startNATS: connect: %v", err)
 	}

--- a/services/engine/processors/ada/growth.go
+++ b/services/engine/processors/ada/growth.go
@@ -380,13 +380,16 @@ func buildSamplePoints() []float64 {
 // ── pgtype helpers ────────────────────────────────────────────────────────────
 
 // numericToFloat converts a pgtype.Numeric to float64, returning 0 for invalid/NULL.
+// Uses Float64Value() — n.Scan(&f) fills n FROM f, not the reverse.
 func numericToFloat(n pgtype.Numeric) float64 {
 	if !n.Valid {
 		return 0
 	}
-	var f float64
-	_ = n.Scan(&f)
-	return f
+	f8, err := n.Float64Value()
+	if err != nil || !f8.Valid {
+		return 0
+	}
+	return f8.Float64
 }
 
 // numericToFloatOk converts a pgtype.Numeric to float64, reporting whether the value
@@ -395,9 +398,11 @@ func numericToFloatOk(n pgtype.Numeric) (float64, bool) {
 	if !n.Valid {
 		return 0, false
 	}
-	var f float64
-	_ = n.Scan(&f)
-	return math.Round(f*10) / 10, true
+	f8, err := n.Float64Value()
+	if err != nil || !f8.Valid {
+		return 0, false
+	}
+	return math.Round(f8.Float64*10) / 10, true
 }
 
 // isNoRows reports whether an error is a pgx "no rows" sentinel.


### PR DESCRIPTION
## Summary

- Fixes growth measurement sensors (`sensor.ada_latest_weight`, `sensor.ada_latest_length`, `sensor.ada_latest_head_circumference`, `sensor.ada_growth_history`) pushing `0.00` for all numeric values instead of the actual stored measurements
- Bumps version to v0.11.1

## Root Cause

`numericToFloat` and `numericToFloatOk` in `growth.go` called `n.Scan(&f)` to extract a `float64` from a `pgtype.Numeric`. `Scan` implements the `pgtype.Scanner` interface, which converts a Go value **into** the `pgtype` — it fills `n` from `f`, not the reverse. Since `f` was initialized to `0`, every call silently returned `0` regardless of the stored value.

The fix replaces both with `n.Float64Value()` (`pgtype.Float64Valuer`), which correctly extracts the stored numeric as a `pgtype.Float8`.

## Impact

All five growth sensors were affected. Sensors were reaching HA with state `"0.00"` — the HA card silently hides zero-state sensor rows, which presented as sensors not displaying. No data was lost; stored values in `growth_measurements` are correct. After this fix, a re-fire of the engine (or a new measurement event) will push correct values.

## Not the Issue

The gateway normalizer was not involved. The `sensor` domain has no passlist entry, so all sensor attributes pass through unchanged. No gateway changes were needed.

## Test plan

- [ ] `go test -tags=fast -race ./...` — all passing (see CI)
- [ ] Deploy v0.11.1; log a growth measurement; verify `sensor.ada_latest_weight` state in HA developer tools matches the submitted weight (not `0.00`)
- [ ] Verify `sensor.ada_growth_history` weight array entries contain correct `weight_oz` values

## Drift Observations

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)