### PR TITLE
fix: replace systemd-run --user with nohup setsid for stability watcher

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -126,10 +126,10 @@ jobs:
 
       - name: Start stability watcher
         run: |
-          systemd-run --user --no-block \
-            --unit=ruby-core-stability-watch-${{ github.ref_name }} \
-            /opt/ruby-core/scripts/stability-watch.sh \
-            ${{ github.ref_name }} 600
+          mkdir -p /var/log/ruby-core
+          nohup setsid /opt/ruby-core/scripts/stability-watch.sh \
+            ${{ github.ref_name }} 600 \
+            >> /var/log/ruby-core/stability.log 2>&1 &
 
   # ==========================================================================
   # Create GitHub Release


### PR DESCRIPTION
## Summary

- Fixes stability watcher failing to launch in the `deploy-prod` job
- `systemd-run --user` requires D-Bus session bus access (`DBUS_SESSION_BUS_ADDRESS` / `XDG_RUNTIME_DIR`) which is not set in the GHA runner job environment
- `systemd-run` (system scope) requires polkit permission the runner user doesn't have
- Replace with `nohup setsid` — creates a new process session outside the runner's process group, survives job completion without any host-level setup or D-Bus dependency

## Note on v0.11.2 and v0.11.3

Both runs: the actual prod deploy (`make deploy-prod`) completed successfully before the watcher step failed. v0.11.3 is running in production — only the watcher launch was broken. `create-release` was correctly skipped since the job failed.

## Test plan

- [ ] Merge and tag `v0.11.4` — full pipeline should complete end-to-end
- [ ] Confirm watcher is running: `ps aux | grep stability-watch`
- [ ] After 10 min: `tail /var/log/ruby-core/stability.log` — should show clean completion entry
- [ ] GitHub Release created for v0.11.4

🤖 Generated with [Claude Code](https://claude.com/claude-code)