### PR TITLE
fix: add bootstrap-sha to release-please config

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,6 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
   "release-type": "simple",
+  "bootstrap-sha": "d1d3b176880844981797bd8e02a5fa7baa6c9017",
   "changelog-sections": [
     {"type": "feat", "section": "Features"},
     {"type": "fix", "section": "Bug Fixes"},


### PR DESCRIPTION
## Summary

Fixes release-please finding zero releasable commits since v0.11.4.

**Root cause:** release-please uses `Set(0) {}` (empty set of release commit SHAs) because existing GitHub Releases (v0.11.0–v0.11.4) were created by `softprops/action-gh-release`, not by release-please, and lack the metadata release-please uses to identify where releases were cut. Without a known release SHA, release-please falls back to a limited commit search that misses recent squash-merged commits.

**Fix:** Add `bootstrap-sha` pointing to the v0.11.4 tag commit (`d1d3b17`). This tells release-please to look for releasable commits starting from that point, correctly finding the `fix:` and `feat:` commits merged since.

## After merge

Merge triggers a release-please run via push. If the push event is delayed, trigger manually via **Actions → Release Please → Run workflow**. Expect a `chore: release v0.11.5` PR to open with the accumulated `fix:` commits in the changelog.

🤖 Generated with [Claude Code](https://claude.com/claude-code)