### PR TITLE
feat(boot): direct-PKI cert issuance via AppRole + in-process renewal (Phase 17.6.2)

### DIFF
--- a/deploy/dev/.env.example
+++ b/deploy/dev/.env.example
@@ -23,10 +23,19 @@ NATS_URL=tls://localhost:4222
 # Require mTLS for all NATS connections
 NATS_REQUIRE_MTLS=true
 
-# TLS client certificates are fetched from Vault at runtime (ADR-0015, ADR-0018)
-# Run ./scripts/setup-credentials.sh to populate Vault with client certs.
-# Override the Vault path if needed:
-# VAULT_TLS_PATH=secret/data/ruby-core/tls/gateway
+# TLS client certificates (ADR-0015, ADR-0018, ADR-0030).
+#
+# Default path (PLAN-0008, Phase 17.6): services issue certs directly from
+# Vault PKI via AppRole. No .env config needed — compose.dev.yaml mounts the
+# AppRole role-id + secret-id from foundation host paths
+# (/opt/foundation/vault/role-id-foundation-agent-ruby-core-<svc>) and sets
+# VAULT_PKI_ROLE per service. The cert is renewed in-process at TTL/2 by a
+# goroutine in pkg/boot/pki.go — no operator action ever required.
+#
+# Rollback path (legacy mkcert KV bundle, retained until Phase 17.7): clear
+# VAULT_PKI_ROLE in compose.dev.yaml for a service to fall back to reading
+# secret/ruby-core/tls/<svc>. Repopulate the KV bundle with
+# ./scripts/setup-credentials.sh if it has been removed.
 
 # =============================================================================
 # Service Configuration

--- a/deploy/dev/compose.dev.yaml
+++ b/deploy/dev/compose.dev.yaml
@@ -20,10 +20,19 @@ services:
       - nats-certs:/certs
       - ../../scripts/fetch-nats-certs.sh:/scripts/fetch-nats-certs.sh:ro
       - /opt/foundation/vault/tls/vault-ca.crt:/vault/tls/vault-ca.crt:ro
+      # AppRole material for direct-PKI (PLAN-0008). The fetch-nats-certs.sh
+      # script picks the PKI path when VAULT_PKI_ROLE is set; the legacy KV
+      # path is unreachable unless VAULT_PKI_ROLE is unset.
+      - /opt/foundation/vault/role-id-foundation-agent-ruby-core-nats-server:/vault/role-id:ro
+      - /opt/foundation/vault/.secret-id-foundation-agent-ruby-core-nats-server:/vault/secret-id:ro
     environment:
       - VAULT_ADDR=https://vault:8200
       - VAULT_CACERT=/vault/tls/vault-ca.crt
+      # VAULT_TOKEN retained as rollback path (consumed only when VAULT_PKI_ROLE
+      # is unset). PLAN-0008 §Stage 2 cutover; remove in Phase 17.7.
       - VAULT_TOKEN=${VAULT_TOKEN:-root}
+      - VAULT_PKI_ROLE=ruby-core-nats-server
+      - VAULT_PKI_IP_SANS=127.0.0.1
     networks:
       - vault-ruby-core-dev
 
@@ -87,6 +96,9 @@ services:
         condition: service_healthy
     volumes:
       - /opt/foundation/vault/tls/vault-ca.crt:/vault/tls/vault-ca.crt:ro
+      # AppRole material for direct-PKI client cert (PLAN-0008).
+      - /opt/foundation/vault/role-id-foundation-agent-ruby-core-gateway:/vault/role-id:ro
+      - /opt/foundation/vault/.secret-id-foundation-agent-ruby-core-gateway:/vault/secret-id:ro
     environment:
       - ENVIRONMENT=development
       - VAULT_ADDR=https://vault:8200
@@ -95,7 +107,10 @@ services:
       - NATS_URL=tls://nats:4222
       - NATS_REQUIRE_MTLS=true
       - VAULT_NKEY_PATH=secret/data/ruby-core/nats/gateway
+      # VAULT_TLS_PATH is the legacy KV bundle, retained as rollback (PLAN-0008).
+      # When VAULT_PKI_ROLE is set, boot.go ignores this and issues from PKI.
       - VAULT_TLS_PATH=secret/data/ruby-core/tls/gateway
+      - VAULT_PKI_ROLE=ruby-core-gateway
       - HTTP_ADDR=:8080
 
   # ==========================================================================
@@ -111,11 +126,19 @@ services:
     networks:
       - default
       - vault-ruby-core-dev
+      # engine's `ada` processor uses foundation-postgres; prod's compose joins
+      # this network too. Adding here makes dev parity with prod and unblocks
+      # `make dev-verify` (which was failing on the postgres DNS lookup before
+      # this PR — drift unrelated to PLAN-0008 but easy to fix inline).
+      - postgres
     depends_on:
       nats:
         condition: service_healthy
     volumes:
       - /opt/foundation/vault/tls/vault-ca.crt:/vault/tls/vault-ca.crt:ro
+      # AppRole material for direct-PKI client cert (PLAN-0008).
+      - /opt/foundation/vault/role-id-foundation-agent-ruby-core-engine:/vault/role-id:ro
+      - /opt/foundation/vault/.secret-id-foundation-agent-ruby-core-engine:/vault/secret-id:ro
       # Rule files (YAML): loaded at startup, published to NATS KV (ADR-0006)
       - ../../configs/rules:/etc/ruby-core/rules:ro
     environment:
@@ -127,6 +150,7 @@ services:
       - NATS_REQUIRE_MTLS=true
       - VAULT_NKEY_PATH=secret/data/ruby-core/nats/engine
       - VAULT_TLS_PATH=secret/data/ruby-core/tls/engine
+      - VAULT_PKI_ROLE=ruby-core-engine
       - RULES_DIR=/etc/ruby-core/rules
       - VAULT_PG_PATH=secret/data/ruby-core/postgres
       - VAULT_HA_PATH=secret/data/ruby-core/ha
@@ -151,6 +175,9 @@ services:
         condition: service_healthy
     volumes:
       - /opt/foundation/vault/tls/vault-ca.crt:/vault/tls/vault-ca.crt:ro
+      # AppRole material for direct-PKI client cert (PLAN-0008).
+      - /opt/foundation/vault/role-id-foundation-agent-ruby-core-notifier:/vault/role-id:ro
+      - /opt/foundation/vault/.secret-id-foundation-agent-ruby-core-notifier:/vault/secret-id:ro
     environment:
       - ENVIRONMENT=development
       - VAULT_ADDR=https://vault:8200
@@ -160,6 +187,7 @@ services:
       - NATS_REQUIRE_MTLS=true
       - VAULT_NKEY_PATH=secret/data/ruby-core/nats/notifier
       - VAULT_TLS_PATH=secret/data/ruby-core/tls/notifier
+      - VAULT_PKI_ROLE=ruby-core-notifier
 
   # ==========================================================================
   # Presence Service (profile: services)
@@ -181,6 +209,9 @@ services:
         condition: service_healthy
     volumes:
       - /opt/foundation/vault/tls/vault-ca.crt:/vault/tls/vault-ca.crt:ro
+      # AppRole material for direct-PKI client cert (PLAN-0008).
+      - /opt/foundation/vault/role-id-foundation-agent-ruby-core-presence:/vault/role-id:ro
+      - /opt/foundation/vault/.secret-id-foundation-agent-ruby-core-presence:/vault/secret-id:ro
     environment:
       - ENVIRONMENT=development
       - VAULT_ADDR=https://vault:8200
@@ -190,6 +221,7 @@ services:
       - NATS_REQUIRE_MTLS=true
       - VAULT_NKEY_PATH=secret/data/ruby-core/nats/presence
       - VAULT_TLS_PATH=secret/data/ruby-core/tls/presence
+      - VAULT_PKI_ROLE=ruby-core-presence
       - VAULT_HA_PATH=secret/data/ruby-core/ha
       - PRESENCE_PERSON_ID=katie
       - PRESENCE_PHONE_ENTITY=phone.katie
@@ -223,10 +255,14 @@ services:
       - NATS_REQUIRE_MTLS=true
       - VAULT_NKEY_PATH=secret/data/ruby-core/nats/audit-sink
       - VAULT_TLS_PATH=secret/data/ruby-core/tls/audit-sink
+      - VAULT_PKI_ROLE=ruby-core-audit-sink
       - AUDIT_DATA_DIR=/data/audit
     volumes:
       - ruby-core-dev-audit-data:/data/audit
       - /opt/foundation/vault/tls/vault-ca.crt:/vault/tls/vault-ca.crt:ro
+      # AppRole material for direct-PKI client cert (PLAN-0008).
+      - /opt/foundation/vault/role-id-foundation-agent-ruby-core-audit-sink:/vault/role-id:ro
+      - /opt/foundation/vault/.secret-id-foundation-agent-ruby-core-audit-sink:/vault/secret-id:ro
 
 # ==========================================================================
 # Networks
@@ -242,6 +278,11 @@ networks:
   event-bus-dev:
     external: true
     name: event-bus-dev
+  # Foundation's shared Postgres network. Engine's `ada` processor connects via
+  # this network to foundation-postgres. Same network as prod uses.
+  postgres:
+    external: true
+    name: postgres
 
 # ==========================================================================
 # Named Volumes

--- a/docs/adr/0030-direct-pki-issuance-no-sidecar.md
+++ b/docs/adr/0030-direct-pki-issuance-no-sidecar.md
@@ -1,0 +1,63 @@
+# ADR-0030 — Direct-PKI Issuance for Ruby-Core mTLS (No Sidecar)
+
+* **Status:** Accepted
+* **Date:** 2026-05-19
+
+## Context
+
+Foundation's ADR-0008 (Vault Agent as the Secret Distribution Layer) prescribes a per-service Vault Agent sidecar that renders TLS material to disk for each consumer service. PLAN-0006 (mosquitto) and PLAN-0007 (FreeRADIUS) followed that pattern: a sidecar container speaks Vault, writes cert+key to a shared volume, and triggers a consumer restart on rotation.
+
+Ruby-core's services are architecturally different. They already speak Vault natively via `pkg/boot/boot.go`: at startup each service calls `vault.KV.Get("secret/data/ruby-core/tls/<svc>")`, parses cert/key/ca from the JSON response, and builds a `tls.Config` in memory. Nothing is written to disk. Wedging a Vault Agent sidecar into ruby-core's compose would mean:
+
+* 21 new sidecar containers (7 services × dev/staging/prod) running alongside their consumers.
+* Refactoring `boot.go` to read cert/key/ca from filesystem rather than the Vault API.
+* Adding shared-volume plumbing, fail-on-permissions edge cases (distroless UIDs vs sidecar root), and restart orchestration.
+
+All of that duplicates infrastructure ruby-core already has — a fully-featured Go Vault client — in order to satisfy the letter of ADR-0008 rather than its spirit. ADR-0008's actual goals are (a) eliminating manual `chown`-based cert distribution, (b) auto-rotation at TTL/2, (c) scoped per-service auth via AppRole, and (d) fail-fast on Vault unavailability. None of those require a sidecar; they require *semantics*.
+
+Foundation amended ADR-0008 in PR #78 with an explicit **direct-issuance exemption** for Vault-native applications. This ADR records the ruby-core-side implementation of that exemption.
+
+## Decision
+
+Ruby-core services **MUST** obtain their mTLS material directly from Vault PKI (`pki_int/issue/ruby-core-<svc>`) via the existing `pkg/boot/boot.go` Vault client. They **MUST NOT** introduce per-service Vault Agent sidecars to ruby-core compose files.
+
+Concrete requirements, all enforced in `pkg/boot/pki.go`:
+
+1. **Authentication via AppRole.** Each service logs in via `auth/approle/login` using a role-id + secret-id mounted into the container from foundation host paths (`/opt/foundation/vault/role-id-foundation-agent-ruby-core-<svc>` and `…-secret-id-…`). Static `VAULT_TOKEN` is NOT used for the TLS issuance path (it remains for legacy KV reads — NKEYs, HA, postgres — until Phase 17.7 retires it).
+
+2. **Issuance from pki_int.** `IssueNATSCert` writes to `pki_int/issue/<role>` with the service's common name and TTL. The response yields `data.certificate`, `data.private_key`, and `data.issuing_ca`, all parsed into the existing `*TLSMaterial` struct so `ConnectNATS`'s downstream wiring is unchanged.
+
+3. **In-process renewal at TTL/2.** A `RenewLoop` goroutine runs for the lifetime of the service. It ticks at TTL/2 (clamped to [1m, 24h] to prevent degenerate scheduling), re-issues a fresh cert, and atomically swaps it into a mutex-guarded `MaterialHolder`. Failures log a WARN and retry on the next tick; the loop never panics.
+
+4. **Hot-swap via `tls.Config.GetClientCertificate`.** `ConnectNATSDynamicTLS` builds a `tls.Config` whose `GetClientCertificate` callback reads the current cert from the `MaterialHolder`. The NATS Go client clones the `tls.Config` per handshake (verified in `nats.go@v1.48.0/nats.go:2240`); Go's stdlib `Clone` is shallow, so function pointers like `GetClientCertificate` survive the clone. On reconnect handshakes the callback runs against the latest cert — rotation is invisible to NATS.
+
+5. **Fail-fast at startup.** If AppRole login or the initial cert issuance fails, the service exits non-zero. Vault unavailability at startup is a configuration error, not a runtime issue to silently retry through.
+
+6. **Graceful shutdown.** `RenewLoop` accepts a `context.Context`; signal handlers cancel it so the goroutine exits cleanly during shutdown.
+
+7. **AppRole policy scope.** The bound policy (foundation-side `vault/policies/foundation-agent-ruby-core-<svc>.hcl`) grants only `update` on the service's own `pki_int/issue/<role>` path plus `auth/token/{lookup,renew}-self`. Negative scope verified live during PR #78: each AppRole cannot read the legacy `secret/ruby-core/tls/*` KV path and cannot cross-issue another service's role.
+
+8. **Rollback path.** `boot.FetchNATSTLS` and `boot.ConnectNATS` (the legacy KV-bundle path) remain callable. `BootstrapNATSTLS` branches on `VAULT_PKI_ROLE` — when unset, it falls back to the legacy path. The mkcert KV bundles in `secret/ruby-core/tls/*` stay populated through Phase 17.7's decommission PR as the durable rollback target.
+
+## Consequences
+
+### Positive Consequences
+
+* Zero new sidecar containers across dev/staging/prod.
+* No shared-volume plumbing, no UID/perm coordination, no restart orchestration.
+* Cert lifecycle scoped to the process: a service that's running has a fresh cert; a service that's not is irrelevant.
+* Reuses the existing `boot` Vault client — no parallel infrastructure.
+* Reconnect handshakes pick up rotated certs without restart; no operator action ever required for routine rotation.
+* AppRole policy scope is identical to foundation's sidecar-pattern AppRoles, so the Vault-side blast radius is the same as if we'd used the sidecar.
+
+### Negative Consequences
+
+* Diverges from the broader homelab pattern (foundation's sidecar pattern is otherwise uniform). The exemption is recorded in both repos (ADR-0008 amendment in foundation; this ADR here) to prevent confusion.
+* Adds `pkg/boot/pki.go` complexity that ruby-core didn't have before — AppRole login flow, renewal goroutine, mutex-guarded `MaterialHolder`. Mitigated by isolated tests (`pkg/boot/pki_test.go`).
+* Process lifetime tied to cert health: if `RenewLoop` consistently fails over a longer window than `TTL/2`, the service eventually presents an expired cert and NATS rejects. Mitigated by Vault availability monitoring (foundation observability stack) and the 1m retry floor.
+
+### Neutral Consequences (Trade-offs)
+
+* `boot.go` retains its static `VAULT_TOKEN` for the other Vault paths (NKEYs, HA config, postgres credentials). Two auth methods coexist on the same client until Phase 17.7 either migrates the other reads to AppRole too or accepts the dual-auth posture.
+* The secret-id host file must be readable by the in-container UID. For distroless `nonroot` (UID 65532) this means `chmod 0644` on the host — looser than foundation's `0640 root:primaryrutabaga` default for sidecar consumers. Acceptable because the security boundary is the Vault policy bound to the AppRole, not the filesystem mode. Foundation will add a `make tighten-vault-approle-perms-readable` target to make this reproducible across secret-id rotations.
+* The `RenewLoop` goroutine survives in memory but does no work until its next tick — negligible.

--- a/docs/ops/vault-dev.md
+++ b/docs/ops/vault-dev.md
@@ -94,25 +94,34 @@ vault kv put secret/ruby-core/nats/engine \
 
 ### TLS Certificates
 
-For development, generate certificates with mkcert (see `deploy/base/nats/certs/README.md`).
+**Dev now uses direct-PKI issuance** (PLAN-0008 Stage 2; ADR-0030). At service
+startup, `pkg/boot/pki.go` AppRole-logs in via mounted role-id + secret-id files
+and issues a cert directly from `pki_int/issue/ruby-core-<svc>`. An in-process
+goroutine renews at TTL/2. No mkcert dependency; no operator action for routine
+rotation.
 
-For production, use Vault's PKI engine:
+The Vault-side state (AppRoles + PKI roles + scoped policies + role-id files on
+disk) is created by foundation's `make setup-pki-ruby-core-roles` +
+`make setup-foundation-agent-ruby-core-roles` (PLAN-0008 Stage 1, foundation
+PR #78). The compose file bind-mounts the resulting role-id + secret-id files
+into each ruby-core container.
+
+**Rollback path (legacy mkcert KV bundle):** still callable when `VAULT_PKI_ROLE`
+is unset in compose. `make setup-creds` repopulates `secret/ruby-core/tls/*`
+from mkcert. Retained as the durable rollback target until Phase 17.7.
+
+**Historical note (Phase 2 design — superseded by Phase 17.6):** the original
+plan was to use mkcert in dev and Vault's PKI engine only in prod, with a
+forward-looking sketch like:
 
 ```bash
-# Enable PKI secrets engine
 vault secrets enable pki
-
-# Generate root CA
 vault write pki/root/generate/internal \
   common_name="Ruby Core CA" \
   ttl=87600h
-
-# Configure CA and CRL URLs
 vault write pki/config/urls \
   issuing_certificates="http://vault:8200/v1/pki/ca" \
   crl_distribution_points="http://vault:8200/v1/pki/crl"
-
-# Create a role for issuing certificates
 vault write pki/roles/ruby-core-service \
   allowed_domains="ruby-core.local" \
   allow_subdomains=true \
@@ -131,9 +140,12 @@ vault kv get secret/ruby-core/nats/gateway
 vault kv get -field=seed secret/ruby-core/nats/gateway
 ```
 
-## Known Limitations (Phase 2)
+## Known Limitations (Phase 2 — partly resolved by Phase 17.6)
 
-- **Static VAULT_TOKEN:** Services authenticate to Vault using a static token passed via environment variable. This is acceptable for Phase 2 but should be migrated to AppRole or Kubernetes auth in a future phase (ADR-0015).
+- **Static VAULT_TOKEN:** Services still authenticate via static token for the
+  NKEY + HA + Postgres KV reads. The TLS path moved to AppRole in Phase 17.6
+  (PLAN-0008 Stage 2; ADR-0030). The remaining KV reads will follow in
+  Phase 17.7 or later as a separate effort.
 
 ## Security Notes
 

--- a/pkg/boot/boot.go
+++ b/pkg/boot/boot.go
@@ -19,12 +19,25 @@ import (
 
 // Config holds bootstrap configuration read from environment variables.
 type Config struct {
+	// Service is the short service name passed to LoadConfig. Used as the
+	// PKI common name when direct-PKI issuance is enabled.
+	Service string
+
 	VaultAddr       string
 	VaultToken      string
 	NATSUrl         string
 	VaultNKEYPath   string
 	VaultTLSPath    string
 	NATSRequireMTLS bool
+
+	// Direct-PKI fields (PLAN-0008, Phase 17.6). When VaultPKIRole is set,
+	// services authenticate via AppRole and issue TLS material directly from
+	// pki_int/issue/<role> instead of reading the legacy KV bundle at
+	// VaultTLSPath. The legacy path remains as the rollback target.
+	VaultPKIRole      string
+	VaultRoleIDPath   string
+	VaultSecretIDPath string
+	VaultPKITTL       string
 }
 
 // TLSMaterial holds PEM-encoded TLS certificate material fetched from Vault.
@@ -43,12 +56,17 @@ type vaultReader interface {
 func LoadConfig(service string) Config {
 	requireMTLS, _ := strconv.ParseBool(os.Getenv("NATS_REQUIRE_MTLS"))
 	cfg := Config{
-		VaultAddr:       envOrDefault("VAULT_ADDR", "http://127.0.0.1:8200"),
-		VaultToken:      os.Getenv("VAULT_TOKEN"),
-		NATSUrl:         envOrDefault("NATS_URL", "tls://localhost:4222"),
-		VaultNKEYPath:   envOrDefault("VAULT_NKEY_PATH", "secret/data/ruby-core/nats/"+service),
-		VaultTLSPath:    envOrDefault("VAULT_TLS_PATH", "secret/data/ruby-core/tls/"+service),
-		NATSRequireMTLS: requireMTLS,
+		Service:           service,
+		VaultAddr:         envOrDefault("VAULT_ADDR", "http://127.0.0.1:8200"),
+		VaultToken:        os.Getenv("VAULT_TOKEN"),
+		NATSUrl:           envOrDefault("NATS_URL", "tls://localhost:4222"),
+		VaultNKEYPath:     envOrDefault("VAULT_NKEY_PATH", "secret/data/ruby-core/nats/"+service),
+		VaultTLSPath:      envOrDefault("VAULT_TLS_PATH", "secret/data/ruby-core/tls/"+service),
+		NATSRequireMTLS:   requireMTLS,
+		VaultPKIRole:      os.Getenv("VAULT_PKI_ROLE"),
+		VaultRoleIDPath:   envOrDefault("VAULT_ROLE_ID_PATH", "/vault/role-id"),
+		VaultSecretIDPath: envOrDefault("VAULT_SECRET_ID_PATH", "/vault/secret-id"),
+		VaultPKITTL:       envOrDefault("VAULT_PKI_TTL", "720h"),
 	}
 
 	// Reject plaintext Vault in production (ADR-0015)

--- a/pkg/boot/pki.go
+++ b/pkg/boot/pki.go
@@ -1,0 +1,398 @@
+// PKI-direct issuance path for service mTLS material (PLAN-0008, Phase 17.6).
+//
+// Services authenticate via AppRole and issue cert+key directly from
+// pki_int/issue/<role>; a renewal goroutine re-issues at TTL/2 and hot-swaps
+// the cert into a mutex-guarded holder. NATS reconnect handshakes call the
+// holder via tls.Config.GetClientCertificate and pick up rotated material
+// without restart.
+//
+// This path supersedes FetchNATSTLS for services that set VAULT_PKI_ROLE.
+// The legacy KV path remains callable as the rollback target until
+// Phase 17.7 retires it.
+
+package boot
+
+import (
+	"context"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"log/slog"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	vault "github.com/hashicorp/vault/api"
+	"github.com/nats-io/nats.go"
+	"github.com/nats-io/nkeys"
+)
+
+// IssueConfig captures the inputs needed to issue a TLS cert from Vault PKI.
+type IssueConfig struct {
+	VaultAddr    string // e.g. https://vault:8200
+	RoleIDPath   string // path to role-id file on disk
+	SecretIDPath string // path to secret-id file on disk
+	PKIRole      string // e.g. "ruby-core-gateway"
+	CommonName   string // e.g. "gateway"
+	IPSANs       string // comma-separated; empty for client-only roles
+	TTL          string // e.g. "720h"
+}
+
+// MaterialHolder wraps TLS material with a mutex so a renewal goroutine can
+// hot-swap fresh material while consumers (the NATS TLS handshake) read it
+// concurrently. The parsed forms of the cert and CA pool are cached to avoid
+// re-parsing PEM on every handshake.
+type MaterialHolder struct {
+	mu     sync.RWMutex
+	raw    *TLSMaterial
+	cert   *tls.Certificate
+	pool   *x509.CertPool
+	expiry time.Time // notAfter of the current cert
+}
+
+// NewMaterialHolder builds a holder from initial cert material. Returns an
+// error if the material cannot be parsed.
+func NewMaterialHolder(mat *TLSMaterial, expiry time.Time) (*MaterialHolder, error) {
+	h := &MaterialHolder{}
+	if err := h.Replace(mat, expiry); err != nil {
+		return nil, err
+	}
+	return h, nil
+}
+
+// Replace atomically swaps in fresh material. The cert and CA pool are
+// re-parsed; callers must hold the holder pointer (which is stable) — the
+// NATS handshake closure that reads via Get sees the new material on the
+// next handshake.
+func (h *MaterialHolder) Replace(mat *TLSMaterial, expiry time.Time) error {
+	cert, err := tls.X509KeyPair(mat.Cert, mat.Key)
+	if err != nil {
+		return fmt.Errorf("parse cert+key: %w", err)
+	}
+	pool := x509.NewCertPool()
+	if !pool.AppendCertsFromPEM(mat.CA) {
+		return fmt.Errorf("parse CA bundle")
+	}
+	h.mu.Lock()
+	h.raw = mat
+	h.cert = &cert
+	h.pool = pool
+	h.expiry = expiry
+	h.mu.Unlock()
+	return nil
+}
+
+// Cert returns the current parsed certificate. Safe for concurrent use.
+func (h *MaterialHolder) Cert() *tls.Certificate {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.cert
+}
+
+// CAPool returns the current CA pool. Safe for concurrent use.
+func (h *MaterialHolder) CAPool() *x509.CertPool {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.pool
+}
+
+// Expiry returns the notAfter of the current cert.
+func (h *MaterialHolder) Expiry() time.Time {
+	h.mu.RLock()
+	defer h.mu.RUnlock()
+	return h.expiry
+}
+
+// appRoleLogin reads role-id + secret-id from disk, performs AppRole login
+// against Vault, and returns an authenticated client. The returned client's
+// token has the policy bound to the AppRole (foundation-agent-ruby-core-<svc>).
+func appRoleLogin(addr, roleIDPath, secretIDPath string) (*vault.Client, error) {
+	// Paths come from VAULT_ROLE_ID_PATH / VAULT_SECRET_ID_PATH env vars set
+	// by compose; they point at specific bind-mounted AppRole material at
+	// well-known container paths (default /vault/role-id, /vault/secret-id).
+	// gosec G304's path-traversal concern doesn't apply: we WANT the operator-
+	// configured path. Wrong path → AppRole login fails → service fails to
+	// start, which is the correct failure mode.
+	roleID, err := os.ReadFile(roleIDPath) // #nosec G304 -- operator-configured AppRole material path
+	if err != nil {
+		return nil, fmt.Errorf("read role-id %s: %w", roleIDPath, err)
+	}
+	secretID, err := os.ReadFile(secretIDPath) // #nosec G304 -- operator-configured AppRole material path
+	if err != nil {
+		return nil, fmt.Errorf("read secret-id %s: %w", secretIDPath, err)
+	}
+
+	cfg := vault.DefaultConfig()
+	cfg.Address = addr
+	client, err := vault.NewClient(cfg)
+	if err != nil {
+		return nil, fmt.Errorf("create vault client: %w", err)
+	}
+
+	resp, err := client.Logical().Write("auth/approle/login", map[string]interface{}{
+		"role_id":   strings.TrimSpace(string(roleID)),
+		"secret_id": strings.TrimSpace(string(secretID)),
+	})
+	if err != nil {
+		return nil, fmt.Errorf("approle login: %w", err)
+	}
+	if resp == nil || resp.Auth == nil || resp.Auth.ClientToken == "" {
+		return nil, fmt.Errorf("approle login: empty response")
+	}
+	client.SetToken(resp.Auth.ClientToken)
+	return client, nil
+}
+
+// IssueNATSCert authenticates via AppRole, issues a fresh cert from the
+// configured PKI role, and returns the material plus its notAfter time.
+// Wrapped in withRetry — transient Vault failures retry up to 3x.
+func IssueNATSCert(cfg IssueConfig) (*TLSMaterial, time.Time, error) {
+	var (
+		mat    *TLSMaterial
+		expiry time.Time
+	)
+	err := withRetry(func() error {
+		client, err := appRoleLogin(cfg.VaultAddr, cfg.RoleIDPath, cfg.SecretIDPath)
+		if err != nil {
+			return err
+		}
+		payload := map[string]interface{}{
+			"common_name": cfg.CommonName,
+			"ttl":         cfg.TTL,
+		}
+		if cfg.IPSANs != "" {
+			payload["ip_sans"] = cfg.IPSANs
+		}
+		resp, err := client.Logical().Write("pki_int/issue/"+cfg.PKIRole, payload)
+		if err != nil {
+			return fmt.Errorf("issue %s: %w", cfg.PKIRole, err)
+		}
+		if resp == nil || resp.Data == nil {
+			return fmt.Errorf("issue %s: empty response", cfg.PKIRole)
+		}
+		certPEM, ok := resp.Data["certificate"].(string)
+		if !ok || certPEM == "" {
+			return fmt.Errorf("issue %s: missing certificate", cfg.PKIRole)
+		}
+		keyPEM, ok := resp.Data["private_key"].(string)
+		if !ok || keyPEM == "" {
+			return fmt.Errorf("issue %s: missing private_key", cfg.PKIRole)
+		}
+		issuingCA, ok := resp.Data["issuing_ca"].(string)
+		if !ok || issuingCA == "" {
+			return fmt.Errorf("issue %s: missing issuing_ca", cfg.PKIRole)
+		}
+		mat = &TLSMaterial{
+			Cert: []byte(certPEM),
+			Key:  []byte(keyPEM),
+			CA:   []byte(issuingCA),
+		}
+		// expiration field is a json.Number (int seconds since epoch).
+		if expNum, ok := resp.Data["expiration"]; ok {
+			switch v := expNum.(type) {
+			case float64:
+				expiry = time.Unix(int64(v), 0)
+			default:
+				// Some Vault clients return json.Number; fall back to parsing.
+				if s := fmt.Sprintf("%v", v); s != "" {
+					if t, err := time.Parse(time.RFC3339, s); err == nil {
+						expiry = t
+					}
+				}
+			}
+		}
+		if expiry.IsZero() {
+			// Vault didn't return an expiration field; parse it from the cert PEM.
+			if t, perr := parseCertNotAfter([]byte(certPEM)); perr == nil {
+				expiry = t
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, time.Time{}, err
+	}
+	return mat, expiry, nil
+}
+
+// parseCertNotAfter extracts the NotAfter time from the first cert in a PEM bundle.
+func parseCertNotAfter(pemData []byte) (time.Time, error) {
+	block, _ := pem.Decode(pemData)
+	if block == nil {
+		return time.Time{}, fmt.Errorf("no PEM block")
+	}
+	x, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		return time.Time{}, fmt.Errorf("parse cert: %w", err)
+	}
+	return x.NotAfter, nil
+}
+
+// RenewLoop ticks at half the current cert's remaining lifetime (or 1 hour,
+// whichever is smaller for early-cycle safety) and re-issues fresh material
+// via IssueNATSCert. On each tick:
+//   - Computes the next tick from the new expiry.
+//   - On success: swaps the holder; logs at INFO with new expiry.
+//   - On failure: logs at WARN with the error and retries on the next tick
+//     using the existing cert (no panic, no exit). The next tick is computed
+//     from the previous expiry so we keep trying before the cert dies.
+//
+// The loop exits when ctx is canceled. RenewLoop is intended to run in a
+// goroutine for the lifetime of the service process.
+func RenewLoop(ctx context.Context, cfg IssueConfig, holder *MaterialHolder) {
+	for {
+		next := renewIn(holder.Expiry(), time.Now())
+		slog.Info("pki: renewal scheduled",
+			slog.String("role", cfg.PKIRole),
+			slog.Duration("in", next),
+			slog.Time("current_expiry", holder.Expiry()),
+		)
+		timer := time.NewTimer(next)
+		select {
+		case <-ctx.Done():
+			timer.Stop()
+			slog.Info("pki: renew loop exiting", slog.String("role", cfg.PKIRole))
+			return
+		case <-timer.C:
+		}
+
+		mat, expiry, err := IssueNATSCert(cfg)
+		if err != nil {
+			slog.Warn("pki: renewal failed; will retry on next tick",
+				slog.String("role", cfg.PKIRole),
+				slog.String("error", err.Error()),
+			)
+			continue
+		}
+		if err := holder.Replace(mat, expiry); err != nil {
+			slog.Warn("pki: renewal parse failed; will retry on next tick",
+				slog.String("role", cfg.PKIRole),
+				slog.String("error", err.Error()),
+			)
+			continue
+		}
+		slog.Info("pki: renewed",
+			slog.String("role", cfg.PKIRole),
+			slog.Time("new_expiry", expiry),
+		)
+	}
+}
+
+// renewIn returns the duration until the next renewal attempt, computed as
+// half the remaining cert lifetime, clamped to [1m, 24h] to avoid degenerate
+// tight loops or overly-long sleeps.
+func renewIn(expiry, now time.Time) time.Duration {
+	remaining := expiry.Sub(now)
+	if remaining <= 0 {
+		return 1 * time.Minute // cert already expired; retry soon
+	}
+	d := remaining / 2
+	if d < 1*time.Minute {
+		return 1 * time.Minute
+	}
+	if d > 24*time.Hour {
+		return 24 * time.Hour
+	}
+	return d
+}
+
+// ConnectNATSDynamicTLS connects to NATS using NKEY auth and mTLS, where the
+// client cert is read through a MaterialHolder on every handshake. Reconnect
+// handshakes pick up rotated material without service restart.
+//
+// Mirrors ConnectNATS's NKEY + name + tls plumbing but replaces the static
+// tls.Config.Certificates with a per-handshake GetClientCertificate callback.
+// Go's tls.Config.Clone (called by nats.go before each handshake) preserves
+// function pointers, so the closure runs against the holder's current cert
+// on every handshake — verified live during the Stage 2 spike.
+func ConnectNATSDynamicTLS(cfg Config, name, seed string, holder *MaterialHolder) (*nats.Conn, error) {
+	kp, err := nkeys.FromSeed([]byte(seed))
+	if err != nil {
+		return nil, fmt.Errorf("parse seed: %w", err)
+	}
+	pub, err := kp.PublicKey()
+	if err != nil {
+		return nil, fmt.Errorf("public key: %w", err)
+	}
+
+	tlsCfg := &tls.Config{
+		MinVersion: tls.VersionTLS13,
+		RootCAs:    holder.CAPool(),
+		GetClientCertificate: func(_ *tls.CertificateRequestInfo) (*tls.Certificate, error) {
+			c := holder.Cert()
+			if c == nil {
+				return nil, fmt.Errorf("no client cert available")
+			}
+			return c, nil
+		},
+	}
+
+	opts := []nats.Option{
+		nats.Nkey(pub, func(nonce []byte) ([]byte, error) {
+			return kp.Sign(nonce)
+		}),
+		nats.Name(name),
+		nats.Secure(tlsCfg),
+	}
+
+	nc, err := nats.Connect(cfg.NATSUrl, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("connect: %w", err)
+	}
+	return nc, nil
+}
+
+// PKIDirectEnabled returns true when the service is configured to use the
+// direct-PKI path (Phase 17.6) rather than the legacy KV bundle (FetchNATSTLS).
+func (c Config) PKIDirectEnabled() bool {
+	return c.VaultPKIRole != ""
+}
+
+// BootstrapNATSTLS wires up the mTLS NATS connection using whichever path is
+// configured: direct-PKI when VAULT_PKI_ROLE is set, or the legacy KV bundle
+// otherwise. When direct-PKI is used, a renewal goroutine is started against
+// ctx — caller cancels ctx at shutdown.
+//
+// The returned conn handles its own reconnection; rotated certs from the
+// renewal loop are picked up automatically on the next handshake.
+func BootstrapNATSTLS(ctx context.Context, cfg Config, name, seed string) (*nats.Conn, error) {
+	if cfg.PKIDirectEnabled() {
+		issueCfg := IssueConfig{
+			VaultAddr:    cfg.VaultAddr,
+			RoleIDPath:   cfg.VaultRoleIDPath,
+			SecretIDPath: cfg.VaultSecretIDPath,
+			PKIRole:      cfg.VaultPKIRole,
+			CommonName:   cfg.Service,
+			TTL:          cfg.VaultPKITTL,
+		}
+		mat, expiry, err := IssueNATSCert(issueCfg)
+		if err != nil {
+			return nil, fmt.Errorf("pki: initial issue: %w", err)
+		}
+		holder, err := NewMaterialHolder(mat, expiry)
+		if err != nil {
+			return nil, fmt.Errorf("pki: parse material: %w", err)
+		}
+		slog.Info("pki: cert issued",
+			slog.String("role", issueCfg.PKIRole),
+			slog.String("cn", issueCfg.CommonName),
+			slog.Time("expiry", expiry),
+		)
+		nc, err := ConnectNATSDynamicTLS(cfg, name, seed, holder)
+		if err != nil {
+			return nil, err
+		}
+		go RenewLoop(ctx, issueCfg, holder)
+		return nc, nil
+	}
+
+	// Legacy KV path (rollback target until Phase 17.7).
+	tlsMat, err := FetchNATSTLS(cfg.VaultAddr, cfg.VaultToken, cfg.VaultTLSPath)
+	if err != nil {
+		return nil, fmt.Errorf("vault: fetch TLS: %w", err)
+	}
+	slog.Info("vault: fetched TLS material (legacy KV path)", slog.String("path", cfg.VaultTLSPath))
+	return ConnectNATS(cfg, name, seed, tlsMat)
+}

--- a/pkg/boot/pki_test.go
+++ b/pkg/boot/pki_test.go
@@ -1,0 +1,232 @@
+//go:build fast
+
+package boot
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"sync"
+	"testing"
+	"time"
+)
+
+// ---------------------------------------------------------------------------
+// parseCertNotAfter
+// ---------------------------------------------------------------------------
+
+// generateTestCertPEM produces a self-signed cert valid for `validFor` and
+// returns its PEM-encoded bytes. Used to test parseCertNotAfter without
+// touching Vault.
+func generateTestCertPEM(t *testing.T, validFor time.Duration) ([]byte, time.Time) {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	notBefore := time.Now().Truncate(time.Second)
+	notAfter := notBefore.Add(validFor)
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "test"},
+		NotBefore:    notBefore,
+		NotAfter:     notAfter,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), notAfter
+}
+
+func TestParseCertNotAfter(t *testing.T) {
+	pemBytes, expected := generateTestCertPEM(t, 24*time.Hour)
+	got, err := parseCertNotAfter(pemBytes)
+	if err != nil {
+		t.Fatalf("parseCertNotAfter: %v", err)
+	}
+	if !got.Equal(expected) {
+		t.Errorf("notAfter mismatch: got %v, want %v", got, expected)
+	}
+}
+
+func TestParseCertNotAfter_NoPEMBlock(t *testing.T) {
+	_, err := parseCertNotAfter([]byte("not a PEM"))
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+func TestParseCertNotAfter_BadDER(t *testing.T) {
+	bad := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: []byte("garbage")})
+	_, err := parseCertNotAfter(bad)
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+}
+
+// ---------------------------------------------------------------------------
+// renewIn — TTL/2 scheduling with clamps
+// ---------------------------------------------------------------------------
+
+func TestRenewIn(t *testing.T) {
+	now := time.Date(2026, 5, 19, 12, 0, 0, 0, time.UTC)
+	cases := []struct {
+		name    string
+		expiry  time.Time
+		want    time.Duration
+		comment string
+	}{
+		{"already expired", now.Add(-1 * time.Hour), 1 * time.Minute, "should retry soon, not negative"},
+		{"expiring now", now, 1 * time.Minute, "edge case: remaining=0 falls into retry-soon"},
+		{"30s out", now.Add(30 * time.Second), 1 * time.Minute, "very small TTL → minimum clamp 1m"},
+		{"4 minutes out", now.Add(4 * time.Minute), 2 * time.Minute, "TTL/2 = 2m, above 1m floor"},
+		{"1 hour out", now.Add(1 * time.Hour), 30 * time.Minute, "TTL/2 = 30m"},
+		{"30 days out (typical)", now.Add(720 * time.Hour), 24 * time.Hour, "TTL/2 = 15d, clamped to 24h ceiling"},
+		{"1 year out (max)", now.Add(8760 * time.Hour), 24 * time.Hour, "very long TTL, ceiling clamp"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := renewIn(tc.expiry, now)
+			if got != tc.want {
+				t.Errorf("renewIn = %v, want %v (%s)", got, tc.want, tc.comment)
+			}
+		})
+	}
+}
+
+// ---------------------------------------------------------------------------
+// MaterialHolder — atomic replace + concurrent read
+// ---------------------------------------------------------------------------
+
+// buildMaterial builds a self-consistent TLSMaterial for tests by generating
+// a self-signed cert + key + CA (same cert serves as its own CA for parser).
+func buildMaterial(t *testing.T) *TLSMaterial {
+	t.Helper()
+	priv, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	template := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "holder-test"},
+		NotBefore:    time.Now(),
+		NotAfter:     time.Now().Add(1 * time.Hour),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &priv.PublicKey, priv)
+	if err != nil {
+		t.Fatalf("create cert: %v", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	keyDER, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER})
+	return &TLSMaterial{Cert: certPEM, Key: keyPEM, CA: certPEM}
+}
+
+func TestMaterialHolder_ReplaceRoundTrip(t *testing.T) {
+	mat := buildMaterial(t)
+	expiry := time.Now().Add(1 * time.Hour)
+	h, err := NewMaterialHolder(mat, expiry)
+	if err != nil {
+		t.Fatalf("NewMaterialHolder: %v", err)
+	}
+	if h.Cert() == nil {
+		t.Fatal("Cert() returned nil after construction")
+	}
+	if h.CAPool() == nil {
+		t.Fatal("CAPool() returned nil after construction")
+	}
+	if !h.Expiry().Equal(expiry) {
+		t.Errorf("Expiry mismatch: got %v, want %v", h.Expiry(), expiry)
+	}
+
+	// Replace with new material
+	mat2 := buildMaterial(t)
+	expiry2 := time.Now().Add(2 * time.Hour)
+	if err := h.Replace(mat2, expiry2); err != nil {
+		t.Fatalf("Replace: %v", err)
+	}
+	if !h.Expiry().Equal(expiry2) {
+		t.Errorf("Expiry after replace: got %v, want %v", h.Expiry(), expiry2)
+	}
+}
+
+func TestMaterialHolder_ReplaceBadCert(t *testing.T) {
+	mat := buildMaterial(t)
+	h, err := NewMaterialHolder(mat, time.Now().Add(1*time.Hour))
+	if err != nil {
+		t.Fatalf("NewMaterialHolder: %v", err)
+	}
+	bad := &TLSMaterial{Cert: []byte("garbage"), Key: mat.Key, CA: mat.CA}
+	if err := h.Replace(bad, time.Now()); err == nil {
+		t.Fatal("expected error replacing with invalid cert PEM")
+	}
+	// Original cert remains accessible after failed Replace.
+	if h.Cert() == nil {
+		t.Fatal("Cert() returned nil after failed Replace")
+	}
+}
+
+func TestMaterialHolder_ConcurrentReadWrite(t *testing.T) {
+	mat := buildMaterial(t)
+	h, err := NewMaterialHolder(mat, time.Now().Add(1*time.Hour))
+	if err != nil {
+		t.Fatalf("NewMaterialHolder: %v", err)
+	}
+
+	// 50 readers hammering h.Cert() / h.CAPool() while a writer Replaces.
+	// Pure race detection — no assertions on values beyond "not nil."
+	var wg sync.WaitGroup
+	stop := make(chan struct{})
+	for i := 0; i < 50; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for {
+				select {
+				case <-stop:
+					return
+				default:
+					if c := h.Cert(); c == nil {
+						t.Error("Cert() returned nil during concurrent read")
+						return
+					}
+					if p := h.CAPool(); p == nil {
+						t.Error("CAPool() returned nil during concurrent read")
+						return
+					}
+				}
+			}
+		}()
+	}
+
+	// 10 sequential replaces.
+	for i := 0; i < 10; i++ {
+		mat := buildMaterial(t)
+		if err := h.Replace(mat, time.Now().Add(time.Duration(i+1)*time.Hour)); err != nil {
+			t.Fatalf("Replace #%d: %v", i, err)
+		}
+	}
+	close(stop)
+	wg.Wait()
+}
+
+// ---------------------------------------------------------------------------
+// Config.PKIDirectEnabled
+// ---------------------------------------------------------------------------
+
+func TestConfig_PKIDirectEnabled(t *testing.T) {
+	if (Config{}).PKIDirectEnabled() {
+		t.Error("empty Config should not be PKI-direct")
+	}
+	if !(Config{VaultPKIRole: "ruby-core-gateway"}).PKIDirectEnabled() {
+		t.Error("Config with VaultPKIRole should be PKI-direct")
+	}
+}

--- a/scripts/fetch-nats-certs.sh
+++ b/scripts/fetch-nats-certs.sh
@@ -2,18 +2,36 @@
 #
 # Ruby Core - Fetch NATS Server Certificates and Generate auth.conf from Vault
 #
-# Used as the entrypoint for the nats-init container. Fetches server TLS
-# certificates and service NKEY public keys from Vault, then writes them to a
-# shared Docker volume that the NATS container reads from.
+# Used as the entrypoint for the nats-init container. Fetches the NATS server
+# TLS material and the service NKEY public keys from Vault, then writes them
+# to a shared Docker volume that the NATS container reads from.
+#
+# Two cert paths supported (PLAN-0008, Phase 17.6):
+#
+#   1. Direct-PKI (preferred). When VAULT_PKI_ROLE is set, the container
+#      AppRole-logs in via the mounted role-id + secret-id files and issues
+#      a fresh server cert from pki_int/issue/<role>. Output mirrors path 2's
+#      file layout (server-cert.pem / server-key.pem / ca.pem). Requires jq
+#      (installed inline below — vault:1.15 Alpine image doesn't ship it).
+#
+#   2. Legacy KV bundle. When VAULT_PKI_ROLE is unset, the script reads the
+#      pre-PKI mkcert bundle from secret/ruby-core/tls/nats-server. Retained
+#      as the rollback target until Phase 17.7's decommission.
 #
 # Environment variables:
-#   VAULT_ADDR   - Vault address (required, set by compose)
-#   VAULT_TOKEN  - Vault token (required, set by compose)
-#   CERTS_DIR    - Output directory (default: /certs)
+#   VAULT_ADDR             - Vault address (required, set by compose)
+#   VAULT_TOKEN            - Vault token (required for path 2; ignored on path 1)
+#   VAULT_PKI_ROLE         - When set, switches to direct-PKI path
+#   VAULT_ROLE_ID_PATH     - Path to AppRole role-id file (default /vault/role-id)
+#   VAULT_SECRET_ID_PATH   - Path to AppRole secret-id file (default /vault/secret-id)
+#   VAULT_PKI_TTL          - Cert TTL (default 720h — matches pki_int role default)
+#   VAULT_PKI_IP_SANS      - IP SANs (default 127.0.0.1)
+#   CERTS_DIR              - Output directory (default /certs)
 #
 # Vault paths:
-#   secret/ruby-core/tls/nats-server  — fields: cert, key, ca
-#   secret/ruby-core/nats/<service>   — field:  public_key
+#   pki_int/issue/<VAULT_PKI_ROLE>    — direct-PKI issuance (path 1)
+#   secret/ruby-core/tls/nats-server  — legacy KV bundle (path 2)
+#   secret/ruby-core/nats/<service>   — NKEY public keys (both paths; KV-only)
 #
 
 set -eu
@@ -21,10 +39,20 @@ set -eu
 CERTS_DIR="${CERTS_DIR:-/certs}"
 TLS_PATH="${TLS_PATH:-secret/ruby-core/tls/nats-server}"
 NKEY_BASE="${NKEY_BASE:-secret/ruby-core/nats}"
+PKI_ROLE="${VAULT_PKI_ROLE:-}"
+ROLE_ID_PATH="${VAULT_ROLE_ID_PATH:-/vault/role-id}"
+SECRET_ID_PATH="${VAULT_SECRET_ID_PATH:-/vault/secret-id}"
+PKI_TTL="${VAULT_PKI_TTL:-720h}"
+PKI_IP_SANS="${VAULT_PKI_IP_SANS:-127.0.0.1}"
 MAX_RETRIES=5
 RETRY_DELAY=2
 
 echo "[nats-init] Vault: ${VAULT_ADDR}"
+if [ -n "${PKI_ROLE}" ]; then
+    echo "[nats-init] mode: direct-PKI (role=${PKI_ROLE})"
+else
+    echo "[nats-init] mode: legacy KV (PLAN-0008 rollback path)"
+fi
 
 # Wait for Vault to become available
 attempt=1
@@ -50,17 +78,65 @@ trap 'rm -rf "${TMP_DIR}"' EXIT
 # TLS Certificates
 # =============================================================================
 
-echo "[nats-init] Fetching NATS server certificates from Vault (${TLS_PATH})..."
+if [ -n "${PKI_ROLE}" ]; then
+    # ── Path 1: direct-PKI via AppRole ────────────────────────────────────
+    echo "[nats-init] Issuing NATS server cert from pki_int/issue/${PKI_ROLE}..."
 
-if ! vault kv get "${TLS_PATH}" >/dev/null 2>&1; then
-    echo "[nats-init] ERROR: Secret not found at ${TLS_PATH}"
-    echo "[nats-init] Run 'make setup-creds' first (with Vault running and VAULT_TOKEN set)."
-    exit 2
+    # jq is needed to extract three fields from one issuance response without
+    # re-issuing. vault:1.15 Alpine doesn't ship jq; apk-add is idempotent and
+    # cheap (~1s on first run, no-op afterward).
+    if ! command -v jq >/dev/null 2>&1; then
+        apk add --no-cache jq >/dev/null
+    fi
+
+    if [ ! -s "${ROLE_ID_PATH}" ]; then
+        echo "[nats-init] ERROR: role-id file missing or empty at ${ROLE_ID_PATH}"
+        exit 1
+    fi
+    if [ ! -s "${SECRET_ID_PATH}" ]; then
+        echo "[nats-init] ERROR: secret-id file missing or empty at ${SECRET_ID_PATH}"
+        exit 1
+    fi
+
+    ROLE_ID=$(tr -d '[:space:]' < "${ROLE_ID_PATH}")
+    SECRET_ID=$(tr -d '[:space:]' < "${SECRET_ID_PATH}")
+
+    # AppRole login — returns a short-lived token scoped to the
+    # foundation-agent-ruby-core-nats-server policy.
+    APPROLE_TOKEN=$(vault write -field=token auth/approle/login \
+        role_id="${ROLE_ID}" secret_id="${SECRET_ID}")
+    if [ -z "${APPROLE_TOKEN}" ]; then
+        echo "[nats-init] ERROR: AppRole login returned empty token"
+        exit 1
+    fi
+
+    # Issue once; capture full JSON so we can extract all three fields from
+    # the same cert/key pair without triggering additional issuances.
+    VAULT_TOKEN="${APPROLE_TOKEN}" vault write -format=json \
+        "pki_int/issue/${PKI_ROLE}" \
+        common_name=nats \
+        ip_sans="${PKI_IP_SANS}" \
+        ttl="${PKI_TTL}" \
+        > "${TMP_DIR}/issue-resp.json"
+
+    jq -r '.data.certificate' "${TMP_DIR}/issue-resp.json" > "${TMP_DIR}/server-cert.pem"
+    jq -r '.data.private_key' "${TMP_DIR}/issue-resp.json" > "${TMP_DIR}/server-key.pem"
+    jq -r '.data.issuing_ca'  "${TMP_DIR}/issue-resp.json" > "${TMP_DIR}/ca.pem"
+    rm -f "${TMP_DIR}/issue-resp.json"
+else
+    # ── Path 2: legacy KV bundle (rollback target) ────────────────────────
+    echo "[nats-init] Fetching NATS server certificates from Vault (${TLS_PATH})..."
+
+    if ! vault kv get "${TLS_PATH}" >/dev/null 2>&1; then
+        echo "[nats-init] ERROR: Secret not found at ${TLS_PATH}"
+        echo "[nats-init] Run 'make setup-creds' first (with Vault running and VAULT_TOKEN set)."
+        exit 2
+    fi
+
+    vault kv get -field=cert "${TLS_PATH}" > "${TMP_DIR}/server-cert.pem"
+    vault kv get -field=key  "${TLS_PATH}" > "${TMP_DIR}/server-key.pem"
+    vault kv get -field=ca   "${TLS_PATH}" > "${TMP_DIR}/ca.pem"
 fi
-
-vault kv get -field=cert "${TLS_PATH}" > "${TMP_DIR}/server-cert.pem"
-vault kv get -field=key  "${TLS_PATH}" > "${TMP_DIR}/server-key.pem"
-vault kv get -field=ca   "${TLS_PATH}" > "${TMP_DIR}/ca.pem"
 
 for f in server-cert.pem server-key.pem ca.pem; do
     if [ ! -s "${TMP_DIR}/${f}" ]; then

--- a/scripts/verify-tls-stack.sh
+++ b/scripts/verify-tls-stack.sh
@@ -36,10 +36,14 @@ CONTAINER_PREFIX="ruby-core-dev"
 export VAULT_ADDR="${VAULT_ADDR:-https://127.0.0.1:8200}"
 export VAULT_CACERT="${VAULT_CACERT:-/opt/foundation/vault/tls/vault-ca.crt}"
 
-# Expected log messages (slog JSON format, from services/gateway/main.go and services/engine/main.go)
+# Expected log messages (slog JSON format).
+# PLAN-0008 (Phase 17.6) split the TLS-material log into two possible lines:
+#   "pki: cert issued"               — direct-PKI path (VAULT_PKI_ROLE set)
+#   "vault: fetched TLS material"    — legacy KV path (rollback target)
+# The grep uses extended regex alternation to accept either.
 EXPECTED_LOGS=(
     "vault: fetched NATS seed"
-    "vault: fetched TLS material"
+    "pki: cert issued\|vault: fetched TLS material"
     "connected to NATS"
 )
 
@@ -117,7 +121,11 @@ preflight() {
 
 start_services() {
     log_info "Building and starting services..."
-    compose --profile services up -d --build gateway engine
+    # --force-recreate ensures fresh log buffers so the verify checks (which
+    # match against startup log lines) don't have to scan months of accumulated
+    # output. Without this, a long-running container with 100MB+ of logs trips
+    # the pipefail+SIGPIPE interaction in verify() below — see the comment there.
+    compose --profile services up -d --build --force-recreate gateway engine
 }
 
 # =============================================================================
@@ -147,7 +155,14 @@ verify() {
             local svc_ok=true
 
             for expected in "${EXPECTED_LOGS[@]}"; do
-                if ! echo "${logs}" | grep -q "${expected}"; then
+                # Use here-string (<<<) instead of `echo "$logs" | grep`.
+                # With `set -o pipefail`, a fast `grep -q` that exits on first
+                # match closes its stdin, SIGPIPE-killing the upstream echo;
+                # pipefail then reports the pipeline as failed even though the
+                # match succeeded — silently turning every match into a MISS
+                # for any service with non-trivial log volume. Here-strings
+                # bypass the pipe entirely.
+                if ! grep -q "${expected}" <<< "${logs}"; then
                     svc_ok=false
                     break
                 fi

--- a/services/audit-sink/main.go
+++ b/services/audit-sink/main.go
@@ -48,16 +48,15 @@ func main() {
 	}
 	logger.Info("vault: fetched NATS seed", slog.String("path", cfg.VaultNKEYPath))
 
-	tlsMat, err := boot.FetchNATSTLS(cfg.VaultAddr, cfg.VaultToken, cfg.VaultTLSPath)
-	if err != nil {
-		logger.Error("vault: fetch TLS material failed", slog.String("error", err.Error()))
-		os.Exit(1)
-	}
-	logger.Info("vault: fetched TLS material", slog.String("path", cfg.VaultTLSPath))
+	// ctx scopes the renewal goroutine started by BootstrapNATSTLS when the
+	// direct-PKI path is enabled. Canceling it at shutdown lets RenewLoop exit
+	// cleanly. The signal handler installed below cancels it.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	nc, err := boot.ConnectNATS(cfg, "ruby-core-audit-sink", seed, tlsMat)
+	nc, err := boot.BootstrapNATSTLS(ctx, cfg, "ruby-core-audit-sink", seed)
 	if err != nil {
-		logger.Error("nats: connect failed", slog.String("error", err.Error()))
+		logger.Error("nats: bootstrap failed", slog.String("error", err.Error()))
 		os.Exit(1)
 	}
 	defer nc.Close()
@@ -118,7 +117,6 @@ func main() {
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
 
-	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		<-sig
 		logger.Info("shutting down")

--- a/services/engine/main.go
+++ b/services/engine/main.go
@@ -49,16 +49,15 @@ func main() {
 	}
 	logger.Info("vault: fetched NATS seed", slog.String("path", cfg.VaultNKEYPath))
 
-	tlsMat, err := boot.FetchNATSTLS(cfg.VaultAddr, cfg.VaultToken, cfg.VaultTLSPath)
-	if err != nil {
-		logger.Error("vault: fetch TLS material failed", slog.String("error", err.Error()))
-		os.Exit(1)
-	}
-	logger.Info("vault: fetched TLS material", slog.String("path", cfg.VaultTLSPath))
+	// ctx scopes the renewal goroutine started by BootstrapNATSTLS when the
+	// direct-PKI path is enabled. Canceling it at shutdown lets RenewLoop exit
+	// cleanly. The signal handler installed below cancels it.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	nc, err := boot.ConnectNATS(cfg, "ruby-core-engine", seed, tlsMat)
+	nc, err := boot.BootstrapNATSTLS(ctx, cfg, "ruby-core-engine", seed)
 	if err != nil {
-		logger.Error("nats: connect failed", slog.String("error", err.Error()))
+		logger.Error("nats: bootstrap failed", slog.String("error", err.Error()))
 		os.Exit(1)
 	}
 	defer nc.Close()
@@ -270,7 +269,6 @@ func main() {
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
 
-	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		<-sig
 		logger.Info("shutting down")

--- a/services/gateway/main.go
+++ b/services/gateway/main.go
@@ -37,16 +37,15 @@ func main() {
 	}
 	logger.Info("vault: fetched NATS seed", slog.String("path", cfg.VaultNKEYPath))
 
-	tlsMat, err := boot.FetchNATSTLS(cfg.VaultAddr, cfg.VaultToken, cfg.VaultTLSPath)
-	if err != nil {
-		logger.Error("vault: fetch TLS material failed", slog.String("error", err.Error()))
-		os.Exit(1)
-	}
-	logger.Info("vault: fetched TLS material", slog.String("path", cfg.VaultTLSPath))
+	// ctx scopes the renewal goroutine started by BootstrapNATSTLS when the
+	// direct-PKI path is enabled. Canceling it at shutdown lets RenewLoop exit
+	// cleanly. The signal handler installed below cancels it.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	nc, err := boot.ConnectNATS(cfg, "ruby-core-gateway", seed, tlsMat)
+	nc, err := boot.BootstrapNATSTLS(ctx, cfg, "ruby-core-gateway", seed)
 	if err != nil {
-		logger.Error("nats: connect failed", slog.String("error", err.Error()))
+		logger.Error("nats: bootstrap failed", slog.String("error", err.Error()))
 		os.Exit(1)
 	}
 	defer nc.Close()
@@ -75,9 +74,6 @@ func main() {
 		logger.Error("gateway: init failed", slog.String("error", err.Error()))
 		os.Exit(1)
 	}
-
-	ctx, cancel := context.WithCancel(context.Background())
-	defer cancel()
 
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)

--- a/services/notifier/main.go
+++ b/services/notifier/main.go
@@ -36,16 +36,15 @@ func main() {
 	}
 	logger.Info("vault: fetched NATS seed", slog.String("path", cfg.VaultNKEYPath))
 
-	tlsMat, err := boot.FetchNATSTLS(cfg.VaultAddr, cfg.VaultToken, cfg.VaultTLSPath)
-	if err != nil {
-		logger.Error("vault: fetch TLS material failed", slog.String("error", err.Error()))
-		os.Exit(1)
-	}
-	logger.Info("vault: fetched TLS material", slog.String("path", cfg.VaultTLSPath))
+	// ctx scopes the renewal goroutine started by BootstrapNATSTLS when the
+	// direct-PKI path is enabled. Canceling it at shutdown lets RenewLoop exit
+	// cleanly. The signal handler installed below cancels it.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	nc, err := boot.ConnectNATS(cfg, "ruby-core-notifier", seed, tlsMat)
+	nc, err := boot.BootstrapNATSTLS(ctx, cfg, "ruby-core-notifier", seed)
 	if err != nil {
-		logger.Error("nats: connect failed", slog.String("error", err.Error()))
+		logger.Error("nats: bootstrap failed", slog.String("error", err.Error()))
 		os.Exit(1)
 	}
 	defer nc.Close()
@@ -91,7 +90,6 @@ func main() {
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
 
-	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		<-sig
 		logger.Info("shutting down")

--- a/services/presence/main.go
+++ b/services/presence/main.go
@@ -47,16 +47,15 @@ func main() {
 	}
 	logger.Info("vault: fetched NATS seed", slog.String("path", cfg.VaultNKEYPath))
 
-	tlsMat, err := boot.FetchNATSTLS(cfg.VaultAddr, cfg.VaultToken, cfg.VaultTLSPath)
-	if err != nil {
-		logger.Error("vault: fetch TLS material failed", slog.String("error", err.Error()))
-		os.Exit(1)
-	}
-	logger.Info("vault: fetched TLS material", slog.String("path", cfg.VaultTLSPath))
+	// ctx scopes the renewal goroutine started by BootstrapNATSTLS when the
+	// direct-PKI path is enabled. Canceling it at shutdown lets RenewLoop exit
+	// cleanly. The signal handler installed below cancels it.
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
 
-	nc, err := boot.ConnectNATS(cfg, "ruby-core-presence", seed, tlsMat)
+	nc, err := boot.BootstrapNATSTLS(ctx, cfg, "ruby-core-presence", seed)
 	if err != nil {
-		logger.Error("nats: connect failed", slog.String("error", err.Error()))
+		logger.Error("nats: bootstrap failed", slog.String("error", err.Error()))
 		os.Exit(1)
 	}
 	defer nc.Close()
@@ -111,7 +110,6 @@ func main() {
 	sig := make(chan os.Signal, 1)
 	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
 
-	ctx, cancel := context.WithCancel(context.Background())
 	go func() {
 		<-sig
 		logger.Info("shutting down")


### PR DESCRIPTION
## Summary

**Stage 2 of foundation's PLAN-0008.** Migrates ruby-core's dev environment off the mkcert-issued KV bundles at `secret/ruby-core/tls/*` onto Vault PKI direct issuance from `pki_int/issue/ruby-core-<svc>`. Stages 3 (staging) and 4 (prod) land in separate PRs after dev soaks.

**Architecturally distinct from foundation's mosquitto/freeradius migrations.** Those services don't speak Vault, so a Vault Agent sidecar bridges Vault → filesystem. Ruby-core's services *do* speak Vault — adding 21 sidecars (7 services × 3 envs) would have duplicated infrastructure ruby-core already had. This PR refactors `pkg/boot/boot.go` to call PKI directly with an in-process renewal goroutine. Foundation amended ADR-0008 with a direct-issuance exemption in their [PR #78](https://github.com/rutabageldev/foundation/pull/78); this PR adds the corresponding [ADR-0030](docs/adr/0030-direct-pki-issuance-no-sidecar.md) here.

## What's in this PR

### New: `pkg/boot/pki.go` + `pkg/boot/pki_test.go`

- `IssueConfig`, `MaterialHolder` — mutex-guarded TLS material with parsed-cert caching to avoid re-parsing PEM per handshake.
- `appRoleLogin` — reads role-id + secret-id from mounted files, logs in via `auth/approle/login`, returns authenticated client.
- `IssueNATSCert` — writes to `pki_int/issue/<role>`, parses cert/key/issuing_ca into the existing `*TLSMaterial` struct (so `ConnectNATS`'s downstream wiring is unchanged).
- `RenewLoop` — ticks at TTL/2 (clamped to [1m, 24h]), re-issues, atomic-swaps. Logs success/failure; never panics; exits cleanly on context cancel.
- `ConnectNATSDynamicTLS` — wires `tls.Config.GetClientCertificate` to a closure that reads through the holder. Verified via `nats.go@v1.48.0` source: it clones the `tls.Config` per handshake; Go's shallow `Clone` preserves function pointers; reconnect handshakes pick up rotated material without restart.
- `BootstrapNATSTLS` — single entry point used by all 5 services. Picks direct-PKI when `VAULT_PKI_ROLE` is set, falls back to legacy `FetchNATSTLS` otherwise (rollback retained through Phase 17.7).
- Tests cover `parseCertNotAfter` (with generated PEM), `renewIn` (edge cases: expired, 30s, 30d, 1y), `MaterialHolder.Replace` round-trip + bad-cert recovery, and concurrent read/write race (50 readers × 10 replaces). Pass with `-race` in ~11s.

### Modified: 5 service `main.go` files
Each replaces the `FetchNATSTLS` + `ConnectNATS` block with one `BootstrapNATSTLS` call. `ctx` moved to top of `main()` so `RenewLoop` cancels at shutdown.

### Modified: `scripts/fetch-nats-certs.sh`
Adds direct-PKI branch using AppRole login + single JSON-format issuance with `jq` (apk-add inline; vault:1.15 Alpine doesn't ship it). Legacy KV branch retained as rollback.

### Modified: `deploy/dev/compose.dev.yaml`
- Bind-mounts role-id + secret-id from `/opt/foundation/vault/...` into all 6 containers (nats-init + 5 services).
- Sets `VAULT_PKI_ROLE=ruby-core-<svc>` per service.
- `VAULT_TLS_PATH` + `VAULT_TOKEN` retained for the rollback path.
- Engine joins `postgres` network (parity with prod; fixes pre-existing dev drift where engine couldn't reach foundation-postgres for `ada` migrations).

### Fixed: `scripts/verify-tls-stack.sh` — real bug, not "brittleness"

Initial verify-tls-stack.sh runs showed engine failing with `"did NOT connect within 60s"` despite engine actually connecting cleanly. Root-cause investigation found a `set -o pipefail` + `echo "$logs" | grep -q "$pattern"` interaction on a 100MB+ engine log buffer:

1. `grep -q` exits 0 on first match
2. closes its stdin
3. SIGPIPE-kills the upstream `echo`
4. `pipefail` reports the pipeline as failed (rightmost-failed cmd was echo, killed by SIGPIPE)
5. the `!` flips it to true → MISS recorded
6. **every successful match silently turned into a miss** for any service with non-trivial log volume

Two-part fix:
- `start_services` adds `--force-recreate` so log buffers start fresh (matches the script's existing teardown-at-end semantics).
- Polling loop replaces `echo "$logs" | grep -q "$p"` with the here-string `grep -q "$p" <<< "$logs"`. No pipe → no SIGPIPE → no pipefail misreport. Also ~2× faster on 100MB input.
- `EXPECTED_LOGS` extended with the new `"pki: cert issued"` line alongside the legacy `"vault: fetched TLS material"` so both paths verify cleanly.
- Validated: **5/5 consecutive verify runs pass.**

### New: `docs/adr/0030-direct-pki-issuance-no-sidecar.md`
Records the direct-issuance exemption for ruby-core. Pairs with foundation's ADR-0008 amendment. Explicit about when the exemption applies (Vault-native consumers only) and what semantics are required (AppRole, TTL/2 renewal, fail-fast, scoped policy).

### Updated: `docs/ops/vault-dev.md`
The TLS Certificates section told operators to use mkcert for dev and sketched a forward-looking prod-PKI setup. Both are now stale; updated to describe the active direct-PKI flow + rollback path; old block kept as a historical note.

### Updated: `deploy/dev/.env.example`
TLS section refreshed to explain the new default vs. the legacy rollback path.

## Live verification (dev)

- All 5 services issue certs from `ruby-core-<svc>` PKI roles at startup
- NATS server cert issuer = `RubyNet Intermediate CA` (was: `mkcert <user>@<host>`)
- All mTLS connections established; renewal goroutines scheduled
- `bash scripts/verify-tls-stack.sh` passes 5/5 back-to-back runs (post-fix)
- `go build ./...` clean; `go test -tags fast -race ./pkg/boot/...` clean (11s)
- `pre-commit run` clean (gosec G304 on the operator-configured file reads suppressed with `#nosec` + justification)

## Foundation-side prerequisite (already merged)

[foundation PR #78](https://github.com/rutabageldev/foundation/pull/78) created the 6 AppRoles + 6 PKI roles + 6 scoped policies + role-id files on disk. Without it, the AppRole login in this PR fails.

## Drift observations (for tracking)

1. **Foundation needs a Make target to chmod 0644 the ruby-core secret-id files.** I `chmod 0644`'d them manually during the cutover, but the next `make rotate-approle-secret-id ROLE=foundation-agent-ruby-core-*` resets perms to `0600`, which breaks the bind-mount into distroless `nonroot` UID 65532. Tracking as a foundation-side follow-up.
2. **Pre-existing dev engine→postgres network gap** — fixed inline here (engine joins `postgres` network like prod). Was breaking `make dev-verify` independently of PKI.
3. **The `pipefail` + `echo "$big_var" | grep -q` bug pattern** could exist elsewhere — worth grepping any other scripts that combine those.

## Out of scope

- staging + prod migrations (Stages 3 + 4 of PLAN-0008) — separate PRs after dev soak
- Removal of legacy KV bundles, `VAULT_TOKEN`, `FetchNATSTLS` (Phase 17.7)
- Migration of `admin` + `navi-*` external clients (separate effort)

## Test plan

- [x] `go build ./...`
- [x] `go test -tags fast -race ./pkg/boot/...` (covers new types + functions)
- [x] Pre-commit hooks pass
- [x] `make dev-down && make dev-up` brings up full stack
- [x] All 5 services log `"pki: cert issued"` and `"connected to NATS"` at startup
- [x] NATS server cert verified via `openssl x509 -noout -issuer` = `RubyNet Intermediate CA`
- [x] AppRole negative-scope tested via foundation PR #78 (each token can only issue its own role; cannot read legacy KV)
- [x] `bash scripts/verify-tls-stack.sh` × 5 = 5/5 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)