### PR TITLE
chore(vault-agent): bump nats-cert-renewer to foundation/vault-agent:2.0.2

### DIFF
--- a/deploy/dev/compose.dev.yaml
+++ b/deploy/dev/compose.dev.yaml
@@ -81,7 +81,7 @@ services:
   # Auth via foundation-agent-ruby-core-nats-server AppRole (created in
   # foundation PR #78); zero new Vault state required.
   nats-cert-renewer:
-    image: foundation/vault-agent:1.21.4
+    image: foundation/vault-agent:2.0.2
     container_name: ruby-core-dev-nats-cert-renewer
     restart: unless-stopped
     read_only: true

--- a/deploy/prod/compose.prod.yaml
+++ b/deploy/prod/compose.prod.yaml
@@ -83,7 +83,7 @@ services:
   # Auth via foundation-agent-ruby-core-nats-server AppRole (foundation PR #78);
   # zero new Vault state required.
   nats-cert-renewer:
-    image: foundation/vault-agent:1.21.4
+    image: foundation/vault-agent:2.0.2
     # Local-only image (built via foundation's `make build-vault-agent-image`,
     # never pushed to a registry). pull_policy: never skips it during compose
     # pull and uses the host's local image on up -d. The self-hosted GH runner

--- a/deploy/staging/compose.staging.yaml
+++ b/deploy/staging/compose.staging.yaml
@@ -87,7 +87,7 @@ services:
   # Auth via foundation-agent-ruby-core-nats-server AppRole (foundation PR #78);
   # zero new Vault state required.
   nats-cert-renewer:
-    image: foundation/vault-agent:1.21.4
+    image: foundation/vault-agent:2.0.2
     # Local-only image (built via foundation's `make build-vault-agent-image`,
     # never pushed to a registry per the Dockerfile comment in /opt/foundation/
     # vault-agent/Dockerfile). pull_policy: never skips it during compose pull


### PR DESCRIPTION
## Summary

Bumps the `nats-cert-renewer` sidecar image from `foundation/vault-agent:1.21.4` to `foundation/vault-agent:2.0.2` across all three environments:

- `deploy/dev/compose.dev.yaml`
- `deploy/staging/compose.staging.yaml`
- `deploy/prod/compose.prod.yaml`

This tracks the latest `foundation/vault-agent` image built in the foundation repo. The image is local-only (built via foundation's `make build-vault-agent-image`, never pushed to a registry); auth is unchanged (foundation-agent-ruby-core-nats-server AppRole, foundation PR #78) — zero new Vault state required.

## Verification

- [x] Diff limited to the three compose image tags (`git diff main..HEAD` — 3 lines changed)
- [x] No lingering references to `1.21.4` elsewhere in the repo
- [x] No version-pinned mentions in docs/runbooks (`docs/ops/vault-dev.md` references paths only)
- [x] Pre-commit hooks pass cleanly (gitleaks, yamllint)

## Pre-PR Checklist

- README: no change needed (image tag bump, no behavior change)
- Runbook: no update needed (no version pin)
- ADR: not warranted (version bump, no architectural decision)
- Plan: N/A (no plan for this chore)
- Branch name: single-concern ✓

## Drift Observations

None this session.

> ⚠️ Note: the prod/staging image is local-only and not pushed to a registry. Ensure `foundation/vault-agent:2.0.2` is built on the host (`make build-vault-agent-image` in foundation) before `make deploy-prod` runs, since `pull_policy: never` relies on the local image being present.