### PR TITLE
fix: use systemd-run --user for stability watcher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,7 +126,7 @@ jobs:
 
       - name: Start stability watcher
         run: |
-          systemd-run --no-block \
+          systemd-run --user --no-block \
             --unit=ruby-core-stability-watch-${{ github.ref_name }} \
             /opt/ruby-core/scripts/stability-watch.sh \
             ${{ github.ref_name }} 600

--- a/scripts/stability-watch.sh
+++ b/scripts/stability-watch.sh
@@ -24,7 +24,16 @@ SERVICES=(gateway engine notifier presence audit-sink)
 
 VAULT_ADDR="${VAULT_ADDR:-https://127.0.0.1:8200}"
 VAULT_CACERT="${VAULT_CACERT:-/opt/foundation/vault/tls/vault-ca.crt}"
-VAULT_TOKEN="${VAULT_TOKEN:?VAULT_TOKEN is required}"
+
+# VAULT_TOKEN may not be inherited when launched via systemd-run --user.
+# Fall back to the prod .env file so the script works in both contexts.
+if [ -z "${VAULT_TOKEN:-}" ]; then
+  PROD_ENV="/opt/ruby-core/deploy/prod/.env"
+  if [ -f "$PROD_ENV" ]; then
+    VAULT_TOKEN="$(grep '^VAULT_TOKEN=' "$PROD_ENV" 2>/dev/null | cut -d= -f2-)"
+  fi
+fi
+VAULT_TOKEN="${VAULT_TOKEN:?VAULT_TOKEN is required — set in environment or deploy/prod/.env}"
 export VAULT_ADDR VAULT_CACERT VAULT_TOKEN
 
 HA_URL=$(vault kv get -field=url secret/ruby-core/ha)


### PR DESCRIPTION
## Summary

- Fixes `deploy-prod` job failure on "Start stability watcher" step
- `systemd-run --no-block` (system scope) requires polkit permission the runner user doesn't have → "Interactive authentication required"
- Switch to `systemd-run --user --no-block` (user scope) which doesn't require polkit
- Add `VAULT_TOKEN` fallback in `stability-watch.sh` — user systemd scope doesn't inherit runner environment variables, so the script now reads from `deploy/prod/.env` when not set

## One-time host prerequisite

`loginctl enable-linger primaryrutabaga` must be run once so the user systemd session persists outside login sessions. Without linger, `systemd-run --user` has no session to attach to when the runner job completes.

## Test plan

- [ ] Merge and tag `v0.11.3` — full pipeline should complete: build → staging smoke → prod deploy → stability watcher starts → create release
- [ ] Confirm stability watcher unit visible: `systemctl --user status ruby-core-stability-watch-v0.11.3`
- [ ] After 10 min: check `/var/log/ruby-core/stability.log` for clean completion entry and HA push notification

## Drift Observations

None.

🤖 Generated with [Claude Code](https://claude.com/claude-code)