### PR TITLE
fix: isolate non-prod environments from prod HA + database (stop 3x Ada writes)

### DIFF
--- a/deploy/dev/compose.dev.yaml
+++ b/deploy/dev/compose.dev.yaml
@@ -194,7 +194,7 @@ services:
       - VAULT_TLS_PATH=secret/data/ruby-core/tls/engine
       - VAULT_PKI_ROLE=ruby-core-engine
       - RULES_DIR=/etc/ruby-core/rules
-      - VAULT_PG_PATH=secret/data/ruby-core/postgres
+      - VAULT_PG_PATH=secret/data/ruby-core/dev/postgres
       - VAULT_HA_PATH=secret/data/ruby-core/ha
       - TZ=America/New_York
 

--- a/deploy/dev/compose.dev.yaml
+++ b/deploy/dev/compose.dev.yaml
@@ -154,6 +154,9 @@ services:
       - VAULT_TLS_PATH=secret/data/ruby-core/tls/gateway
       - VAULT_PKI_ROLE=ruby-core-gateway
       - HTTP_ADDR=:8080
+      # HA ingestion gate: only prod consumes the shared Home Assistant event
+      # stream. Non-prod stays off it to avoid duplicate fan-out writes.
+      - HA_INGEST_ENABLED=false
 
   # ==========================================================================
   # Engine Service (profile: services)

--- a/deploy/prod/compose.prod.yaml
+++ b/deploy/prod/compose.prod.yaml
@@ -157,6 +157,9 @@ services:
       - VAULT_TLS_PATH=${VAULT_TLS_PATH_GATEWAY:-secret/data/ruby-core/tls/gateway}
       - VAULT_PKI_ROLE=ruby-core-gateway
       - HTTP_ADDR=:8080
+      # HA ingestion gate: prod is the sole consumer of the shared Home
+      # Assistant event stream (state_changed + ada_event).
+      - HA_INGEST_ENABLED=true
     labels:
       - "traefik.enable=true"
       - "traefik.docker.network=traefik_proxy"

--- a/deploy/staging/compose.staging.yaml
+++ b/deploy/staging/compose.staging.yaml
@@ -158,6 +158,9 @@ services:
       - VAULT_TLS_PATH=secret/data/ruby-core/staging/tls/gateway
       - VAULT_PKI_ROLE=ruby-core-gateway
       - HTTP_ADDR=:8080
+      # HA ingestion gate: only prod consumes the shared Home Assistant event
+      # stream. Non-prod stays off it to avoid duplicate fan-out writes.
+      - HA_INGEST_ENABLED=false
     # No Traefik labels — staging gateway is not publicly routed
 
   # ==========================================================================

--- a/services/gateway/README.md
+++ b/services/gateway/README.md
@@ -26,6 +26,7 @@ All secrets are fetched from Vault at startup. The service will not start if Vau
 | `NATS_REQUIRE_MTLS` | `false` | Force mTLS even if NATS_URL is not `tls://` |
 | `HTTP_ADDR` | `:8080` | Bind address for the health endpoint |
 | `ENVIRONMENT` | *(unset)* | Set to `production` to enforce HTTPS Vault |
+| `HA_INGEST_ENABLED` | *(unset → enabled)* | Set to `false` to disable Home Assistant ingestion (no WebSocket; degraded mode). All environments share one HA, so only prod should ingest — non-prod gateways set this to `false`. |
 | `VAULT_ALLOW_HTTP` | `false` | Override HTTPS enforcement for co-located Vault |
 
 ## Health check

--- a/services/gateway/main.go
+++ b/services/gateway/main.go
@@ -51,22 +51,34 @@ func main() {
 	defer nc.Close()
 	logger.Info("connected to NATS", slog.String("url", cfg.NATSUrl))
 
-	// Fetch Home Assistant credentials from Vault.
-	// Non-fatal: if the secret is absent the gateway starts in degraded mode
-	// (health endpoint up, HA WebSocket client disabled) and logs a warning.
-	haVaultPath := os.Getenv("VAULT_HA_PATH")
-	if haVaultPath == "" {
-		haVaultPath = "secret/data/ruby-core/ha"
-	}
-	haCfg, err := boot.FetchHAConfig(cfg.VaultAddr, cfg.VaultToken, haVaultPath)
-	if err != nil {
-		logger.Warn("vault: HA config unavailable — starting in degraded mode (no HA WebSocket)",
-			slog.String("vault_path", haVaultPath),
-			slog.String("error", err.Error()),
-		)
+	// Home Assistant ingestion gate. All environments share one Home Assistant,
+	// so only the production gateway may consume its event stream (state_changed
+	// + ada_event). Non-prod gateways set HA_INGEST_ENABLED=false to stay off it
+	// — otherwise every HA event fans out to all environments and is written
+	// multiple times. Disabled => empty HA config => degraded mode (no WebSocket),
+	// while the HTTP/health endpoints still run.
+	var haCfg *boot.HAConfig
+	if os.Getenv("HA_INGEST_ENABLED") == "false" {
+		logger.Warn("HA ingestion disabled (HA_INGEST_ENABLED=false) — gateway will not connect to Home Assistant")
 		haCfg = &boot.HAConfig{} // empty: HA client will not connect
 	} else {
-		logger.Info("vault: fetched HA config", slog.String("ha_url", haCfg.URL))
+		// Fetch Home Assistant credentials from Vault.
+		// Non-fatal: if the secret is absent the gateway starts in degraded mode
+		// (health endpoint up, HA WebSocket client disabled) and logs a warning.
+		haVaultPath := os.Getenv("VAULT_HA_PATH")
+		if haVaultPath == "" {
+			haVaultPath = "secret/data/ruby-core/ha"
+		}
+		haCfg, err = boot.FetchHAConfig(cfg.VaultAddr, cfg.VaultToken, haVaultPath)
+		if err != nil {
+			logger.Warn("vault: HA config unavailable — starting in degraded mode (no HA WebSocket)",
+				slog.String("vault_path", haVaultPath),
+				slog.String("error", err.Error()),
+			)
+			haCfg = &boot.HAConfig{} // empty: HA client will not connect
+		} else {
+			logger.Info("vault: fetched HA config", slog.String("ha_url", haCfg.URL))
+		}
 	}
 
 	gateway, err := app.New(haCfg.URL, haCfg.Token, nc, logger)


### PR DESCRIPTION
## Problem

Every Ada event (diaper, feeding, sleep, …) was written **3×** into the production database. Root cause was shared prod dependencies across environments:

- **One Home Assistant, three consumers:** dev, staging, and prod gateways all subscribed to the same HA `state_changed` + `ada_event` streams, so each HA event fanned out to all three engines.
- **One database, three writers:** `secret/ruby-core/postgres` *and* `secret/ruby-core/staging/postgres` both resolved to `foundation-postgres/ruby_core`, and dev used the prod path outright — so all three engines wrote into the one prod-read DB.

## Fix (two layers of isolation)

**1. Per-environment databases** — each env is now its own isolated consumer:

| Env | Database | Vault secret |
|---|---|---|
| prod | `ruby_core` | `secret/ruby-core/postgres` (unchanged) |
| staging | `ruby_core_staging` | `secret/ruby-core/staging/postgres` (repointed) |
| dev | `ruby_core_dev` | `secret/ruby-core/dev/postgres` (new) |

`28813cc` repoints dev's `VAULT_PG_PATH` off the prod path. The databases/roles were provisioned in `foundation-postgres` (companion branch `chore/ruby-core-per-env-databases` in the foundation repo), with `CONNECT` revoked from `PUBLIC` so each DB is reachable only by its own role.

**2. HA ingestion gate** (`5f776bd`) — adds `HA_INGEST_ENABLED` (default enabled). When `false`, the gateway skips the Vault HA fetch and runs in the existing degraded mode (no WebSocket, no `state_changed`/`ada_event` consumption; HTTP/health stay up). Set `false` in dev + staging, `true` in prod. This also stops non-prod **engines** from pushing `sensor.ada_*` values back to the shared prod HA (no inbound events → no outbound push) — which would otherwise make the HA totals flicker.

## Verification

- `pg_stat_activity`: each engine connects only to its own DB; new DBs migrated cleanly (12 tables each).
- ACL: `dev` role is **denied** connecting to prod `ruby_core`; prod role unaffected.
- Dev gateway (rebuilt from this branch) logs `HA ingestion disabled` + degraded mode, **0** HA subscriptions.
- Prod remains the sole HA consumer throughout — no regression.

## Rollout note

Dev is already live with both changes. **Staging/prod gateways apply the HA gate only once they run an image built from this branch** (they run GHCR releases); the per-env DBs are already live, so the row-duplication is already resolved for prod the moment staging/dev engines point at their own DBs.

## Pre-PR checklist

- ✅ Gateway README documents `HA_INGEST_ENABLED`
- ✅ Pre-commit clean (golangci-lint, fast unit tests)
- ✅ No runbook affected
- Single-concern: non-prod environment isolation (DB + HA)

## Drift / follow-ups

- 🔍 Staging compose sets `ENVIRONMENT=production` across all services (staging masquerading as prod) — worth a separate issue.
- No data cleanup of the existing 3× rows is included — intentionally deferred to an upcoming data purge.
- Companion change lives in the foundation repo (`chore/ruby-core-per-env-databases`); these dev/staging changes depend on those DBs (already provisioned live).
- An ADR for cross-environment isolation could be warranted (complements foundation ADR-0007) — not included here.

## Cross-repo dependency

Requires the foundation `postgres` databases (already provisioned live; captured in foundation branch `chore/ruby-core-per-env-databases`).