### PR TITLE
fix(deploy): validate NATS PKI AppRole material, not decommissioned KV cert bundle

### DIFF
--- a/deploy/base/nats/validate-config.sh
+++ b/deploy/base/nats/validate-config.sh
@@ -55,20 +55,22 @@ else
     WARNINGS=$((WARNINGS + 1))
 fi
 
-# Check for TLS server certificate in Vault (ADR-0015, ADR-0018)
-# Server certs are stored exclusively in Vault and fetched at container start
-if command -v vault >/dev/null 2>&1; then
-    if vault kv get "secret/ruby-core/tls/nats-server" >/dev/null 2>&1; then
-        echo "[OK] NATS server certificate found in Vault (secret/ruby-core/tls/nats-server)"
-    else
-        echo "[FAIL] NATS server certificate not found in Vault"
-        echo "       Run: make setup-creds"
-        ERRORS=$((ERRORS + 1))
-    fi
+# Check NATS server TLS certificate prerequisites (ADR-0018, ADR-0030).
+# The server cert is no longer a Vault KV bundle — since the direct-PKI migration
+# (PLAN-0008 Stage 4 / ADR-0030) nats-init issues it at container start from
+# pki_int/issue/<role> using the nats-server AppRole, and the legacy KV path
+# secret/ruby-core/tls/nats-server was decommissioned (see cleanup-mkcert-kv-bundles).
+# Validate the AppRole material that issuance depends on, not the removed bundle.
+NATS_ROLE_ID="${NATS_PKI_ROLE_ID:-/opt/foundation/vault/role-id-foundation-agent-ruby-core-nats-server}"
+NATS_SECRET_ID="${NATS_PKI_SECRET_ID:-/opt/foundation/vault/.secret-id-foundation-agent-ruby-core-nats-server}"
+if [ -s "$NATS_ROLE_ID" ] && [ -s "$NATS_SECRET_ID" ]; then
+    echo "[OK] NATS server PKI AppRole material present (cert is direct-PKI issued at startup)"
 else
-    echo "[WARN] vault CLI not available — skipping Vault cert check"
-    echo "       Ensure server certs are seeded with: make setup-creds"
-    WARNINGS=$((WARNINGS + 1))
+    echo "[FAIL] NATS server PKI AppRole material missing — cert issuance will fail at startup"
+    echo "       Expected non-empty: $NATS_ROLE_ID"
+    echo "                       and: $NATS_SECRET_ID"
+    echo "       (NATS server cert is PKI-issued at container start per ADR-0030, not a Vault KV bundle.)"
+    ERRORS=$((ERRORS + 1))
 fi
 
 # Check for JetStream storage directory reference


### PR DESCRIPTION
## Summary

Fixes the prod-deploy pre-flight that has been hard-failing the **Release** workflow at the "Deploy to Production" step — for both v0.15.2 (2026-06-17) and v0.16.0 (the Ada release). Builds and staging deploy succeed; only the prod pre-flight aborts, so prod is untouched but stuck behind.

## Root cause

`nats-validate` (`deploy/base/nats/validate-config.sh`) required the NATS server cert at the Vault KV path `secret/ruby-core/tls/nats-server` and `[FAIL]`ed when absent. But since the direct-PKI migration (ADR-0030 / PLAN-0008 Stage 4) the server cert is **issued at container start** by `nats-init` from `pki_int/issue/<role>` via the nats-server AppRole, and the legacy KV path was **decommissioned** (it's exactly what `make cleanup-mkcert-kv-bundles` deletes). So the check validated a path that no longer exists and blocked every deploy.

Confirmed: `secret/ruby-core/tls/nats-server` is absent in Vault, and `scripts/fetch-nats-certs.sh` issues via PKI.

## Change

Replace the stale KV-bundle check with a check of what issuance actually depends on — the nats-server AppRole `role-id`/`secret-id` material on the host (overridable via `NATS_PKI_ROLE_ID` / `NATS_PKI_SECRET_ID`). Verified locally: validator now reports `[OK] NATS server PKI AppRole material present` and exits 0 (`Errors: 0`).

## Effect

Unblocks automated prod deploys. Merging this lets release-please cut the next patch (v0.16.1 — same Ada changes from #83 plus this fix), and the Release workflow's prod deploy will pass the pre-flight and proceed.

## Test plan

- `bash deploy/base/nats/validate-config.sh` on the deploy host → `PASSED: Configuration is valid`, exit 0.
- shellcheck (pre-commit) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
