### PR TITLE
fix: no-push-to-main hook incorrectly blocks tag pushes

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -109,7 +109,7 @@ repos:
       - id: no-push-to-main
         name: Prevent direct push to main
         language: system
-        entry: bash -c 'b=$(git rev-parse --abbrev-ref HEAD 2>/dev/null); if [ "$b" = "main" ]; then echo "Direct push to main is not allowed. Open a PR." >&2; exit 1; fi'
+        entry: bash -c 'while IFS=" " read -r l ls r rs; do if [ "$r" = "refs/heads/main" ]; then echo "Direct push to main is not allowed. Open a PR." >&2; exit 1; fi; done; exit 0'
         stages: [pre-push]
         pass_filenames: false
         always_run: true


### PR DESCRIPTION
## Summary

- Fixes the `no-push-to-main` pre-push hook blocking `git push origin vX.Y.Z` tag pushes
- No functional change to the main-push protection — direct branch pushes to `main` are still blocked

## Root Cause

The hook checked `git rev-parse --abbrev-ref HEAD` (current branch name), which returns `"main"` even when pushing a tag while on the main branch. Tag pushes have nothing to do with the branch name.

## Fix

Read the remote ref from stdin using the git pre-push hook protocol. Git passes push details as `<local_ref> <local_sha> <remote_ref> <remote_sha>` on stdin. The hook now blocks only when `remote_ref == refs/heads/main`. Tag pushes have remote refs like `refs/tags/v0.11.2` and pass through correctly.

## Test plan

- [ ] `git push origin vX.Y.Z` — tag push succeeds without hook blocking
- [ ] Direct branch push to `main` still blocked (GitHub branch protection is the primary control; hook is belt-and-suspenders)

🤖 Generated with [Claude Code](https://claude.com/claude-code)