### PR TITLE
fix: ensure log directory exists before writing stability log

### DIFF
--- a/scripts/stability-watch.sh
+++ b/scripts/stability-watch.sh
@@ -78,5 +78,6 @@ while [ "$(date +%s)" -lt "$DEADLINE" ]; do
 done
 
 echo "$(date -Iseconds) stability-watch: ${VERSION} — ${DURATION}s window clean"
+mkdir -p /var/log/ruby-core
 echo "$(date -Iseconds) ${VERSION} stable" >> /var/log/ruby-core/stability.log
 notify_ha "ruby-core ${VERSION} stable" "${DURATION}s post-deploy window clean"


### PR DESCRIPTION
## Summary

Defensive fix: move `mkdir -p /var/log/ruby-core` into the stability watcher script itself so the log write succeeds whether the script is invoked by the release pipeline or manually.

Previously the directory creation was only in `release.yml`, meaning a manual `./scripts/stability-watch.sh` invocation would fail silently on the log write (the script itself would still run; only the completion log entry would be lost).

## Also testing

This PR is a merge-commit PR (not squash) to validate release-please picks up the `fix:` conventional commit and opens a `chore: release v0.11.5` PR after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)