### PR TITLE
fix(deploy-prod): force-recreate nats-cert-renewer to pick up script changes

### DIFF
--- a/scripts/deploy-prod.sh
+++ b/scripts/deploy-prod.sh
@@ -72,6 +72,22 @@ docker compose -f "$PROD_COMPOSE" pull
 docker compose -f "$PROD_COMPOSE" up -d
 
 # ---------------------------------------------------------------------------
+# Force-recreate nats-cert-renewer to pick up any post-render.sh changes.
+#
+# The renewer bind-mounts post-render.sh as a single file. `git checkout`
+# (above, in this script's caller) replaces the file with a new inode rather
+# than editing in place, so the running container keeps a reference to the
+# original (now-orphaned) inode and never sees script changes — even though
+# the file on disk is updated. `compose up -d` won't recreate the renewer
+# because its compose config didn't change.
+#
+# Recycling it here is a sub-second sidecar restart: cert+key on disk persist,
+# NATS keeps running, the next render uses the latest script. See drift #66.
+# ---------------------------------------------------------------------------
+echo "=== Recreating nats-cert-renewer to pick up any script changes ==="
+docker compose -f "$PROD_COMPOSE" up -d --force-recreate --no-deps nats-cert-renewer
+
+# ---------------------------------------------------------------------------
 # Reload NATS auth configuration.
 # nats-init may have refreshed auth.conf on the named volume; SIGHUP applies it.
 # ---------------------------------------------------------------------------
@@ -105,6 +121,7 @@ fi
 
 # Roll back by re-deploying with the old version tag (uses cached images; no pull).
 VERSION="$PREV_VERSION" docker compose -f "$PROD_COMPOSE" up -d
+VERSION="$PREV_VERSION" docker compose -f "$PROD_COMPOSE" up -d --force-recreate --no-deps nats-cert-renewer
 docker wait ruby-core-prod-nats-init 2>/dev/null || true
 docker kill --signal=SIGHUP ruby-core-prod-nats
 


### PR DESCRIPTION
## Summary

Fixes #66 — `nats-cert-renewer` was holding a stale inode of its bind-mounted `post-render.sh` after every prod deploy. Surfaced during v0.15.0 post-deploy validation: the renewer was still running v0.14.0's script (host inode `11143873` vs container inode `11143943`) even though the host disk had the new script.

Root cause: single-file bind mounts + `git checkout` = orphaned inode. The renewer's compose config doesn't change when only script content changes, so `compose up -d` won't recreate it.

## Change

- `scripts/deploy-prod.sh`: explicit `docker compose up -d --force-recreate --no-deps nats-cert-renewer` after the main `compose up -d`. Sub-second sidecar recycle that triggers an immediate template render against the latest bind-mounted script.
- Applied to both the happy-path deploy and the rollback path.
- `--no-deps` avoids pulling `nats`/`nats-init`/the 5 services into the recreation chain.

## Why not just `--force-recreate` everything?

That would recycle `nats` itself, which we deliberately treat as a long-lived stateful pet (no NATS disruption, no client churn during deploy). Targeted force-recreate of just the sidecar is the smallest possible change.

## Why staging/dev don't need this

- **staging**: \`deploy-staging.sh\` does \`compose down -v\` on exit → every deploy starts fresh
- **dev**: stacks are short-lived; not run via \`deploy-*.sh\`

## Test plan

- [x] Manually validated on prod **outside** this PR: I ran \`docker compose up -d --force-recreate nats-cert-renewer\` after the v0.15.0 deploy. Renewer's inode matched the host (\`11143873\`), new log message landed (\`\"cert+key+ca written to /certs; SIGHUP sent to ruby-core-prod-nats\"\`), \`ca.pem\` stayed PKI-only (1 cert), 6/6 NATS conns held without churn.
- [ ] After this PR merges + release-please cuts v0.15.1, the auto-deploy will exercise the new code path. Verify in the workflow log that the explicit recreate step ran and the renewer's container ID changed.

## Rollback

Pure script change; no compose change. \`git revert\` is the only path needed. Worst case: the line errors out and the explicit recreate is a no-op (renewer keeps its current state, which is correct anyway as of v0.15.0's post-deploy fix).

## References

- Drift #66
- Stage 4.A PR #59 (introduced the prod renewer)
- Stage 4.B PR #64 (the script change that surfaced this)
- Related drift #61 (deploy-prod.sh SIGHUP race)

🤖 Generated with [Claude Code](https://claude.com/claude-code)