### PR TITLE
feat(deploy/staging): direct-PKI + nats-cert-renewer (PLAN-0008 Stage 3)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,13 @@ jobs:
         with:
           images: ${{ env.REGISTRY }}/${{ env.IMAGE_OWNER }}/ruby-core-${{ matrix.service }}
           tags: |
-            type=semver,pattern=v{{version}},value=${{ inputs.version || github.ref_name }}
+            # Always emit the raw ref/version as a tag — preserves the `v` prefix.
+            # The docker/metadata-action's `pattern=v{{version}}` quietly skips the
+            # v-prefix form for prereleases (rc/alpha/beta) because {{version}} is
+            # parsed via semver which strips the v; type=raw is the unambiguous form.
+            # Pulls in deploy/staging|prod/compose.*.yaml use ${VERSION} which is the
+            # raw ref_name, so this tag must always match.
+            type=raw,value=${{ inputs.version || github.ref_name }}
             type=semver,pattern={{version}},value=${{ inputs.version || github.ref_name }}
             type=semver,pattern={{major}}.{{minor}},value=${{ inputs.version || github.ref_name }}
             type=sha,prefix=

--- a/deploy/dev/vault-agent/post-render.sh
+++ b/deploy/dev/vault-agent/post-render.sh
@@ -93,7 +93,7 @@ HTTP_CODE=$(curl --silent --unix-socket /var/run/docker.sock \
 
 case "$HTTP_CODE" in
   204)
-    echo "post-render: cert+key+ca written to ${CERTS_DIR}; SIGHUP sent to ${NATS_CONTAINER}"
+    echo "post-render: cert+key written to ${CERTS_DIR} (ca.pem preserved from nats-init); SIGHUP sent to ${NATS_CONTAINER}"
     ;;
   *)
     echo "post-render: write OK but SIGHUP call returned HTTP $HTTP_CODE" >&2

--- a/deploy/dev/vault-agent/post-render.sh
+++ b/deploy/dev/vault-agent/post-render.sh
@@ -61,8 +61,25 @@ fi
 chmod 0644 "$CERT_TMP" "$CA_TMP" "$KEY_TMP"
 
 mv "$CERT_TMP" "$CERTS_DIR/server-cert.pem"
-mv "$CA_TMP"   "$CERTS_DIR/ca.pem"
 mv "$KEY_TMP"  "$CERTS_DIR/server-key.pem"
+
+# ─────────────────────────────────────────────────────────────────────────
+# TRANSITIONAL: deliberately DO NOT overwrite ca.pem on rotation.
+# nats-init writes a BUNDLED ca.pem (pki_int issuing_ca + legacy mkcert CA)
+# at startup; overwriting here with PKI-only would drop the mkcert anchor
+# and break the admin smoke path. The renewer's AppRole has no KV read
+# capability so it cannot reproduce the bundle on its own — letting
+# nats-init's bundle persist is the simpler, correct behavior.
+#
+# Both CAs are stable for years (RubyNet Intermediate, mkcert root), so a
+# static ca.pem across cert rotations is fine. The renewer just rotates
+# cert+key.
+#
+# *** REMOVE the discard-CA behavior in PLAN-0008 Stage 4 ***
+# Once admin migrates to PKI in Stage 4, the bundle becomes unnecessary and
+# this script can resume writing ca.pem with just the PKI issuing_ca.
+# ─────────────────────────────────────────────────────────────────────────
+rm -f "$CA_TMP"
 rm -f "$BUNDLE"
 
 # SIGHUP NATS via the Docker API. /kill (not /restart) with signal=SIGHUP

--- a/deploy/staging/compose.staging.yaml
+++ b/deploy/staging/compose.staging.yaml
@@ -31,13 +31,20 @@ services:
       - nats-certs:/certs
       - ../../scripts/fetch-nats-certs.sh:/scripts/fetch-nats-certs.sh:ro
       - /opt/foundation/vault/tls/vault-ca.crt:/vault/tls/vault-ca.crt:ro
+      # AppRole material for direct-PKI cert issuance (PLAN-0008).
+      - /opt/foundation/vault/role-id-foundation-agent-ruby-core-nats-server:/vault/role-id:ro
+      - /opt/foundation/vault/.secret-id-foundation-agent-ruby-core-nats-server:/vault/secret-id:ro
     environment:
       - VAULT_ADDR=https://vault:8200
       - VAULT_CACERT=/vault/tls/vault-ca.crt
       - VAULT_TOKEN=${VAULT_TOKEN}
-      # Staging Vault paths (override fetch-nats-certs.sh defaults)
-      - TLS_PATH=secret/ruby-core/staging/tls/nats-server
+      # Direct-PKI path (PLAN-0008): switches fetch-nats-certs.sh to AppRole +
+      # pki_int/issue/ruby-core-nats-server. NKEY base stays on legacy KV path
+      # (NKEY migration is out of scope; admin/navi externals still on KV).
+      - VAULT_PKI_ROLE=ruby-core-nats-server
       - NKEY_BASE=secret/ruby-core/staging/nats
+      # Legacy KV path retained as rollback target (unused when VAULT_PKI_ROLE is set).
+      - TLS_PATH=secret/ruby-core/staging/tls/nats-server
     networks:
       - vault-ruby-core-staging
 
@@ -70,6 +77,48 @@ services:
       start_period: 10s
 
   # ==========================================================================
+  # NATS Cert Renewer (long-running sidecar — PLAN-0008 Stage 3)
+  # ==========================================================================
+  # Vault Agent that re-issues the NATS server cert at TTL/2 and SIGHUPs the
+  # NATS container to reload TLS without dropping client connections. Mirrors
+  # deploy/dev/compose.dev.yaml's nats-cert-renewer; only NATS_CONTAINER differs.
+  #
+  # See deploy/staging/vault-agent/ for config + template + post-render script.
+  # Auth via foundation-agent-ruby-core-nats-server AppRole (foundation PR #78);
+  # zero new Vault state required.
+  nats-cert-renewer:
+    image: foundation/vault-agent:1.21.4
+    container_name: ruby-core-staging-nats-cert-renewer
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
+    depends_on:
+      nats:
+        condition: service_healthy
+    command:
+      - sh
+      - -c
+      - vault agent -config=/etc/vault-agent/config.hcl
+    environment:
+      - NATS_CONTAINER=ruby-core-staging-nats
+    volumes:
+      - nats-certs:/certs
+      - ./vault-agent/config.hcl:/etc/vault-agent/config.hcl:ro
+      - ./vault-agent/nats-server.tpl:/etc/vault-agent/nats-server.tpl:ro
+      - ./vault-agent/post-render.sh:/etc/vault-agent/post-render.sh:ro
+      - /opt/foundation/vault/role-id-foundation-agent-ruby-core-nats-server:/vault/role-id:ro
+      - /opt/foundation/vault/.secret-id-foundation-agent-ruby-core-nats-server:/vault/secret-id:ro
+      - /opt/foundation/vault/tls/vault-ca.crt:/vault/tls/vault-ca.crt:ro
+      - ./vault-agent/rendered:/rendered
+      - /var/run/docker.sock:/var/run/docker.sock  # allow:docker.sock -- nats-cert-renewer SIGHUP hook (PLAN-0008 Stage 3)
+    networks:
+      - default
+      - vault-ruby-core-staging
+    cap_drop:
+      - ALL
+
+  # ==========================================================================
   # Gateway Service (Staging)
   # ==========================================================================
   gateway:
@@ -89,6 +138,9 @@ services:
         condition: service_healthy
     volumes:
       - /opt/foundation/vault/tls/vault-ca.crt:/vault/tls/vault-ca.crt:ro
+      # AppRole material for direct-PKI client cert (PLAN-0008).
+      - /opt/foundation/vault/role-id-foundation-agent-ruby-core-gateway:/vault/role-id:ro
+      - /opt/foundation/vault/.secret-id-foundation-agent-ruby-core-gateway:/vault/secret-id:ro
     environment:
       - ENVIRONMENT=production
       - VAULT_ADDR=https://vault:8200
@@ -98,6 +150,7 @@ services:
       - NATS_REQUIRE_MTLS=true
       - VAULT_NKEY_PATH=secret/data/ruby-core/staging/nats/gateway
       - VAULT_TLS_PATH=secret/data/ruby-core/staging/tls/gateway
+      - VAULT_PKI_ROLE=ruby-core-gateway
       - HTTP_ADDR=:8080
     # No Traefik labels — staging gateway is not publicly routed
 
@@ -122,6 +175,9 @@ services:
         condition: service_healthy
     volumes:
       - /opt/foundation/vault/tls/vault-ca.crt:/vault/tls/vault-ca.crt:ro
+      # AppRole material for direct-PKI client cert (PLAN-0008).
+      - /opt/foundation/vault/role-id-foundation-agent-ruby-core-engine:/vault/role-id:ro
+      - /opt/foundation/vault/.secret-id-foundation-agent-ruby-core-engine:/vault/secret-id:ro
     environment:
       - ENVIRONMENT=production
       - VAULT_ADDR=https://vault:8200
@@ -131,6 +187,7 @@ services:
       - NATS_REQUIRE_MTLS=true
       - VAULT_NKEY_PATH=secret/data/ruby-core/staging/nats/engine
       - VAULT_TLS_PATH=secret/data/ruby-core/staging/tls/engine
+      - VAULT_PKI_ROLE=ruby-core-engine
       - VAULT_PG_PATH=secret/data/ruby-core/staging/postgres
       - VAULT_HA_PATH=secret/data/ruby-core/ha
       - RULES_DIR=/etc/ruby-core/rules
@@ -156,6 +213,9 @@ services:
         condition: service_healthy
     volumes:
       - /opt/foundation/vault/tls/vault-ca.crt:/vault/tls/vault-ca.crt:ro
+      # AppRole material for direct-PKI client cert (PLAN-0008).
+      - /opt/foundation/vault/role-id-foundation-agent-ruby-core-notifier:/vault/role-id:ro
+      - /opt/foundation/vault/.secret-id-foundation-agent-ruby-core-notifier:/vault/secret-id:ro
     environment:
       - ENVIRONMENT=production
       - VAULT_ADDR=https://vault:8200
@@ -165,6 +225,7 @@ services:
       - NATS_REQUIRE_MTLS=true
       - VAULT_NKEY_PATH=secret/data/ruby-core/staging/nats/notifier
       - VAULT_TLS_PATH=secret/data/ruby-core/staging/tls/notifier
+      - VAULT_PKI_ROLE=ruby-core-notifier
       # Uses prod HA credentials — staging smoke test sends a real push notification
       - VAULT_HA_PATH=secret/data/ruby-core/ha
 
@@ -188,6 +249,9 @@ services:
         condition: service_healthy
     volumes:
       - /opt/foundation/vault/tls/vault-ca.crt:/vault/tls/vault-ca.crt:ro
+      # AppRole material for direct-PKI client cert (PLAN-0008).
+      - /opt/foundation/vault/role-id-foundation-agent-ruby-core-presence:/vault/role-id:ro
+      - /opt/foundation/vault/.secret-id-foundation-agent-ruby-core-presence:/vault/secret-id:ro
     environment:
       - ENVIRONMENT=production
       - VAULT_ADDR=https://vault:8200
@@ -197,6 +261,7 @@ services:
       - NATS_REQUIRE_MTLS=true
       - VAULT_NKEY_PATH=secret/data/ruby-core/staging/nats/presence
       - VAULT_TLS_PATH=secret/data/ruby-core/staging/tls/presence
+      - VAULT_PKI_ROLE=ruby-core-presence
       - VAULT_HA_PATH=secret/data/ruby-core/ha
       - PRESENCE_PERSON_ID=katie
       - PRESENCE_PHONE_ENTITY=phone.katie
@@ -230,11 +295,15 @@ services:
       - NATS_REQUIRE_MTLS=true
       - VAULT_NKEY_PATH=secret/data/ruby-core/staging/nats/audit-sink
       - VAULT_TLS_PATH=secret/data/ruby-core/staging/tls/audit-sink
+      - VAULT_PKI_ROLE=ruby-core-audit-sink
       - AUDIT_DATA_DIR=/data/audit
     volumes:
       # Staging audit: named volume (ephemeral; removed on `down -v`)
       - staging-audit-data:/data/audit
       - /opt/foundation/vault/tls/vault-ca.crt:/vault/tls/vault-ca.crt:ro
+      # AppRole material for direct-PKI client cert (PLAN-0008).
+      - /opt/foundation/vault/role-id-foundation-agent-ruby-core-audit-sink:/vault/role-id:ro
+      - /opt/foundation/vault/.secret-id-foundation-agent-ruby-core-audit-sink:/vault/secret-id:ro
 
 # ==========================================================================
 # Networks

--- a/deploy/staging/compose.staging.yaml
+++ b/deploy/staging/compose.staging.yaml
@@ -88,6 +88,12 @@ services:
   # zero new Vault state required.
   nats-cert-renewer:
     image: foundation/vault-agent:1.21.4
+    # Local-only image (built via foundation's `make build-vault-agent-image`,
+    # never pushed to a registry per the Dockerfile comment in /opt/foundation/
+    # vault-agent/Dockerfile). pull_policy: never skips it during compose pull
+    # and uses the host's local image on up -d. The self-hosted GH runner IS
+    # this host, so the image is reliably present.
+    pull_policy: never
     container_name: ruby-core-staging-nats-cert-renewer
     restart: unless-stopped
     read_only: true

--- a/deploy/staging/vault-agent/config.hcl
+++ b/deploy/staging/vault-agent/config.hcl
@@ -1,0 +1,50 @@
+# Vault Agent — NATS server cert auto-renewer (PLAN-0008 follow-up)
+#
+# Authenticates via the foundation-agent-ruby-core-nats-server AppRole
+# (created in foundation PR #78) and renders the NATS server cert + key + CA
+# from a single pki_int/issue/ruby-core-nats-server call. The post-render
+# script atomic-writes the three files into the shared `nats-certs` volume
+# and SIGHUPs NATS via the Docker API. NATS reloads its TLS config in-place
+# (~40ms); existing mTLS connections survive (only new handshakes use the
+# rotated cert).
+#
+# Renewal cadence: Vault Agent's template engine refreshes at TTL/2 — same
+# cadence as the in-process renewal goroutine on the 5 Go services (24h-ish
+# with the default lease behavior).
+#
+# Image: foundation/vault-agent:1.21.4 — hashicorp/vault + curl baked in for
+# the Docker API SIGHUP call (foundation drift #75 / PLAN-0007).
+
+pid_file = "/tmp/vault-agent.pid"
+
+vault {
+  address = "https://vault:8200"
+  ca_cert = "/vault/tls/vault-ca.crt"
+}
+
+auto_auth {
+  method "approle" {
+    config = {
+      role_id_file_path                   = "/vault/role-id"
+      secret_id_file_path                 = "/vault/secret-id"
+      remove_secret_id_file_after_reading = false
+    }
+  }
+
+  sink "file" {
+    config = {
+      path = "/tmp/.vault-agent-token"
+    }
+  }
+}
+
+# Single template stanza — NATS needs cert+key+ca, all three from one
+# issuance (so the chain matches). Template emits them with ==CA== and
+# ==KEY== separators; post-render.sh splits, atomic-renames into /certs/,
+# and signals NATS.
+template {
+  source      = "/etc/vault-agent/nats-server.tpl"
+  destination = "/rendered/nats-bundle.tmp"
+  perms       = "0644"
+  command     = ["/etc/vault-agent/post-render.sh"]
+}

--- a/deploy/staging/vault-agent/nats-server.tpl
+++ b/deploy/staging/vault-agent/nats-server.tpl
@@ -1,0 +1,6 @@
+{{ with secret "pki_int/issue/ruby-core-nats-server" "common_name=nats" "ip_sans=127.0.0.1" "alt_names=ruby-core-dev-nats,ruby-core-staging-nats,ruby-core-prod-nats,localhost" "ttl=720h" }}{{ .Data.certificate }}
+==CA==
+{{ .Data.issuing_ca }}
+==KEY==
+{{ .Data.private_key }}
+{{ end }}

--- a/deploy/staging/vault-agent/post-render.sh
+++ b/deploy/staging/vault-agent/post-render.sh
@@ -93,7 +93,7 @@ HTTP_CODE=$(curl --silent --unix-socket /var/run/docker.sock \
 
 case "$HTTP_CODE" in
   204)
-    echo "post-render: cert+key+ca written to ${CERTS_DIR}; SIGHUP sent to ${NATS_CONTAINER}"
+    echo "post-render: cert+key written to ${CERTS_DIR} (ca.pem preserved from nats-init); SIGHUP sent to ${NATS_CONTAINER}"
     ;;
   *)
     echo "post-render: write OK but SIGHUP call returned HTTP $HTTP_CODE" >&2

--- a/deploy/staging/vault-agent/post-render.sh
+++ b/deploy/staging/vault-agent/post-render.sh
@@ -1,0 +1,85 @@
+#!/bin/sh
+# Vault Agent post-render hook for the NATS server cert bundle.
+#
+# Splits /rendered/nats-bundle.tmp (cert + ==CA== + ca + ==KEY== + key) into
+# the three files NATS reads from its shared `nats-certs` volume, then sends
+# SIGHUP to the NATS container via the Docker API. NATS reloads its TLS
+# config in-place (~40ms); existing mTLS connections survive — only new
+# TLS handshakes use the rotated cert.
+#
+# Runs inside the foundation/vault-agent:1.21.4 image (hashicorp/vault + curl).
+# busybox tools only otherwise (sh, sed, grep, mv).
+#
+# Atomic-write pattern: writes to /rendered/.*.tmp first, validates PEM
+# markers, then `mv` into the shared volume. Under cap_drop: ALL the agent
+# (container root) can't overwrite a file in place but `mv` only needs write
+# permission on the target directory, which it has.
+set -eu
+
+BUNDLE=/rendered/nats-bundle.tmp
+CERTS_DIR=/certs
+NATS_CONTAINER="${NATS_CONTAINER:-ruby-core-dev-nats}"
+
+CERT_TMP=/rendered/.server-cert.pem.tmp
+CA_TMP=/rendered/.ca.pem.tmp
+KEY_TMP=/rendered/.server-key.pem.tmp
+
+if [ ! -s "$BUNDLE" ]; then
+  echo "post-render: bundle empty or missing — abort" >&2
+  exit 1
+fi
+
+# Split on ==CA== and ==KEY== separators.
+#   - Lines 1..==CA== (exclusive) → cert
+#   - Lines ==CA==..==KEY== (exclusive on both ends) → CA
+#   - Lines ==KEY==..end (exclusive) → key
+sed -n '1,/^==CA==$/p'           "$BUNDLE" | sed '/^==CA==$/d'                  > "$CERT_TMP"
+sed -n '/^==CA==$/,/^==KEY==$/p' "$BUNDLE" | sed -e '/^==CA==$/d' -e '/^==KEY==$/d' > "$CA_TMP"
+sed -n '/^==KEY==$/,$p'          "$BUNDLE" | sed '/^==KEY==$/d'                 > "$KEY_TMP"
+
+# Validate all three have the expected PEM markers. If anything is wrong,
+# abort BEFORE moving into the shared volume — NATS keeps using its last-good
+# cert and the Vault Agent retries on the next template tick.
+if ! grep -q 'BEGIN CERTIFICATE' "$CERT_TMP"; then
+  echo "post-render: $CERT_TMP missing BEGIN CERTIFICATE — abort" >&2
+  rm -f "$CERT_TMP" "$CA_TMP" "$KEY_TMP"
+  exit 1
+fi
+if ! grep -q 'BEGIN CERTIFICATE' "$CA_TMP"; then
+  echo "post-render: $CA_TMP missing BEGIN CERTIFICATE — abort" >&2
+  rm -f "$CERT_TMP" "$CA_TMP" "$KEY_TMP"
+  exit 1
+fi
+if ! grep -qE 'BEGIN .* PRIVATE KEY' "$KEY_TMP"; then
+  echo "post-render: $KEY_TMP missing BEGIN .* PRIVATE KEY — abort" >&2
+  rm -f "$CERT_TMP" "$CA_TMP" "$KEY_TMP"
+  exit 1
+fi
+
+# Mode 0644 — same as nats-init writes. Volume scope is bounded to this
+# sidecar + nats-init + NATS, so "world-readable" is just those three.
+chmod 0644 "$CERT_TMP" "$CA_TMP" "$KEY_TMP"
+
+mv "$CERT_TMP" "$CERTS_DIR/server-cert.pem"
+mv "$CA_TMP"   "$CERTS_DIR/ca.pem"
+mv "$KEY_TMP"  "$CERTS_DIR/server-key.pem"
+rm -f "$BUNDLE"
+
+# SIGHUP NATS via the Docker API. /kill (not /restart) with signal=SIGHUP
+# triggers NATS's config reload without dropping existing connections.
+# NATS validates the new cert during reload; if it's malformed it keeps the
+# old config (server/reload.go's validateOptions runs before Apply).
+HTTP_CODE=$(curl --silent --unix-socket /var/run/docker.sock \
+  -X POST --max-time 10 \
+  -o /dev/null -w '%{http_code}' \
+  "http://localhost/containers/${NATS_CONTAINER}/kill?signal=SIGHUP" || echo "000")
+
+case "$HTTP_CODE" in
+  204)
+    echo "post-render: cert+key+ca written to ${CERTS_DIR}; SIGHUP sent to ${NATS_CONTAINER}"
+    ;;
+  *)
+    echo "post-render: write OK but SIGHUP call returned HTTP $HTTP_CODE" >&2
+    exit 1
+    ;;
+esac

--- a/deploy/staging/vault-agent/post-render.sh
+++ b/deploy/staging/vault-agent/post-render.sh
@@ -61,8 +61,25 @@ fi
 chmod 0644 "$CERT_TMP" "$CA_TMP" "$KEY_TMP"
 
 mv "$CERT_TMP" "$CERTS_DIR/server-cert.pem"
-mv "$CA_TMP"   "$CERTS_DIR/ca.pem"
 mv "$KEY_TMP"  "$CERTS_DIR/server-key.pem"
+
+# ─────────────────────────────────────────────────────────────────────────
+# TRANSITIONAL: deliberately DO NOT overwrite ca.pem on rotation.
+# nats-init writes a BUNDLED ca.pem (pki_int issuing_ca + legacy mkcert CA)
+# at startup; overwriting here with PKI-only would drop the mkcert anchor
+# and break the admin smoke path. The renewer's AppRole has no KV read
+# capability so it cannot reproduce the bundle on its own — letting
+# nats-init's bundle persist is the simpler, correct behavior.
+#
+# Both CAs are stable for years (RubyNet Intermediate, mkcert root), so a
+# static ca.pem across cert rotations is fine. The renewer just rotates
+# cert+key.
+#
+# *** REMOVE the discard-CA behavior in PLAN-0008 Stage 4 ***
+# Once admin migrates to PKI in Stage 4, the bundle becomes unnecessary and
+# this script can resume writing ca.pem with just the PKI issuing_ca.
+# ─────────────────────────────────────────────────────────────────────────
+rm -f "$CA_TMP"
 rm -f "$BUNDLE"
 
 # SIGHUP NATS via the Docker API. /kill (not /restart) with signal=SIGHUP

--- a/docs/ops/vault-dev.md
+++ b/docs/ops/vault-dev.md
@@ -114,6 +114,16 @@ disk) is created by foundation's `make setup-pki-ruby-core-roles` +
 PR #78). The compose file bind-mounts the resulting role-id + secret-id files
 into each ruby-core container — including the `nats-cert-renewer` sidecar.
 
+**Staging** uses the same flow (PLAN-0008 Stage 3; `deploy/staging/vault-agent/`)
+with a transitional difference: NATS's `ca.pem` is bundled with both the
+`pki_int` intermediate CA **and** the legacy mkcert root CA. This is purely so
+the smoke test (which still uses `admin`'s mkcert-signed cert from the legacy
+KV path) can complete its mTLS handshake. The 5 services + NATS server cert are
+100% pki_int-signed — the mkcert anchor is an additive trust anchor for the one
+out-of-scope principal (admin). Stage 4 (prod migration) folds in admin's
+migration to PKI and removes the bundle entirely; each transitional block in
+the affected files carries an explicit `REMOVE in Stage 4` marker.
+
 **Rollback path (legacy mkcert KV bundle):** still callable when `VAULT_PKI_ROLE`
 is unset in compose. `make setup-creds` repopulates `secret/ruby-core/tls/*`
 from mkcert. Retained as the durable rollback target until Phase 17.7.

--- a/scripts/fetch-nats-certs.sh
+++ b/scripts/fetch-nats-certs.sh
@@ -123,6 +123,32 @@ if [ -n "${PKI_ROLE}" ]; then
     jq -r '.data.private_key' "${TMP_DIR}/issue-resp.json" > "${TMP_DIR}/server-key.pem"
     jq -r '.data.issuing_ca'  "${TMP_DIR}/issue-resp.json" > "${TMP_DIR}/ca.pem"
     rm -f "${TMP_DIR}/issue-resp.json"
+
+    # ───────────────────────────────────────────────────────────────────────
+    # TRANSITIONAL: bundle the legacy mkcert CA into ca.pem so admin
+    # (still mkcert-signed via KV) can pass mTLS during the staged rollout.
+    # Without this, NATS would only trust pki_int-signed clients, breaking
+    # the smoke test (which uses admin) until admin migrates to PKI.
+    #
+    # The 5 service certs (gateway/engine/notifier/presence/audit-sink) AND
+    # the NATS server cert remain pki_int-signed; the mkcert CA here is an
+    # ADDITIVE trust anchor purely so the admin smoke path keeps working.
+    # Service-to-service traffic does not depend on the mkcert anchor.
+    #
+    # *** REMOVE in PLAN-0008 Stage 4 (prod migration) ***
+    # Stage 4 migrates admin to PKI; once admin's smoke path is PKI-signed,
+    # NATS no longer needs the mkcert anchor and this block becomes dead
+    # weight. Delete from line 127 to the matching marker below.
+    # ───────────────────────────────────────────────────────────────────────
+    if vault kv get "${TLS_PATH}" >/dev/null 2>&1; then
+        echo "[nats-init] bundling legacy mkcert CA from ${TLS_PATH} (transitional — remove in Stage 4)"
+        printf '\n' >> "${TMP_DIR}/ca.pem"
+        vault kv get -field=ca "${TLS_PATH}" >> "${TMP_DIR}/ca.pem"
+    else
+        echo "[nats-init] WARNING: legacy KV bundle at ${TLS_PATH} not found; admin smoke will fail"
+        echo "[nats-init] (this is benign once Stage 4 migrates admin to PKI)"
+    fi
+    # *** END TRANSITIONAL BLOCK — REMOVE in Stage 4 ***
 else
     # ── Path 2: legacy KV bundle (rollback target) ────────────────────────
     echo "[nats-init] Fetching NATS server certificates from Vault (${TLS_PATH})..."

--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -57,6 +57,25 @@ _vault kv get -field=key  "${VAULT_SECRET_PREFIX}/tls/admin" > "$TMPDIR/client.k
 _vault kv get -field=ca   "${VAULT_SECRET_PREFIX}/tls/admin" > "$TMPDIR/ca.crt"
 chmod 600 "$TMPDIR/client.key"
 
+# ─────────────────────────────────────────────────────────────────────────
+# TRANSITIONAL: append the pki_int intermediate CA to the trust bundle so
+# the smoke test can verify NATS's PKI-signed server cert. Admin's client
+# cert is still mkcert-signed; both anchors coexist until Stage 4 of
+# PLAN-0008 migrates admin to PKI too.
+#
+# Without this, the smoke test fails with:
+#   "tls: failed to verify certificate: x509: certificate signed by
+#    unknown authority"
+# because admin's mkcert CA bundle alone can't verify NATS's pki_int-signed
+# server cert.
+#
+# *** REMOVE in PLAN-0008 Stage 4 ***
+# When admin migrates to PKI, fetch admin's cert/key from pki_int/issue
+# and drop both this bundling and the legacy KV reads above.
+# ─────────────────────────────────────────────────────────────────────────
+printf '\n' >> "$TMPDIR/ca.crt"
+_vault read -field=certificate pki_int/cert/ca >> "$TMPDIR/ca.crt"
+
 # Millisecond-unique smoke ID so grep matches only this run's audit event.
 SMOKE_ID="smoke-$(date +%s%3N)"
 


### PR DESCRIPTION
## Summary

**Stage 3 of foundation's PLAN-0008.** Migrates ruby-core staging to the same direct-PKI flow already running in dev (PRs #53 + #55, soaked for ~36h+ with zero PKI errors). The 5 Go services + the NATS server cert all move from legacy mkcert KV bundles to `pki_int/issue/ruby-core-*`. The PKI/AppRole/sidecar pattern ports cleanly — no architectural change.

**Pinned RC tag for staging soak: `v0.13.0-rc4`.** The workflow auto-deploys to staging on `v*` tag push and is gated against prod for `*-rc*` tags (existing guard at `release.yml`). After staging soak, `v0.13.0` final cuts via release-please for prod.

## What changes

### Sidecar config (new — `deploy/staging/vault-agent/`)
- `config.hcl`, `nats-server.tpl`, `post-render.sh` — verbatim copies from `deploy/dev/vault-agent/`. Files are env-agnostic; only `NATS_CONTAINER` override (set via compose env var) differs across envs.

### `deploy/staging/compose.staging.yaml`
- `nats-init`: AppRole role-id + secret-id mounts; `VAULT_PKI_ROLE=ruby-core-nats-server` switches `fetch-nats-certs.sh` to the direct-PKI branch
- `nats-cert-renewer` (new service): long-running Vault Agent sidecar, port of dev's. `NATS_CONTAINER=ruby-core-staging-nats`; `pull_policy: never` (foundation/vault-agent is local-only). `cap_drop: ALL`, `read_only`, docker.sock with `allow:docker.sock` annotation
- Per-service (gateway/engine/notifier/presence/audit-sink): role-id + secret-id mounts + `VAULT_PKI_ROLE=ruby-core-<svc>` env var. `VAULT_TLS_PATH` + `VAULT_TOKEN` retained for rollback

### Vault state
**Zero new state.** The `foundation-agent-ruby-core-<svc>` AppRoles + `pki_int/roles/ruby-core-<svc>` were created in foundation PR #78 and are env-agnostic (allowed_domains already covers staging hostnames).

## Iteration log (rc1 → rc4)

Three operational bugs surfaced during rc cuts; each was scoped, fixed, and recommitted on the same branch:

| RC | Failure | Fix |
|---|---|---|
| **rc1** | `compose pull` failed on `foundation/vault-agent:1.21.4` — local-only image | `c488686` — `pull_policy: never` on the sidecar |
| **rc2** | GHCR pulled `manifest unknown` for `:v0.13.0-rc2` (only `:0.13.0-rc2` existed) | `b8ebb7e` — `release.yml`: add `type=raw,value=ref_name` tag; docker/metadata-action's `pattern=v{{version}}` quietly omits the v-prefix form for prereleases |
| **rc3** | Smoke test failed: `tls: failed to verify certificate: x509: certificate signed by unknown authority` | `7ad23d2` — bundle the legacy mkcert CA into NATS `ca.pem` + smoke test `--tlsca`; admin (out of scope) still uses mkcert |
| **rc4** | ✅ All 5 builds + staging deploy + smoke PASS | — |

Two cosmetic commits closed out: `eb5afef` (echo string accuracy) and `fbe9197` (vault-dev runbook).

## Transitional bundle (`fix(pki)` commit `7ad23d2`) — **MUST be removed in Stage 4**

The smoke test path (`scripts/smoke-test.sh` via `deploy-staging.sh`) uses `admin`'s mkcert-signed cert from the legacy KV path. That cert can't validate against a pure pki_int NATS, and pure mkcert can't verify NATS's pki_int server cert. Two fixes:

1. **NATS `ca.pem` bundle:** `fetch-nats-certs.sh` appends the legacy KV CA to the PKI issuing_ca when in direct-PKI mode. NATS accepts client certs signed by either anchor.
2. **Smoke-test `--tlsca` bundle:** `smoke-test.sh` appends `pki_int/cert/ca` to admin's KV CA. Smoke can verify NATS's PKI-signed server cert.
3. **Renewer skips `ca.pem` writes:** `post-render.sh` (dev + staging) leaves `nats-init`'s bundled `ca.pem` alone on rotation. Renewer's AppRole has no KV access; static `ca.pem` is correct (both CAs are stable for years).

Each transitional block carries an explicit `*** REMOVE in PLAN-0008 Stage 4 ***` marker. Stage 4 migrates admin to PKI everywhere and reverts these three changes.

## Why this doesn't undercut PKI confidence

The mkcert anchor is ADDITIVE, not a fallback. **Drill #4 of the validation suite proved this empirically**: stripped the mkcert cert from `ca.pem` (leaving only the pki_int CA), SIGHUP'd NATS, observed all 5 services stay connected with the same cids, then forced a gateway reconnect → fresh PKI mTLS handshake succeeded under PKI-only. The mkcert anchor exists purely so the admin smoke path keeps working until Stage 4.

## Live verification (rc4 against staging)

All 5 drills PASS. Capture commands + results in the [Stage 2 thread/notes].

| Drill | Result |
|---|---|
| **2.1** — State verification | NATS cert from RubyNet Intermediate CA (serial `5C14CB...`); ca.pem has 2 anchors; 5/5 conns; all services PKI-issued |
| **2.3** — Forced rotation | Cert serial rotated `5C14CB...→36FCCC...`; bundle preserved; zero client churn; ~25ms NATS reload |
| **2.4** — Malformed cert | Garbage template → post-render aborted → NATS untouched → recovery on restore |
| **2.5** — Vault outage | NATS unaffected during outage → full recovery on reconnect |
| **2.6** — PKI-only drill | Stripped mkcert anchor → 5 services kept their connections → gateway reconnect under PKI-only succeeded |

## Drift observations (for tracking)

1. **`release.yml` raw-tag fix** is scope creep but necessary — would have broken any future release-please prerelease. Independently useful fix; flagged in commit message.
2. **`pull_policy: never` pattern for local-only `foundation/vault-agent` image** needs to be added to `deploy/prod/compose.prod.yaml` in Stage 4. Same pull pattern as staging via `deploy-prod.sh`.
3. **Foundation/vault-agent image is local-only** by design (per its Dockerfile comment). Consider whether to push to GHCR for cross-host portability. Out of scope for this PR.

## Foundation-side prerequisites (already merged)

- [foundation PR #78](https://github.com/rutabageldev/foundation/pull/78) — AppRoles + pki_int roles + scoped policies + role-id/secret-id files

## Out of scope

- **Stage 4 (prod migration)** — separate PR after staging soak passes
- **Admin migration to PKI** — folded into Stage 4
- **Phase 17.7 cleanup** — remove `setup-creds` mkcert generation; deprecate `secret/ruby-core/staging/tls/*` KV bundles; remove the transitional bundle code (revert paths from this PR)

## Test plan

- [x] `docker compose -f deploy/staging/compose.staging.yaml config --quiet` clean
- [x] `gh release create v0.13.0-rc4` → workflow: 5 image builds + staging deploy + smoke test all PASS
- [x] Manual: all 5 services on PKI; NATS server cert from RubyNet Intermediate CA
- [x] Drill 2.3 forced rotation
- [x] Drill 2.4 malformed cert
- [x] Drill 2.5 Vault outage
- [x] Drill 2.6 PKI-only proof
- [x] Pre-commit hooks pass on all 6 commits

🤖 Generated with [Claude Code](https://claude.com/claude-code)