### PR TITLE
feat(deploy/prod): direct-PKI + nats-cert-renewer (PLAN-0008 Stage 4.A)

### DIFF
--- a/deploy/prod/compose.prod.yaml
+++ b/deploy/prod/compose.prod.yaml
@@ -20,10 +20,17 @@ services:
       - nats-certs:/certs
       - ../../scripts/fetch-nats-certs.sh:/scripts/fetch-nats-certs.sh:ro
       - /opt/foundation/vault/tls/vault-ca.crt:/vault/tls/vault-ca.crt:ro
+      # AppRole material for direct-PKI cert issuance (PLAN-0008 Stage 4).
+      - /opt/foundation/vault/role-id-foundation-agent-ruby-core-nats-server:/vault/role-id:ro
+      - /opt/foundation/vault/.secret-id-foundation-agent-ruby-core-nats-server:/vault/secret-id:ro
     environment:
       - VAULT_ADDR=https://vault:8200
       - VAULT_CACERT=/vault/tls/vault-ca.crt
       - VAULT_TOKEN=${VAULT_TOKEN}
+      # Direct-PKI path (PLAN-0008 Stage 4): switches fetch-nats-certs.sh to AppRole +
+      # pki_int/issue/ruby-core-nats-server. NKEY base stays on legacy KV path
+      # (NKEY migration is out of scope; admin/navi externals still on KV).
+      - VAULT_PKI_ROLE=ruby-core-nats-server
     networks:
       - vault-ruby-core-prod
 
@@ -66,6 +73,53 @@ services:
   # must be running before starting services.
 
   # ==========================================================================
+  # NATS Cert Renewer (long-running sidecar — PLAN-0008 Stage 4)
+  # ==========================================================================
+  # Vault Agent that re-issues the NATS server cert at TTL/2 and SIGHUPs the
+  # NATS container to reload TLS without dropping client connections.
+  # Identical pattern to staging (PR #57); only NATS_CONTAINER differs.
+  #
+  # See deploy/prod/vault-agent/ for config + template + post-render script.
+  # Auth via foundation-agent-ruby-core-nats-server AppRole (foundation PR #78);
+  # zero new Vault state required.
+  nats-cert-renewer:
+    image: foundation/vault-agent:1.21.4
+    # Local-only image (built via foundation's `make build-vault-agent-image`,
+    # never pushed to a registry). pull_policy: never skips it during compose
+    # pull and uses the host's local image on up -d. The self-hosted GH runner
+    # IS this host, so the image is reliably present.
+    pull_policy: never
+    container_name: ruby-core-prod-nats-cert-renewer
+    restart: unless-stopped
+    read_only: true
+    tmpfs:
+      - /tmp
+    depends_on:
+      nats:
+        condition: service_healthy
+    command:
+      - sh
+      - -c
+      - vault agent -config=/etc/vault-agent/config.hcl
+    environment:
+      - NATS_CONTAINER=ruby-core-prod-nats
+    volumes:
+      - nats-certs:/certs
+      - ./vault-agent/config.hcl:/etc/vault-agent/config.hcl:ro
+      - ./vault-agent/nats-server.tpl:/etc/vault-agent/nats-server.tpl:ro
+      - ./vault-agent/post-render.sh:/etc/vault-agent/post-render.sh:ro
+      - /opt/foundation/vault/role-id-foundation-agent-ruby-core-nats-server:/vault/role-id:ro
+      - /opt/foundation/vault/.secret-id-foundation-agent-ruby-core-nats-server:/vault/secret-id:ro
+      - /opt/foundation/vault/tls/vault-ca.crt:/vault/tls/vault-ca.crt:ro
+      - ./vault-agent/rendered:/rendered
+      - /var/run/docker.sock:/var/run/docker.sock  # allow:docker.sock -- nats-cert-renewer SIGHUP hook (PLAN-0008 Stage 4)
+    networks:
+      - default
+      - vault-ruby-core-prod
+    cap_drop:
+      - ALL
+
+  # ==========================================================================
   # Gateway Service
   # ==========================================================================
   # ADR-0020: Port NOT published to host — all HTTP access goes through Traefik.
@@ -89,6 +143,9 @@ services:
         condition: service_healthy
     volumes:
       - /opt/foundation/vault/tls/vault-ca.crt:/vault/tls/vault-ca.crt:ro
+      # AppRole material for direct-PKI client cert (PLAN-0008 Stage 4).
+      - /opt/foundation/vault/role-id-foundation-agent-ruby-core-gateway:/vault/role-id:ro
+      - /opt/foundation/vault/.secret-id-foundation-agent-ruby-core-gateway:/vault/secret-id:ro
     environment:
       - ENVIRONMENT=production
       - VAULT_ADDR=https://vault:8200
@@ -98,6 +155,7 @@ services:
       - NATS_REQUIRE_MTLS=true
       - VAULT_NKEY_PATH=${VAULT_NKEY_PATH_GATEWAY:-secret/data/ruby-core/nats/gateway}
       - VAULT_TLS_PATH=${VAULT_TLS_PATH_GATEWAY:-secret/data/ruby-core/tls/gateway}
+      - VAULT_PKI_ROLE=ruby-core-gateway
       - HTTP_ADDR=:8080
     labels:
       - "traefik.enable=true"
@@ -129,6 +187,9 @@ services:
         condition: service_healthy
     volumes:
       - /opt/foundation/vault/tls/vault-ca.crt:/vault/tls/vault-ca.crt:ro
+      # AppRole material for direct-PKI client cert (PLAN-0008 Stage 4).
+      - /opt/foundation/vault/role-id-foundation-agent-ruby-core-engine:/vault/role-id:ro
+      - /opt/foundation/vault/.secret-id-foundation-agent-ruby-core-engine:/vault/secret-id:ro
     environment:
       - ENVIRONMENT=production
       - VAULT_ADDR=https://vault:8200
@@ -138,6 +199,7 @@ services:
       - NATS_REQUIRE_MTLS=true
       - VAULT_NKEY_PATH=${VAULT_NKEY_PATH_ENGINE:-secret/data/ruby-core/nats/engine}
       - VAULT_TLS_PATH=${VAULT_TLS_PATH_ENGINE:-secret/data/ruby-core/tls/engine}
+      - VAULT_PKI_ROLE=ruby-core-engine
       - RULES_DIR=/etc/ruby-core/rules
       - VAULT_PG_PATH=secret/data/ruby-core/postgres
       - VAULT_HA_PATH=secret/data/ruby-core/ha
@@ -163,6 +225,9 @@ services:
         condition: service_healthy
     volumes:
       - /opt/foundation/vault/tls/vault-ca.crt:/vault/tls/vault-ca.crt:ro
+      # AppRole material for direct-PKI client cert (PLAN-0008 Stage 4).
+      - /opt/foundation/vault/role-id-foundation-agent-ruby-core-notifier:/vault/role-id:ro
+      - /opt/foundation/vault/.secret-id-foundation-agent-ruby-core-notifier:/vault/secret-id:ro
     environment:
       - ENVIRONMENT=production
       - VAULT_ADDR=https://vault:8200
@@ -172,6 +237,7 @@ services:
       - NATS_REQUIRE_MTLS=true
       - VAULT_NKEY_PATH=${VAULT_NKEY_PATH_NOTIFIER:-secret/data/ruby-core/nats/notifier}
       - VAULT_TLS_PATH=${VAULT_TLS_PATH_NOTIFIER:-secret/data/ruby-core/tls/notifier}
+      - VAULT_PKI_ROLE=ruby-core-notifier
 
   # ==========================================================================
   # Presence Service
@@ -194,6 +260,9 @@ services:
         condition: service_healthy
     volumes:
       - /opt/foundation/vault/tls/vault-ca.crt:/vault/tls/vault-ca.crt:ro
+      # AppRole material for direct-PKI client cert (PLAN-0008 Stage 4).
+      - /opt/foundation/vault/role-id-foundation-agent-ruby-core-presence:/vault/role-id:ro
+      - /opt/foundation/vault/.secret-id-foundation-agent-ruby-core-presence:/vault/secret-id:ro
     environment:
       - ENVIRONMENT=production
       - VAULT_ADDR=https://vault:8200
@@ -203,6 +272,7 @@ services:
       - NATS_REQUIRE_MTLS=true
       - VAULT_NKEY_PATH=${VAULT_NKEY_PATH_PRESENCE:-secret/data/ruby-core/nats/presence}
       - VAULT_TLS_PATH=${VAULT_TLS_PATH_PRESENCE:-secret/data/ruby-core/tls/presence}
+      - VAULT_PKI_ROLE=ruby-core-presence
       - VAULT_HA_PATH=secret/data/ruby-core/ha
       - PRESENCE_PERSON_ID=katie
       - PRESENCE_PHONE_ENTITY=phone.katie
@@ -239,6 +309,7 @@ services:
       - NATS_REQUIRE_MTLS=true
       - VAULT_NKEY_PATH=${VAULT_NKEY_PATH_AUDIT_SINK:-secret/data/ruby-core/nats/audit-sink}
       - VAULT_TLS_PATH=${VAULT_TLS_PATH_AUDIT_SINK:-secret/data/ruby-core/tls/audit-sink}
+      - VAULT_PKI_ROLE=ruby-core-audit-sink
       - AUDIT_DATA_DIR=/data/audit
     volumes:
       # HOST BIND MOUNT — include /var/lib/ruby-core/audit in automated backups (ADR-0019).
@@ -246,6 +317,9 @@ services:
       #   mkdir -p /var/lib/ruby-core/audit
       - /var/lib/ruby-core/audit:/data/audit
       - /opt/foundation/vault/tls/vault-ca.crt:/vault/tls/vault-ca.crt:ro
+      # AppRole material for direct-PKI client cert (PLAN-0008 Stage 4).
+      - /opt/foundation/vault/role-id-foundation-agent-ruby-core-audit-sink:/vault/role-id:ro
+      - /opt/foundation/vault/.secret-id-foundation-agent-ruby-core-audit-sink:/vault/secret-id:ro
 
 # ==========================================================================
 # Networks

--- a/deploy/prod/vault-agent/config.hcl
+++ b/deploy/prod/vault-agent/config.hcl
@@ -1,0 +1,50 @@
+# Vault Agent — NATS server cert auto-renewer (PLAN-0008 follow-up)
+#
+# Authenticates via the foundation-agent-ruby-core-nats-server AppRole
+# (created in foundation PR #78) and renders the NATS server cert + key + CA
+# from a single pki_int/issue/ruby-core-nats-server call. The post-render
+# script atomic-writes the three files into the shared `nats-certs` volume
+# and SIGHUPs NATS via the Docker API. NATS reloads its TLS config in-place
+# (~40ms); existing mTLS connections survive (only new handshakes use the
+# rotated cert).
+#
+# Renewal cadence: Vault Agent's template engine refreshes at TTL/2 — same
+# cadence as the in-process renewal goroutine on the 5 Go services (24h-ish
+# with the default lease behavior).
+#
+# Image: foundation/vault-agent:1.21.4 — hashicorp/vault + curl baked in for
+# the Docker API SIGHUP call (foundation drift #75 / PLAN-0007).
+
+pid_file = "/tmp/vault-agent.pid"
+
+vault {
+  address = "https://vault:8200"
+  ca_cert = "/vault/tls/vault-ca.crt"
+}
+
+auto_auth {
+  method "approle" {
+    config = {
+      role_id_file_path                   = "/vault/role-id"
+      secret_id_file_path                 = "/vault/secret-id"
+      remove_secret_id_file_after_reading = false
+    }
+  }
+
+  sink "file" {
+    config = {
+      path = "/tmp/.vault-agent-token"
+    }
+  }
+}
+
+# Single template stanza — NATS needs cert+key+ca, all three from one
+# issuance (so the chain matches). Template emits them with ==CA== and
+# ==KEY== separators; post-render.sh splits, atomic-renames into /certs/,
+# and signals NATS.
+template {
+  source      = "/etc/vault-agent/nats-server.tpl"
+  destination = "/rendered/nats-bundle.tmp"
+  perms       = "0644"
+  command     = ["/etc/vault-agent/post-render.sh"]
+}

--- a/deploy/prod/vault-agent/nats-server.tpl
+++ b/deploy/prod/vault-agent/nats-server.tpl
@@ -1,0 +1,6 @@
+{{ with secret "pki_int/issue/ruby-core-nats-server" "common_name=nats" "ip_sans=127.0.0.1" "alt_names=ruby-core-dev-nats,ruby-core-staging-nats,ruby-core-prod-nats,localhost" "ttl=720h" }}{{ .Data.certificate }}
+==CA==
+{{ .Data.issuing_ca }}
+==KEY==
+{{ .Data.private_key }}
+{{ end }}

--- a/deploy/prod/vault-agent/post-render.sh
+++ b/deploy/prod/vault-agent/post-render.sh
@@ -1,0 +1,102 @@
+#!/bin/sh
+# Vault Agent post-render hook for the NATS server cert bundle.
+#
+# Splits /rendered/nats-bundle.tmp (cert + ==CA== + ca + ==KEY== + key) into
+# the three files NATS reads from its shared `nats-certs` volume, then sends
+# SIGHUP to the NATS container via the Docker API. NATS reloads its TLS
+# config in-place (~40ms); existing mTLS connections survive — only new
+# TLS handshakes use the rotated cert.
+#
+# Runs inside the foundation/vault-agent:1.21.4 image (hashicorp/vault + curl).
+# busybox tools only otherwise (sh, sed, grep, mv).
+#
+# Atomic-write pattern: writes to /rendered/.*.tmp first, validates PEM
+# markers, then `mv` into the shared volume. Under cap_drop: ALL the agent
+# (container root) can't overwrite a file in place but `mv` only needs write
+# permission on the target directory, which it has.
+set -eu
+
+BUNDLE=/rendered/nats-bundle.tmp
+CERTS_DIR=/certs
+NATS_CONTAINER="${NATS_CONTAINER:-ruby-core-dev-nats}"
+
+CERT_TMP=/rendered/.server-cert.pem.tmp
+CA_TMP=/rendered/.ca.pem.tmp
+KEY_TMP=/rendered/.server-key.pem.tmp
+
+if [ ! -s "$BUNDLE" ]; then
+  echo "post-render: bundle empty or missing — abort" >&2
+  exit 1
+fi
+
+# Split on ==CA== and ==KEY== separators.
+#   - Lines 1..==CA== (exclusive) → cert
+#   - Lines ==CA==..==KEY== (exclusive on both ends) → CA
+#   - Lines ==KEY==..end (exclusive) → key
+sed -n '1,/^==CA==$/p'           "$BUNDLE" | sed '/^==CA==$/d'                  > "$CERT_TMP"
+sed -n '/^==CA==$/,/^==KEY==$/p' "$BUNDLE" | sed -e '/^==CA==$/d' -e '/^==KEY==$/d' > "$CA_TMP"
+sed -n '/^==KEY==$/,$p'          "$BUNDLE" | sed '/^==KEY==$/d'                 > "$KEY_TMP"
+
+# Validate all three have the expected PEM markers. If anything is wrong,
+# abort BEFORE moving into the shared volume — NATS keeps using its last-good
+# cert and the Vault Agent retries on the next template tick.
+if ! grep -q 'BEGIN CERTIFICATE' "$CERT_TMP"; then
+  echo "post-render: $CERT_TMP missing BEGIN CERTIFICATE — abort" >&2
+  rm -f "$CERT_TMP" "$CA_TMP" "$KEY_TMP"
+  exit 1
+fi
+if ! grep -q 'BEGIN CERTIFICATE' "$CA_TMP"; then
+  echo "post-render: $CA_TMP missing BEGIN CERTIFICATE — abort" >&2
+  rm -f "$CERT_TMP" "$CA_TMP" "$KEY_TMP"
+  exit 1
+fi
+if ! grep -qE 'BEGIN .* PRIVATE KEY' "$KEY_TMP"; then
+  echo "post-render: $KEY_TMP missing BEGIN .* PRIVATE KEY — abort" >&2
+  rm -f "$CERT_TMP" "$CA_TMP" "$KEY_TMP"
+  exit 1
+fi
+
+# Mode 0644 — same as nats-init writes. Volume scope is bounded to this
+# sidecar + nats-init + NATS, so "world-readable" is just those three.
+chmod 0644 "$CERT_TMP" "$CA_TMP" "$KEY_TMP"
+
+mv "$CERT_TMP" "$CERTS_DIR/server-cert.pem"
+mv "$KEY_TMP"  "$CERTS_DIR/server-key.pem"
+
+# ─────────────────────────────────────────────────────────────────────────
+# TRANSITIONAL: deliberately DO NOT overwrite ca.pem on rotation.
+# nats-init writes a BUNDLED ca.pem (pki_int issuing_ca + legacy mkcert CA)
+# at startup; overwriting here with PKI-only would drop the mkcert anchor
+# and break the admin smoke path. The renewer's AppRole has no KV read
+# capability so it cannot reproduce the bundle on its own — letting
+# nats-init's bundle persist is the simpler, correct behavior.
+#
+# Both CAs are stable for years (RubyNet Intermediate, mkcert root), so a
+# static ca.pem across cert rotations is fine. The renewer just rotates
+# cert+key.
+#
+# *** REMOVE the discard-CA behavior in PLAN-0008 Stage 4 ***
+# Once admin migrates to PKI in Stage 4, the bundle becomes unnecessary and
+# this script can resume writing ca.pem with just the PKI issuing_ca.
+# ─────────────────────────────────────────────────────────────────────────
+rm -f "$CA_TMP"
+rm -f "$BUNDLE"
+
+# SIGHUP NATS via the Docker API. /kill (not /restart) with signal=SIGHUP
+# triggers NATS's config reload without dropping existing connections.
+# NATS validates the new cert during reload; if it's malformed it keeps the
+# old config (server/reload.go's validateOptions runs before Apply).
+HTTP_CODE=$(curl --silent --unix-socket /var/run/docker.sock \
+  -X POST --max-time 10 \
+  -o /dev/null -w '%{http_code}' \
+  "http://localhost/containers/${NATS_CONTAINER}/kill?signal=SIGHUP" || echo "000")
+
+case "$HTTP_CODE" in
+  204)
+    echo "post-render: cert+key written to ${CERTS_DIR} (ca.pem preserved from nats-init); SIGHUP sent to ${NATS_CONTAINER}"
+    ;;
+  *)
+    echo "post-render: write OK but SIGHUP call returned HTTP $HTTP_CODE" >&2
+    exit 1
+    ;;
+esac

--- a/docs/ops/vault-dev.md
+++ b/docs/ops/vault-dev.md
@@ -114,15 +114,16 @@ disk) is created by foundation's `make setup-pki-ruby-core-roles` +
 PR #78). The compose file bind-mounts the resulting role-id + secret-id files
 into each ruby-core container — including the `nats-cert-renewer` sidecar.
 
-**Staging** uses the same flow (PLAN-0008 Stage 3; `deploy/staging/vault-agent/`)
-with a transitional difference: NATS's `ca.pem` is bundled with both the
-`pki_int` intermediate CA **and** the legacy mkcert root CA. This is purely so
-the smoke test (which still uses `admin`'s mkcert-signed cert from the legacy
-KV path) can complete its mTLS handshake. The 5 services + NATS server cert are
-100% pki_int-signed — the mkcert anchor is an additive trust anchor for the one
-out-of-scope principal (admin). Stage 4 (prod migration) folds in admin's
-migration to PKI and removes the bundle entirely; each transitional block in
-the affected files carries an explicit `REMOVE in Stage 4` marker.
+**Staging and Production** use the same flow (PLAN-0008 Stages 3 + 4.A;
+`deploy/{staging,prod}/vault-agent/`) with a transitional difference: NATS's
+`ca.pem` is bundled with both the `pki_int` intermediate CA **and** the
+legacy mkcert root CA. This is purely so the smoke test (which still uses
+`admin`'s mkcert-signed cert from the legacy KV path) can complete its mTLS
+handshake. The 5 services + NATS server cert are 100% pki_int-signed — the
+mkcert anchor is an additive trust anchor for the one out-of-scope principal
+(admin). Stage 4.B folds in admin's migration to PKI and removes the bundle
+entirely; each transitional block in the affected files carries an explicit
+`REMOVE in Stage 4` marker.
 
 **Rollback path (legacy mkcert KV bundle):** still callable when `VAULT_PKI_ROLE`
 is unset in compose. `make setup-creds` repopulates `secret/ruby-core/tls/*`


### PR DESCRIPTION
## Summary

**Stage 4.A of PLAN-0008.** Migrates ruby-core production to the same direct-PKI flow already running in dev (~3 weeks soaked) and staging (PR #57). Final environment to come off legacy mkcert KV bundles for service-to-service traffic.

The migration is **pre-staged**: this PR merges the compose changes onto main, then release-please proposes `v0.13.1` (one `feat:` since `v0.13.0`). Merging the v0.13.1 release PR triggers the workflow, which auto-deploys to prod with the new PKI compose — that's when prod actually cuts over. `deploy-prod.sh` captures v0.13.0 as the rollback target.

## What changes

### `nats-init`
- Mount AppRole role-id + secret-id from foundation host paths
- Add `VAULT_PKI_ROLE=ruby-core-nats-server` env var (switches `fetch-nats-certs.sh` to the direct-PKI branch wired in PR #53)
- `TLS_PATH` retained as the rollback target

### `nats-cert-renewer` (new service)
- Long-running Vault Agent sidecar, port of staging's
- `NATS_CONTAINER=ruby-core-prod-nats` — only env-var difference from staging
- `pull_policy: never` (foundation/vault-agent is local-only)
- `cap_drop ALL`, `read_only`, `tmpfs: [/tmp]`, docker.sock with `allow:docker.sock` annotation
- Joins `vault-ruby-core-prod` for Vault DNS resolution

### Per-service: gateway, engine, notifier, presence, audit-sink
- Mount role-id + secret-id from `/opt/foundation/vault/*-ruby-core-<svc>`
- Add `VAULT_PKI_ROLE=ruby-core-<svc>`
- `VAULT_TLS_PATH` + `VAULT_TOKEN` retained for the rollback path
- Prod-specifics **preserved**: Traefik labels on gateway, host bind mounts (JetStream + audit), no port publishing on gateway (Traefik-only)

### `deploy/prod/vault-agent/` (new)
- `config.hcl`, `nats-server.tpl`, `post-render.sh` — verbatim copies from `deploy/staging/vault-agent/`. Files are env-agnostic; behavior diverges via `NATS_CONTAINER` override in compose.

## Transitional state preserved

The mkcert CA bundling introduced in PR #57 (commit `7ad23d2`) stays in place through this PR. NATS's `ca.pem` will contain both `pki_int` issuing CA **and** the legacy mkcert CA so admin (still mkcert) can complete its smoke-test handshake. **Stage 4.B (separate PR) migrates admin to PKI and removes the bundle entirely.** Each transitional block in the affected files carries an explicit `*** REMOVE in PLAN-0008 Stage 4 ***` marker.

## Vault state

**Zero new Vault state required.** The `foundation-agent-ruby-core-<svc>` AppRoles + `pki_int/roles/ruby-core-<svc>` were created in foundation PR #78 and are env-agnostic. The `nats-server` PKI role's `allowed_domains` already covers `ruby-core-prod-nats`.

## v0.13.0 release verification (prerequisite for this PR)

Before this PR, `v0.13.0` was cut and auto-deployed to prod (PR #58 merge). Result: ✅ workflow green, all 5 services running v0.13.0 images, prod continued operating on legacy mkcert KV bundles (no PKI yet — that's this PR). This separated "image bump" from "PKI cutover" so any image-level regression would have surfaced there, not lumped into PKI.

## Live validation plan (post v0.13.1 auto-deploy)

Same 5 drills as staging (PR #57 §Stage 2):

| Drill | What it proves |
|---|---|
| 2.1 — State verification | NATS cert from RubyNet Intermediate CA; ca.pem has 2 anchors; 5 conns; all services PKI-issued |
| 2.3 — Forced rotation | Cert serial rotates on `docker restart` of renewer; zero client churn; <50ms reload |
| 2.4 — Malformed cert | post-render aborts on PEM check; NATS keeps old cert; recovery after template restore |
| 2.5 — Vault outage | NATS unaffected during network disconnect; full recovery on reconnect |
| 2.6 — PKI-only proof | Strip mkcert anchor from ca.pem → 5 services still connect → proves PKI is doing the work, not mkcert |

Followed by a 3–5 day soak before Stage 4.B opens.

## Rollback

If v0.13.1 prod deploy fails: `deploy-prod.sh` auto-redeploys v0.13.0 images with the new compose on disk. v0.13.0 images already support PKI (same `boot.go`); auto-rollback handles image-level regression. If the **compose itself** is broken, manual `git revert` of this PR + redeploy at v0.13.0 with the old compose. JetStream + audit host bind mounts are unaffected throughout (no `down -v`).

## Drift observations (for tracking)

- **`scripts/stability-watch.sh` invocation mismatch** — script header says `systemd-run --no-block`, workflow uses `nohup setsid &`. Watcher silently doesn't run post-deploy (surfaced during v0.13.0 verification: no process running, stability.log empty since Apr 29). Pre-existing, not introduced by this PR. Worth a follow-up fix; for now, the 5 manual drills above provide better PKI-specific signal than the generic health checker stability-watch does.

## Foundation-side prerequisites (already merged)

- [foundation PR #78](https://github.com/rutabageldev/foundation/pull/78) — created the 6 AppRoles + 6 PKI roles + 6 scoped policies + role-id/secret-id on disk

## Out of scope

- **Stage 4.B** — admin migration to PKI + remove transitional bundle + deprecate mkcert in `setup-credentials.sh` + delete legacy KV bundles. Separate PR after Stage 4.A soak.
- **Foundation admin AppRole** — created during Stage 4.B (out-of-band foundation work).
- **PLAN-0008 archive** — happens after Stage 4.B + KV cleanup, in a small docs PR.

## Test plan

- [x] `docker compose -f deploy/prod/compose.prod.yaml config --quiet` clean (with sample env vars)
- [x] All 12 AppRole files (6 role-id + 6 secret-id) confirmed at `/opt/foundation/vault/*-ruby-core-*`, all 0644
- [x] Pre-commit hooks pass on both commits
- [ ] After v0.13.1 cut: workflow `deploy-prod` step exits 0
- [ ] After v0.13.1 cut: all 6 prod containers (5 services + nats-cert-renewer; nats-init exited cleanly; nats healthy) up within 60s
- [ ] After v0.13.1 cut: nats-cert-renewer logs show AppRole login + first cert render + SIGHUP HTTP 204
- [ ] After v0.13.1 cut: NATS log shows `Reloaded: tls = enabled`
- [ ] Five manual drills pass (state, forced rotation, malformed cert, Vault outage, PKI-only proof)
- [ ] 3–5 day soak passes (auto-renewal observed; no PKI/AppRole errors)

🤖 Generated with [Claude Code](https://claude.com/claude-code)