### PR TITLE
chore(staging): align staging config templates and docs with permanent stack

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -88,8 +88,9 @@ jobs:
   # ==========================================================================
   # Deploy to Staging & Run Smoke Test (Phase 8, ADR-0013)
   # Runs after all images are built. SSHes into the node, checks out the tag,
-  # runs deploy-staging.sh which: pulls images, starts the staging stack,
-  # runs smoke-test.sh against staging NATS (port 4224), then tears down.
+  # runs deploy-staging.sh which: pulls images, rolling-restarts the permanent
+  # staging stack onto the tag, then runs smoke-test.sh against staging NATS
+  # (port 4224). The stack is left running (PLAN-0017 step 7).
   # create-release only runs if this job passes.
   # ==========================================================================
   deploy-staging:

--- a/Makefile
+++ b/Makefile
@@ -192,7 +192,7 @@ staging-up: ## Start staging stack (requires deploy/staging/.env with VAULT_TOKE
 staging-down: ## Stop staging stack and remove volumes
 	$(COMPOSE_CMD) -f $(STAGING_COMPOSE) down -v
 
-deploy-staging: ## Pull images, start staging, run smoke test, tear down (requires VERSION=)
+deploy-staging: ## Pull images, rolling-restart permanent staging, run smoke test (requires VERSION=)
 	@VERSION="$(VERSION)" ./scripts/deploy-staging.sh "$(VERSION)"
 
 # =============================================================================

--- a/deploy/staging/.env.example
+++ b/deploy/staging/.env.example
@@ -13,4 +13,4 @@
 VAULT_TOKEN=
 VAULT_ADDR=https://127.0.0.1:8200
 VAULT_CACERT=/opt/foundation/vault/tls/vault-ca.crt
-GITHUB_REPOSITORY_OWNER=primaryrutabaga
+GITHUB_REPOSITORY_OWNER=your-org

--- a/scripts/deploy-staging.sh
+++ b/scripts/deploy-staging.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 # deploy-staging.sh VERSION
 #
-# Deploys the staging stack, runs a smoke test, then tears down.
-# Designed to be idempotent: always runs `docker compose down -v` on exit
-# so the next run starts from a clean state.
+# Updates the permanent staging stack to VERSION and runs a smoke test.
+# The stack is NOT torn down on exit (PLAN-0017 step 7): the warm stack stays
+# up to validate the rolling-restart path prod will take. Re-running performs a
+# rolling restart onto the requested version. To explicitly tear staging down
+# and remove its volumes, use `make staging-down`.
 #
 # Exit codes:
 #   0  smoke test passed
-#   1  smoke test failed (stack has been torn down)
+#   1  smoke test failed (stack is left running for inspection)
 #
 # Environment:
 #   VAULT_TOKEN    (required) — read from deploy/staging/.env if not set
@@ -97,5 +99,4 @@ else
   docker logs ruby-core-staging-engine --tail 50 2>&1 >&2 || true
 fi
 
-# cleanup trap runs on exit
 exit "$smoke_exit"


### PR DESCRIPTION
## Summary

Cleans up two pieces of drift surfaced while reconciling the staging deploy configuration after the `foundation/vault-agent:2.0.2` bump (#70). No runtime code changed — comments, Make help text, and a committed env template only.

### 1. Stale GHCR owner in committed env template
`deploy/staging/.env.example` pinned `GITHUB_REPOSITORY_OWNER=primaryrutabaga`, an orphaned GHCR namespace with no packages (left behind by the account rename to `rutabageldev`). A fresh staging bootstrap copying this example would fail at image pull (`manifest unknown`). Replaced with the `your-org` placeholder to match `deploy/prod/.env.example`'s convention.

### 2. Comments still describing the removed ephemeral teardown
PLAN-0017 step 7 made staging a permanent warm stack and dropped the `docker compose down -v` teardown trap, but several comments were never updated and still claimed the old behavior:
- `scripts/deploy-staging.sh` — header ("then tears down", "always runs `docker compose down -v` on exit"), exit-code note ("stack has been torn down"), and a dangling "cleanup trap runs on exit" line (there is no trap).
- `.github/workflows/release.yml` — staging-job comment ("then tears down").
- `Makefile` — `deploy-staging` target help text ("...run smoke test, tear down").

All corrected to describe the rolling-restart-on-permanent-stack behavior and to point at `make staging-down` for explicit teardown. The `staging-down` target keeps its real `down -v` — that's a deliberate, user-invoked teardown.

## Why `chore:` (no release)

Nothing shippable changed — no service code, only comments and a template. Typed `chore:` so release-please does not cut an empty release that would rebuild identical images.

## Verification

- [x] `pre-commit` passes (gitleaks, yamllint, actionlint, shellcheck)
- [x] No live docs/README describe staging as ephemeral (only archived PLAN-0017 / ROADMAP-0008, which are historical records)
- [x] `staging-down` retains its intentional `down -v`

## Pre-PR Checklist

- README: accurate, no change needed
- Runbook: no live runbook affected
- ADR: not warranted (PLAN-0017 already decided this; PR aligns docs to it)
- Plan: PLAN-0017 already archived; this PR conforms to it
- Branch name: single-concern ✓

## Drift Observations

This PR is itself the remediation for two drift observations raised during the #70 follow-up:
1. `deploy/staging/.env.example` stale GHCR owner
2. Stale ephemeral-teardown comments across `deploy-staging.sh` / `release.yml` / `Makefile`

Both are resolved here, so no separate `drift` issues are being filed.

> Note: the host-local `deploy/staging/.env` and `deploy/prod/.env` were also corrected out-of-band (staging owner → `rutabageldev`; both `VERSION` → `v0.15.1`, matching the running stack). Those files are gitignored and not part of this PR.