### PR TITLE
fix: add workflow_dispatch to release-please for manual triggering

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -15,6 +15,7 @@ on:
   push:
     branches:
       - main
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

Adds `workflow_dispatch` trigger to the release-please workflow so it can be manually run from the Actions tab when the `push` event doesn't fire (observed after squash merges where the webhook delivery appears to be delayed or dropped).

## After merge

1. Go to **Actions → Release Please → Run workflow** and trigger it manually
2. Verify a `chore: release v0.11.5` PR is opened (patch bump from the two `fix:` commits since v0.11.4)
3. Merge that release PR → tag created → full build → staging → prod → stability watcher

🤖 Generated with [Claude Code](https://claude.com/claude-code)