### PR TITLE
feat(deploy/dev): nats-cert-renewer sidecar for automatic NATS server cert rotation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,6 +28,9 @@ dist/
 # deployment state
 .last-deployed-version
 
+# Vault Agent rendered output (sidecar writes here; never commit)
+deploy/*/vault-agent/rendered/
+
 # GitHub Actions runner artifacts (runner lives at ~/actions-runner, not in repo)
 _runner-work/
 _diag/

--- a/deploy/dev/compose.dev.yaml
+++ b/deploy/dev/compose.dev.yaml
@@ -71,6 +71,48 @@ services:
       start_period: 5s
 
   # ==========================================================================
+  # NATS Cert Renewer (long-running sidecar — PLAN-0008 follow-up)
+  # ==========================================================================
+  # Vault Agent that re-issues the NATS server cert at TTL/2 and SIGHUPs the
+  # NATS container to reload TLS without dropping client connections. Closes
+  # the renewal gap from PLAN-0008 Stage 2 verification.
+  #
+  # See deploy/dev/vault-agent/ for config + template + post-render script.
+  # Auth via foundation-agent-ruby-core-nats-server AppRole (created in
+  # foundation PR #78); zero new Vault state required.
+  nats-cert-renewer:
+    image: foundation/vault-agent:1.21.4
+    container_name: ruby-core-dev-nats-cert-renewer
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
+    depends_on:
+      nats:
+        condition: service_healthy
+    command:
+      - sh
+      - -c
+      - vault agent -config=/etc/vault-agent/config.hcl
+    environment:
+      - NATS_CONTAINER=ruby-core-dev-nats
+    volumes:
+      - nats-certs:/certs
+      - ./vault-agent/config.hcl:/etc/vault-agent/config.hcl:ro
+      - ./vault-agent/nats-server.tpl:/etc/vault-agent/nats-server.tpl:ro
+      - ./vault-agent/post-render.sh:/etc/vault-agent/post-render.sh:ro
+      - /opt/foundation/vault/role-id-foundation-agent-ruby-core-nats-server:/vault/role-id:ro
+      - /opt/foundation/vault/.secret-id-foundation-agent-ruby-core-nats-server:/vault/secret-id:ro
+      - /opt/foundation/vault/tls/vault-ca.crt:/vault/tls/vault-ca.crt:ro
+      - ./vault-agent/rendered:/rendered
+      - /var/run/docker.sock:/var/run/docker.sock  # allow:docker.sock -- nats-cert-renewer SIGHUP hook (PLAN-0008 follow-up)
+    networks:
+      - default
+      - vault-ruby-core-dev
+    cap_drop:
+      - ALL
+
+  # ==========================================================================
   # Gateway Service (profile: services)
   # ==========================================================================
   # Activated with: docker compose --profile services up -d

--- a/deploy/dev/vault-agent/config.hcl
+++ b/deploy/dev/vault-agent/config.hcl
@@ -1,0 +1,50 @@
+# Vault Agent — NATS server cert auto-renewer (PLAN-0008 follow-up)
+#
+# Authenticates via the foundation-agent-ruby-core-nats-server AppRole
+# (created in foundation PR #78) and renders the NATS server cert + key + CA
+# from a single pki_int/issue/ruby-core-nats-server call. The post-render
+# script atomic-writes the three files into the shared `nats-certs` volume
+# and SIGHUPs NATS via the Docker API. NATS reloads its TLS config in-place
+# (~40ms); existing mTLS connections survive (only new handshakes use the
+# rotated cert).
+#
+# Renewal cadence: Vault Agent's template engine refreshes at TTL/2 — same
+# cadence as the in-process renewal goroutine on the 5 Go services (24h-ish
+# with the default lease behavior).
+#
+# Image: foundation/vault-agent:1.21.4 — hashicorp/vault + curl baked in for
+# the Docker API SIGHUP call (foundation drift #75 / PLAN-0007).
+
+pid_file = "/tmp/vault-agent.pid"
+
+vault {
+  address = "https://vault:8200"
+  ca_cert = "/vault/tls/vault-ca.crt"
+}
+
+auto_auth {
+  method "approle" {
+    config = {
+      role_id_file_path                   = "/vault/role-id"
+      secret_id_file_path                 = "/vault/secret-id"
+      remove_secret_id_file_after_reading = false
+    }
+  }
+
+  sink "file" {
+    config = {
+      path = "/tmp/.vault-agent-token"
+    }
+  }
+}
+
+# Single template stanza — NATS needs cert+key+ca, all three from one
+# issuance (so the chain matches). Template emits them with ==CA== and
+# ==KEY== separators; post-render.sh splits, atomic-renames into /certs/,
+# and signals NATS.
+template {
+  source      = "/etc/vault-agent/nats-server.tpl"
+  destination = "/rendered/nats-bundle.tmp"
+  perms       = "0644"
+  command     = ["/etc/vault-agent/post-render.sh"]
+}

--- a/deploy/dev/vault-agent/nats-server.tpl
+++ b/deploy/dev/vault-agent/nats-server.tpl
@@ -1,0 +1,6 @@
+{{ with secret "pki_int/issue/ruby-core-nats-server" "common_name=nats" "ip_sans=127.0.0.1" "alt_names=ruby-core-dev-nats,ruby-core-staging-nats,ruby-core-prod-nats,localhost" "ttl=720h" }}{{ .Data.certificate }}
+==CA==
+{{ .Data.issuing_ca }}
+==KEY==
+{{ .Data.private_key }}
+{{ end }}

--- a/deploy/dev/vault-agent/post-render.sh
+++ b/deploy/dev/vault-agent/post-render.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+# Vault Agent post-render hook for the NATS server cert bundle.
+#
+# Splits /rendered/nats-bundle.tmp (cert + ==CA== + ca + ==KEY== + key) into
+# the three files NATS reads from its shared `nats-certs` volume, then sends
+# SIGHUP to the NATS container via the Docker API. NATS reloads its TLS
+# config in-place (~40ms); existing mTLS connections survive — only new
+# TLS handshakes use the rotated cert.
+#
+# Runs inside the foundation/vault-agent:1.21.4 image (hashicorp/vault + curl).
+# busybox tools only otherwise (sh, sed, grep, mv).
+#
+# Atomic-write pattern: writes to /rendered/.*.tmp first, validates PEM
+# markers, then `mv` into the shared volume. Under cap_drop: ALL the agent
+# (container root) can't overwrite a file in place but `mv` only needs write
+# permission on the target directory, which it has.
+set -eu
+
+BUNDLE=/rendered/nats-bundle.tmp
+CERTS_DIR=/certs
+NATS_CONTAINER="${NATS_CONTAINER:-ruby-core-dev-nats}"
+
+CERT_TMP=/rendered/.server-cert.pem.tmp
+CA_TMP=/rendered/.ca.pem.tmp
+KEY_TMP=/rendered/.server-key.pem.tmp
+
+if [ ! -s "$BUNDLE" ]; then
+  echo "post-render: bundle empty or missing — abort" >&2
+  exit 1
+fi
+
+# Split on ==CA== and ==KEY== separators.
+#   - Lines 1..==CA== (exclusive) → cert
+#   - Lines ==CA==..==KEY== (exclusive on both ends) → CA
+#   - Lines ==KEY==..end (exclusive) → key
+sed -n '1,/^==CA==$/p'           "$BUNDLE" | sed '/^==CA==$/d'                  > "$CERT_TMP"
+sed -n '/^==CA==$/,/^==KEY==$/p' "$BUNDLE" | sed -e '/^==CA==$/d' -e '/^==KEY==$/d' > "$CA_TMP"
+sed -n '/^==KEY==$/,$p'          "$BUNDLE" | sed '/^==KEY==$/d'                 > "$KEY_TMP"
+
+# Validate all three have the expected PEM markers. If anything is wrong,
+# abort BEFORE moving into the shared volume — NATS keeps using its last-good
+# cert and the Vault Agent retries on the next template tick.
+if ! grep -q 'BEGIN CERTIFICATE' "$CERT_TMP"; then
+  echo "post-render: $CERT_TMP missing BEGIN CERTIFICATE — abort" >&2
+  rm -f "$CERT_TMP" "$CA_TMP" "$KEY_TMP"
+  exit 1
+fi
+if ! grep -q 'BEGIN CERTIFICATE' "$CA_TMP"; then
+  echo "post-render: $CA_TMP missing BEGIN CERTIFICATE — abort" >&2
+  rm -f "$CERT_TMP" "$CA_TMP" "$KEY_TMP"
+  exit 1
+fi
+if ! grep -qE 'BEGIN .* PRIVATE KEY' "$KEY_TMP"; then
+  echo "post-render: $KEY_TMP missing BEGIN .* PRIVATE KEY — abort" >&2
+  rm -f "$CERT_TMP" "$CA_TMP" "$KEY_TMP"
+  exit 1
+fi
+
+# Mode 0644 — same as nats-init writes. Volume scope is bounded to this
+# sidecar + nats-init + NATS, so "world-readable" is just those three.
+chmod 0644 "$CERT_TMP" "$CA_TMP" "$KEY_TMP"
+
+mv "$CERT_TMP" "$CERTS_DIR/server-cert.pem"
+mv "$CA_TMP"   "$CERTS_DIR/ca.pem"
+mv "$KEY_TMP"  "$CERTS_DIR/server-key.pem"
+rm -f "$BUNDLE"
+
+# SIGHUP NATS via the Docker API. /kill (not /restart) with signal=SIGHUP
+# triggers NATS's config reload without dropping existing connections.
+# NATS validates the new cert during reload; if it's malformed it keeps the
+# old config (server/reload.go's validateOptions runs before Apply).
+HTTP_CODE=$(curl --silent --unix-socket /var/run/docker.sock \
+  -X POST --max-time 10 \
+  -o /dev/null -w '%{http_code}' \
+  "http://localhost/containers/${NATS_CONTAINER}/kill?signal=SIGHUP" || echo "000")
+
+case "$HTTP_CODE" in
+  204)
+    echo "post-render: cert+key+ca written to ${CERTS_DIR}; SIGHUP sent to ${NATS_CONTAINER}"
+    ;;
+  *)
+    echo "post-render: write OK but SIGHUP call returned HTTP $HTTP_CODE" >&2
+    exit 1
+    ;;
+esac

--- a/docs/adr/0030-direct-pki-issuance-no-sidecar.md
+++ b/docs/adr/0030-direct-pki-issuance-no-sidecar.md
@@ -43,8 +43,8 @@ Concrete requirements, all enforced in `pkg/boot/pki.go`:
 
 ### Positive Consequences
 
-* Zero new sidecar containers across dev/staging/prod.
-* No shared-volume plumbing, no UID/perm coordination, no restart orchestration.
+* Zero sidecars for the 5 Go services across dev/staging/prod (15 sidecars avoided). One sidecar remains for the NATS server cert — `nats-cert-renewer` — because NATS is a third-party process that reads certs from disk and provides none of the in-process semantics this ADR requires for the exemption. The two-pattern split is exactly what's intended: direct-PKI for Vault-native consumers, sidecar pattern (per foundation's ADR-0008) for filesystem consumers.
+* No shared-volume plumbing, no UID/perm coordination, no restart orchestration **for the Go services**. The NATS sidecar handles those concerns for the one process that does need them.
 * Cert lifecycle scoped to the process: a service that's running has a fresh cert; a service that's not is irrelevant.
 * Reuses the existing `boot` Vault client — no parallel infrastructure.
 * Reconnect handshakes pick up rotated certs without restart; no operator action ever required for routine rotation.

--- a/docs/ops/vault-dev.md
+++ b/docs/ops/vault-dev.md
@@ -100,11 +100,19 @@ and issues a cert directly from `pki_int/issue/ruby-core-<svc>`. An in-process
 goroutine renews at TTL/2. No mkcert dependency; no operator action for routine
 rotation.
 
+**NATS server cert is also auto-renewed** by the `nats-cert-renewer` sidecar
+(PLAN-0008 follow-up). It's a long-running Vault Agent that uses the same
+`foundation-agent-ruby-core-nats-server` AppRole, re-issues the server cert at
+TTL/2, writes cert/key/ca atomically into the shared `nats-certs` volume, and
+SIGHUPs NATS via the Docker API. NATS reloads its TLS config in-place (~40ms);
+existing mTLS connections are unaffected — only new TLS handshakes use the
+rotated cert. Config under `deploy/dev/vault-agent/`.
+
 The Vault-side state (AppRoles + PKI roles + scoped policies + role-id files on
 disk) is created by foundation's `make setup-pki-ruby-core-roles` +
 `make setup-foundation-agent-ruby-core-roles` (PLAN-0008 Stage 1, foundation
 PR #78). The compose file bind-mounts the resulting role-id + secret-id files
-into each ruby-core container.
+into each ruby-core container — including the `nats-cert-renewer` sidecar.
 
 **Rollback path (legacy mkcert KV bundle):** still callable when `VAULT_PKI_ROLE`
 is unset in compose. `make setup-creds` repopulates `secret/ruby-core/tls/*`


### PR DESCRIPTION
## Summary

Closes the renewal gap surfaced during PLAN-0008 Stage 2 verification (PR #53): the NATS *server* cert moved to PKI in that PR but had no auto-renewal — `nats-init` is a one-shot container that only runs at startup. With a 30-day TTL, operators would have had to remember to `docker restart nats` every ~25 days to re-trigger `nats-init`. This sidecar makes the NATS cert lifecycle hands-off, matching the in-process renewal already running on the 5 Go services.

## Pattern

Same as foundation's `vault-agent-freeradius` (PLAN-0007 / foundation PR #77): a long-running Vault Agent that AppRole-logs in, renders the cert+key+ca via a template, and signals the consumer. Adapted to NATS:

- Render three files (cert/key/ca) instead of two — template uses `==CA==` + `==KEY==` separators that `post-render.sh` splits on.
- Signal via Docker API `POST /containers/{id}/kill?signal=SIGHUP` (not `/restart`). NATS reloads its TLS config in-place; **existing mTLS connections survive** because TLS only validates the cert at handshake time, and the established TLS session has already handshook.
- **Zero new Vault state**: reuses `foundation-agent-ruby-core-nats-server` AppRole + on-disk role-id/secret-id created in foundation PR #78.

This is the sidecar half of the "two-pattern" approach recorded in [ADR-0030](docs/adr/0030-direct-pki-issuance-no-sidecar.md): the 5 Go services use direct-PKI because they speak Vault natively; the NATS server (third-party process that reads certs from disk) uses the sidecar pattern from foundation's ADR-0008. Two patterns for two consumer types — not a contradiction. ADR-0030's §Positive Consequences updated to spell this out explicitly.

## Pre-implementation SIGHUP spike

Before writing any code, confirmed NATS 2.10 reloads TLS on SIGHUP:
- Issued a fresh cert via Vault PKI, wrote into the `nats-certs` volume manually
- `docker kill --signal=HUP ruby-core-dev-nats`
- NATS logged `[INF] Reloaded: tls = enabled` + `[INF] Reloaded server configuration` within ~40ms
- All 5 existing mTLS connections kept their cids and uptimes
- Failure mode confirmed safe: `server/reload.go` runs `validateOptions` BEFORE `Apply`; malformed certs are rejected and the server keeps its previous config

## Validation drills — all PASS

| Drill | Result |
|---|---|
| **2.1** — Cold deploy + first render | Cert serial `5E12EB...` → `35306547...`; NATS reloaded; 5 conns intact with same cids |
| **2.2** — Forced rotation (`docker restart` renewer) | Serial `35306547...` → `21E939B6...`; `connz.total = 5` unchanged (zero client churn); ~24ms reload |
| **2.3** — Malformed cert failure mode | Replaced template with garbage; `post-render.sh` aborted on PEM-marker check; NATS got no SIGHUP; on-disk cert UNCHANGED; full recovery after template restore |
| **2.4** — Vault outage drill | Disconnected renewer from `vault-ruby-core-dev` network; renewer retried Vault auth (failing); NATS unaffected (5 conns stable, cert unchanged). Reconnected → AppRole login → fresh cert (`21B3A397...`) → SIGHUP delivered |

## Files

- `deploy/dev/vault-agent/config.hcl` (new) — Vault Agent config: AppRole auto-auth + one template stanza
- `deploy/dev/vault-agent/nats-server.tpl` (new) — cert+key+ca template with `==CA==`/`==KEY==` separators; SANs cover all three env hostnames so the same template ships unchanged to staging/prod
- `deploy/dev/vault-agent/post-render.sh` (new, executable) — splits the bundle, validates PEM markers, atomic-renames into `/certs/`, SIGHUPs NATS via Docker API. `NATS_CONTAINER` env var so staging/prod can reuse with different target names
- `deploy/dev/compose.dev.yaml` (modified) — adds the sidecar. `cap_drop: ALL`, `read_only: true`, `tmpfs: [/tmp]`, docker.sock with `# allow:docker.sock` annotation
- `.gitignore` (modified) — excludes `deploy/*/vault-agent/rendered/` (sidecar's temp staging area)
- `docs/adr/0030-direct-pki-issuance-no-sidecar.md` (amended) — §Positive Consequences corrected to acknowledge the one server-side sidecar
- `docs/ops/vault-dev.md` (amended) — TLS Certificates section now describes both renewal paths

## Foundation-side prerequisites (already merged)

- [foundation PR #78](https://github.com/rutabageldev/foundation/pull/78) — created the `foundation-agent-ruby-core-nats-server` AppRole + PKI role + scoped policy + role-id/secret-id files on disk. This sidecar reuses all of it; **zero new Vault state required.**

## Out of scope

- Staging + prod replication. Same pattern; ship as part of PLAN-0008 Stages 3 + 4. Only the `NATS_CONTAINER` env var differs across envs.
- 24h passive soak (Stage 2.5 from the plan). The explicit rotation drill (2.2) already proved the mechanism end-to-end; the soak is continued observation, not a gating criterion.

## Test plan

- [x] `docker compose -f deploy/dev/compose.dev.yaml config --quiet` clean
- [x] Cold deploy: sidecar starts, AppRole login, template render, post-render OK, NATS reloads
- [x] Forced rotation: cert serial changes, zero client churn
- [x] Malformed cert: post-render aborts, NATS untouched, full recovery
- [x] Vault outage: NATS unaffected, full recovery on reconnect
- [x] Pre-commit hooks pass (yamllint, gitleaks, shellcheck)

🤖 Generated with [Claude Code](https://claude.com/claude-code)