### PR TITLE
fix: add packages key to release-please-config.json

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,13 +1,17 @@
 {
   "$schema": "https://raw.githubusercontent.com/googleapis/release-please/main/schemas/config.json",
-  "release-type": "simple",
   "bootstrap-sha": "d1d3b176880844981797bd8e02a5fa7baa6c9017",
-  "changelog-sections": [
-    {"type": "feat", "section": "Features"},
-    {"type": "fix", "section": "Bug Fixes"},
-    {"type": "perf", "section": "Performance Improvements"},
-    {"type": "revert", "section": "Reverts"},
-    {"type": "docs", "section": "Documentation", "hidden": true},
-    {"type": "chore", "section": "Miscellaneous", "hidden": true}
-  ]
+  "packages": {
+    ".": {
+      "release-type": "simple",
+      "changelog-sections": [
+        {"type": "feat", "section": "Features"},
+        {"type": "fix", "section": "Bug Fixes"},
+        {"type": "perf", "section": "Performance Improvements"},
+        {"type": "revert", "section": "Reverts"},
+        {"type": "docs", "section": "Documentation", "hidden": true},
+        {"type": "chore", "section": "Miscellaneous", "hidden": true}
+      ]
+    }
+  }
 }


### PR DESCRIPTION
## Root cause

Every release-please run reported `Splitting 0 commits by path` regardless of bootstrap-sha, merge strategy, or any other change. The actual bug: `release-please-config.json` had no `packages` key.

`parseConfig` in release-please's manifest only populates `repositoryConfig` from `config.packages`:

```typescript
for (const path in config.packages) {
    repositoryConfig[path] = mergeReleaserConfig(...);
}
```

Without a `packages` key, `config.packages` is `undefined`, the loop runs 0 times, and `repositoryConfig = {}`. This cascades:
- `expectedReleases = 0`
- `needsBootstrap = false` (0 < 0 is false)
- Commit loop condition: `!needsBootstrap && releaseCommitsFound (0) >= expectedShas (0)` → breaks immediately
- `commits = []` → `Splitting 0 commits by path`

The top-level `"release-type"` and `"changelog-sections"` were being read as manifest-level *defaults*, not as package configuration. None of it was having any effect.

## Fix

Add `"packages": {".": {...}}` with the package-specific config nested inside. The top-level `bootstrap-sha` stays where it is (it's a manifest-level option, not package-level).

## What to verify after merge

1. Release Please workflow fires on push to main
2. It should now report `Splitting N commits by path` with N > 0
3. A `chore: release vX.Y.Z` PR should open

🤖 Generated with [Claude Code](https://claude.com/claude-code)