### PR TITLE
fix(natsx): bound JetStream stream retention + reconcile existing streams (ADR-0034)

### DIFF
--- a/docs/adr/0034-jetstream-stream-retention-bounds.md
+++ b/docs/adr/0034-jetstream-stream-retention-bounds.md
@@ -1,0 +1,79 @@
+# ADR-0034 - Bounded JetStream stream retention and config reconciliation
+
+* **Status:** Accepted
+* **Date:** 2026-06-18
+* **Supersedes:** *(partially revises the HA_EVENTS retention choice in ADR-0021/ADR-0022)*
+* **Superseded by:** *(none)*
+
+---
+
+## Context
+
+The prod NATS JetStream store (1 GiB `max_file_store`) filled to 100% — `HA_EVENTS` alone held
+1.59M messages / 937 MB (87% of the account). JetStream began returning `insufficient resources` on
+new writes: the `discard=new` `KV_idempotency` bucket failed its marks (degrading deduplication),
+and `HA_EVENTS` itself — having no per-stream limit to trigger its own `discard=old` eviction — was
+at risk of dropping incoming events.
+
+Two root causes:
+
+1. **`HA_EVENTS` was created with no `MaxAge` and no `MaxBytes`.** The original rationale was to keep
+   original payloads available "for DLQ routing during the full BackOff window." But that window is
+   `MaxDeliver` (5) × `AckWait` (30s) plus the backoff schedule (1+2+4+8s) — a few minutes, not
+   forever. The firehose of every HA `state_changed` event therefore grew without bound.
+2. **`ensureStream` only created streams when absent; it never updated an existing stream.** So a
+   retention limit added in code would silently *not* apply to an already-created stream — limits
+   could be assumed in code yet never enforced in the running system.
+
+All other streams are age-bounded (DLQ 7d, AUDIT 72h, COMMANDS 1h, PRESENCE 24h); only `HA_EVENTS`
+was unbounded.
+
+## Alternatives Considered
+
+**Raise `max_file_store` only** — Buys time but does not fix the unbounded stream; it would refill.
+
+**Switch `HA_EVENTS` to interest/work-queue retention** (delete after all consumers ack) — Changes
+replay semantics that the gateway reconciler and any future consumer may rely on, and `Retention` is
+an immutable field, so it cannot be applied to the existing stream without recreating it (losing
+data and consumers). Higher risk than bounding by age.
+
+**Bound `HA_EVENTS` by age + bytes, cap every stream, and reconcile existing streams (chosen).**
+
+## Decision
+
+1. `HA_EVENTS` MUST be bounded by `MaxAge` (`DefaultHAEventsMaxAge` = 48h — far beyond the retry/DLQ
+   window, covering reconciliation and debugging) **and** `MaxBytes` (512 MiB) as a hard ceiling.
+2. Every JetStream stream MUST set an explicit `MaxBytes` cap with `discard=old`, so it self-evicts
+   at its own ceiling rather than failing writes. The sum of all stream caps MUST remain below the
+   server `max_file_store`, so no stream can exhaust the account and starve the `discard=new` KV
+   buckets.
+3. `ensureStream` MUST reconcile an existing stream's mutable retention limits (`MaxAge`, `MaxBytes`,
+   `MaxMsgs`) via `UpdateStream` when they drift from the desired config. Immutable fields (name,
+   storage, retention policy, subjects) are never changed by reconciliation.
+4. JetStream account storage utilization SHOULD be alerted on (e.g. >75%) in the shared
+   observability stack so saturation surfaces before the account fills — this incident was only
+   noticed after it was full.
+
+## Consequences
+
+### Positive
+
+* The account can no longer be exhausted by a single stream; `discard=new` KV deduplication stays
+  reliable.
+* Retention-limit changes in code now take effect on deploy (and self-heal drift) rather than being
+  silently ignored.
+* `HA_EVENTS` retains ~48h (~tens of MB) — ample for consumer retries, reconciliation, and debugging.
+
+### Negative
+
+* `HA_EVENTS` no longer keeps full history; events older than 48h are purged (they have no
+  operational value, but full-history replay is gone).
+* Per-stream `MaxBytes` caps require occasional review as event volume grows; if a cap is hit before
+  its age limit, the stream silently drops oldest messages.
+
+### Neutral
+
+* Stream-config reconciliation becomes a startup responsibility of every service that ensures
+  streams. Relates to ADR-0021 (NATS), ADR-0022 (DLQ), ADR-0024 (backpressure).
+* Raising `max_file_store` for additional headroom remains available but is not required: the sum of
+  per-stream caps already sits below the current 1 GiB limit.

--- a/docs/plans/PLAN-0024-jetstream-retention-fix.md
+++ b/docs/plans/PLAN-0024-jetstream-retention-fix.md
@@ -1,0 +1,66 @@
+# PLAN-0024 - Bound JetStream stream retention + reconcile (JetStream-full incident)
+
+* **Status:** In Progress
+* **Date:** 2026-06-18
+* **Project:** ruby-core
+* **Roadmap Item:** none (operational reliability fix)
+* **Branch:** fix/jetstream-stream-retention
+* **Related ADRs:** ADR-0034
+
+---
+
+## Scope
+
+Fix the unbounded `HA_EVENTS` stream that filled the prod JetStream store and starved the
+idempotency KV. Bound `HA_EVENTS` by age + bytes, cap every stream, make `ensureStream` reconcile
+existing streams, and add a reusable admin helper. Out of scope: automated JetStream backups
+(ADR-0021 already covers the bind-mount), the Prometheus storage alert (foundation repo).
+
+## Pre-conditions
+
+* [x] On `fix/jetstream-stream-retention` (from current `origin/main`).
+* [x] Immediate mitigation already applied to the live prod stream (see Step 0).
+
+## Steps
+
+### Step 0 — Immediate mitigation (DONE, operational)
+
+**Action:** `ENV=prod scripts/nats-admin.sh stream edit HA_EVENTS --max-age=48h --max-bytes=512MB --force`.
+**Verification:** ✅ HA_EVENTS 894 MiB → 118 MiB; account storage 100% → 24%; `insufficient resources`
+warnings stopped within ~1 min. The edit persists in JetStream across NATS restarts.
+
+### Step 1 — Bound HA_EVENTS + cap all streams
+
+**Action:** Add `DefaultHAEventsMaxAge` (48h) and per-stream `MaxBytes*` constants to
+`pkg/config/consumer_defaults.go`; set `MaxAge`+`MaxBytes` on `HA_EVENTS` and a `MaxBytes` cap on
+every other stream in `pkg/natsx/streams.go`.
+**Verification:** `go build ./...`; cap sum (880 MiB) < `max_file_store` (1 GiB).
+
+### Step 2 — Reconcile existing streams
+
+**Action:** Change `ensureStream` to `UpdateStream` an existing stream when its mutable limits
+(`MaxAge`/`MaxBytes`/`MaxMsgs`) drift from desired (pure `streamLimitsDrifted` helper); never touch
+immutable fields.
+**Verification:** new `TestStreamLimitsDrifted` passes; `go test -tags=fast ./pkg/natsx/...`.
+
+### Step 3 — Reusable admin helper
+
+**Action:** Add `scripts/nats-admin.sh` — fetch admin NKEY + PKI-issued mTLS from Vault and run the
+`nats` CLI (the same auth `scripts/smoke-test.sh` uses), env-parameterized.
+**Verification:** `ENV=prod scripts/nats-admin.sh stream report` connects and lists streams.
+
+### Step 4 — ADR + build/lint/test
+
+**Action:** Write ADR-0034. `go build ./...`; `go test -tags=fast ./...`; golangci-lint; shellcheck.
+**Verification:** all green.
+
+## Rollback
+
+Code change is a clean revert (no schema/state migration). The live stream's reconciled limits
+persist regardless of the code; reverting the code would, on the next deploy, leave the live limits
+as last set (the reconcile is idempotent and only acts on drift). The Step-0 purge is irreversible
+(old `state_changed` events are gone) but those have no operational value.
+
+## Open Questions
+
+None — ready for execution.

--- a/docs/plans/archived/PLAN-0024-jetstream-retention-fix.md
+++ b/docs/plans/archived/PLAN-0024-jetstream-retention-fix.md
@@ -1,6 +1,6 @@
 # PLAN-0024 - Bound JetStream stream retention + reconcile (JetStream-full incident)
 
-* **Status:** In Progress
+* **Status:** Complete
 * **Date:** 2026-06-18
 * **Project:** ruby-core
 * **Roadmap Item:** none (operational reliability fix)

--- a/pkg/config/consumer_defaults.go
+++ b/pkg/config/consumer_defaults.go
@@ -42,6 +42,25 @@ const (
 	// Stale command messages (push notifications) are not worth replaying after this window.
 	DefaultCommandsMaxAge = 1 * time.Hour
 
+	// DefaultHAEventsMaxAge bounds the HA_EVENTS firehose (ADR-0034). It must exceed
+	// the maximum consumer retry window (MaxDeliver × AckWait + BackOff ≈ a few minutes)
+	// so original payloads stay available for DLQ routing, and comfortably covers
+	// reconciliation/replay after an outage. Previously unbounded, the stream grew until
+	// it exhausted the JetStream store and starved the discard=new KV buckets.
+	DefaultHAEventsMaxAge = 48 * time.Hour
+)
+
+// Per-stream byte caps (ADR-0034) — defense in depth so no single stream can exhaust
+// the JetStream account store and starve the discard=new KV buckets. Each stream uses
+// discard=old, so it self-evicts at its cap rather than failing new writes; the sum
+// sits under the server's max_file_store. Age limits remain the primary bound.
+const (
+	MaxBytesHAEvents int64 = 512 * 1024 * 1024 // 512 MiB
+	MaxBytesAudit    int64 = 256 * 1024 * 1024 // 256 MiB
+	MaxBytesDLQ      int64 = 64 * 1024 * 1024  // 64 MiB
+	MaxBytesCommands int64 = 16 * 1024 * 1024  // 16 MiB
+	MaxBytesPresence int64 = 32 * 1024 * 1024  // 32 MiB
+
 	// Audit-sink consumer defaults — lower throughput than the engine consumer
 	// because audit events are emitted only on critical actions (low volume).
 

--- a/pkg/natsx/streams.go
+++ b/pkg/natsx/streams.go
@@ -10,16 +10,20 @@ import (
 	"github.com/primaryrutabaga/ruby-core/pkg/config"
 )
 
-// EnsureHAEventsStream creates the HA_EVENTS JetStream stream if it does not already exist.
+// EnsureHAEventsStream creates or reconciles the HA_EVENTS JetStream stream.
 // The stream captures all ha.events.> subjects published by the gateway and adapters.
-// No MaxAge or MaxMsgs limit is set — messages are retained until storage is exhausted.
-// This ensures original payloads remain available for DLQ routing during the full BackOff window.
+// Bounded by both age and bytes (ADR-0034): the age limit keeps original payloads
+// available well past the consumer retry/DLQ-routing window, and the byte cap is a hard
+// ceiling so this high-volume firehose can never exhaust the JetStream store — its prior
+// unbounded retention filled the account and starved the discard=new KV buckets.
 func EnsureHAEventsStream(js nats.JetStreamContext) error {
 	return ensureStream(js, &nats.StreamConfig{
 		Name:      "HA_EVENTS",
 		Subjects:  []string{"ha.events.>"},
 		Storage:   nats.FileStorage,
 		Retention: nats.LimitsPolicy,
+		MaxAge:    config.DefaultHAEventsMaxAge,
+		MaxBytes:  config.MaxBytesHAEvents,
 	})
 }
 
@@ -33,6 +37,7 @@ func EnsureDLQStream(js nats.JetStreamContext) error {
 		Storage:   nats.FileStorage,
 		Retention: nats.LimitsPolicy,
 		MaxAge:    config.DefaultDLQMaxAge,
+		MaxBytes:  config.MaxBytesDLQ,
 	})
 }
 
@@ -55,6 +60,7 @@ func EnsureAuditStream(js nats.JetStreamContext) error {
 		Storage:   nats.FileStorage,
 		Retention: nats.LimitsPolicy,
 		MaxAge:    config.DefaultAuditMaxAge,
+		MaxBytes:  config.MaxBytesAudit,
 	})
 }
 
@@ -68,6 +74,7 @@ func EnsureCommandsStream(js nats.JetStreamContext) error {
 		Storage:   nats.FileStorage,
 		Retention: nats.LimitsPolicy,
 		MaxAge:    config.DefaultCommandsMaxAge,
+		MaxBytes:  config.MaxBytesCommands,
 	})
 }
 
@@ -81,20 +88,40 @@ func EnsurePresenceStream(js nats.JetStreamContext) error {
 		Storage:   nats.FileStorage,
 		Retention: nats.LimitsPolicy,
 		MaxAge:    24 * time.Hour,
+		MaxBytes:  config.MaxBytesPresence,
 	})
 }
 
-// ensureStream creates a stream only if it does not already exist. Idempotent.
+// ensureStream creates a stream if absent, or reconciles its mutable retention limits
+// if it already exists with drifted config. Idempotent. Reconciliation is what lets a
+// limit change in code (e.g. a new MaxAge/MaxBytes) actually take effect on an existing
+// deployment instead of being silently ignored — the gap that let HA_EVENTS grow
+// unbounded after its limits were assumed but never applied (ADR-0034).
 func ensureStream(js nats.JetStreamContext, cfg *nats.StreamConfig) error {
-	_, err := js.StreamInfo(cfg.Name)
-	if err == nil {
+	info, err := js.StreamInfo(cfg.Name)
+	if errors.Is(err, nats.ErrStreamNotFound) {
+		if _, err = js.AddStream(cfg); err != nil {
+			return fmt.Errorf("add stream %q: %w", cfg.Name, err)
+		}
 		return nil
 	}
-	if !errors.Is(err, nats.ErrStreamNotFound) {
+	if err != nil {
 		return fmt.Errorf("stream info %q: %w", cfg.Name, err)
 	}
-	if _, err = js.AddStream(cfg); err != nil {
-		return fmt.Errorf("add stream %q: %w", cfg.Name, err)
+	// Only retention limits are reconciled — these are safe to UpdateStream. Immutable
+	// fields (name, storage, retention policy, subjects) are never changed here.
+	if streamLimitsDrifted(&info.Config, cfg) {
+		if _, err = js.UpdateStream(cfg); err != nil {
+			return fmt.Errorf("update stream %q: %w", cfg.Name, err)
+		}
 	}
 	return nil
+}
+
+// streamLimitsDrifted reports whether the live stream's mutable retention limits differ
+// from the desired config. Pure, so the reconcile trigger is unit-testable.
+func streamLimitsDrifted(existing, desired *nats.StreamConfig) bool {
+	return existing.MaxAge != desired.MaxAge ||
+		existing.MaxBytes != desired.MaxBytes ||
+		existing.MaxMsgs != desired.MaxMsgs
 }

--- a/pkg/natsx/streams_test.go
+++ b/pkg/natsx/streams_test.go
@@ -1,0 +1,32 @@
+//go:build fast
+
+package natsx
+
+import (
+	"testing"
+	"time"
+
+	"github.com/nats-io/nats.go"
+)
+
+func TestStreamLimitsDrifted(t *testing.T) {
+	base := &nats.StreamConfig{MaxAge: 48 * time.Hour, MaxBytes: 512 << 20, MaxMsgs: -1}
+
+	cases := []struct {
+		name     string
+		existing *nats.StreamConfig
+		want     bool
+	}{
+		{"identical", &nats.StreamConfig{MaxAge: 48 * time.Hour, MaxBytes: 512 << 20, MaxMsgs: -1}, false},
+		{"max_age differs (was unbounded)", &nats.StreamConfig{MaxAge: 0, MaxBytes: 512 << 20, MaxMsgs: -1}, true},
+		{"max_bytes differs (was unbounded)", &nats.StreamConfig{MaxAge: 48 * time.Hour, MaxBytes: -1, MaxMsgs: -1}, true},
+		{"max_msgs differs", &nats.StreamConfig{MaxAge: 48 * time.Hour, MaxBytes: 512 << 20, MaxMsgs: 1000}, true},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := streamLimitsDrifted(c.existing, base); got != c.want {
+				t.Errorf("streamLimitsDrifted = %v, want %v", got, c.want)
+			}
+		})
+	}
+}

--- a/scripts/nats-admin.sh
+++ b/scripts/nats-admin.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# nats-admin.sh — run the `nats` CLI against a ruby-core NATS server as the admin
+# user, with credentials fetched from Vault (NKEY seed + PKI-issued client cert,
+# the same path scripts/smoke-test.sh uses). All arguments are passed through to
+# `nats`, so this is a thin authenticated wrapper for ad-hoc admin operations.
+#
+# Usage:  ENV=<dev|staging|prod> scripts/nats-admin.sh <nats args...>
+# Example: ENV=prod scripts/nats-admin.sh stream report
+#          ENV=prod scripts/nats-admin.sh stream edit HA_EVENTS --max-age=48h --max-bytes=512MB --force
+#
+# Requires: the `nats` CLI, `vault`, `jq`, and the admin AppRole material on the
+# host (/opt/foundation/vault/...-ruby-core-admin). Read VAULT_TOKEN from
+# deploy/prod/.env if not already set.
+
+set -euo pipefail
+
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${DIR}/.." && pwd)"
+
+NATS_CLI="${NATS_CLI:-${HOME}/go/bin/nats}"
+command -v "${NATS_CLI}" >/dev/null 2>&1 || { echo "error: nats CLI not found at ${NATS_CLI}" >&2; exit 1; }
+
+case "${ENV:-}" in
+    prod)    NATS_SERVER="tls://127.0.0.1:4223"; VAULT_SECRET_PREFIX="secret/ruby-core" ;;
+    staging) NATS_SERVER="tls://127.0.0.1:4224"; VAULT_SECRET_PREFIX="secret/ruby-core/staging" ;;
+    dev)     NATS_SERVER="tls://127.0.0.1:4222"; VAULT_SECRET_PREFIX="secret/ruby-core/dev" ;;
+    "")      echo "error: ENV is required (dev | staging | prod)" >&2; exit 2 ;;
+    *)       echo "error: unknown ENV='${ENV}'" >&2; exit 2 ;;
+esac
+
+export VAULT_ADDR="${VAULT_ADDR:-https://127.0.0.1:8200}"
+export VAULT_CACERT="${VAULT_CACERT:-/opt/foundation/vault/tls/vault-ca.crt}"
+if [[ -z "${VAULT_TOKEN:-}" ]]; then
+    VAULT_TOKEN="$(grep '^VAULT_TOKEN=' "${REPO_ROOT}/deploy/prod/.env" | head -1 | cut -d= -f2-)"
+    export VAULT_TOKEN
+fi
+
+TMPDIR="$(mktemp -d)"
+trap 'rm -rf "${TMPDIR}"' EXIT
+
+# Admin NKEY seed (KV; NKEY auth is orthogonal to TLS).
+vault kv get -field=seed "${VAULT_SECRET_PREFIX}/nats/admin" > "${TMPDIR}/seed.nk"
+chmod 600 "${TMPDIR}/seed.nk"
+
+# Admin client cert: AppRole-login then issue from pki_int (PLAN-0008 Stage 4.B).
+ADMIN_ROLE_ID="$(tr -d '[:space:]' < "${ADMIN_ROLE_ID_PATH:-/opt/foundation/vault/role-id-foundation-agent-ruby-core-admin}")"
+ADMIN_SECRET_ID="$(tr -d '[:space:]' < "${ADMIN_SECRET_ID_PATH:-/opt/foundation/vault/.secret-id-foundation-agent-ruby-core-admin}")"
+ADMIN_VAULT_TOKEN="$(vault write -field=token auth/approle/login role_id="${ADMIN_ROLE_ID}" secret_id="${ADMIN_SECRET_ID}")"
+VAULT_TOKEN="${ADMIN_VAULT_TOKEN}" vault write -format=json pki_int/issue/ruby-core-admin \
+    common_name=admin ttl=1h > "${TMPDIR}/issue.json"
+jq -r '.data.certificate' "${TMPDIR}/issue.json" > "${TMPDIR}/client.crt"
+jq -r '.data.private_key' "${TMPDIR}/issue.json" > "${TMPDIR}/client.key"
+jq -r '.data.issuing_ca'  "${TMPDIR}/issue.json" > "${TMPDIR}/ca.crt"
+chmod 600 "${TMPDIR}/client.key"
+
+exec "${NATS_CLI}" \
+    --server  "${NATS_SERVER}" \
+    --tlscert "${TMPDIR}/client.crt" \
+    --tlskey  "${TMPDIR}/client.key" \
+    --tlsca   "${TMPDIR}/ca.crt" \
+    --nkey    "${TMPDIR}/seed.nk" \
+    "$@"


### PR DESCRIPTION
## Summary

Fixes the prod JetStream store filling to 100% and returning `insufficient resources` on new writes (degraded idempotency dedup; risk of dropped events). Implements ADR-0034.

The live prod stream was already mitigated operationally (see below); this PR makes the fix permanent and self-applying.

## Root cause

- **`HA_EVENTS` was created with no `MaxAge`/`MaxBytes`** ("retained until storage exhausted" — for DLQ replay, but that window is only minutes: `MaxDeliver 5 × AckWait 30s` + backoff). It grew to **937 MB / 1.59M msgs** and the 1 GiB account hit its cap.
- **`ensureStream` only created streams when absent and never updated existing ones**, so a limit set in code would silently never apply to a live stream.

## Change

- **Bound `HA_EVENTS`**: `MaxAge` 48h + `MaxBytes` 512 MiB.
- **Per-stream `MaxBytes` cap** on every stream (`discard=old` self-eviction) so no single stream can exhaust the account and starve the `discard=new` KV buckets. Caps sum to 880 MiB < `max_file_store` (1 GiB).
- **`ensureStream` reconciles** existing streams via `UpdateStream` when mutable limits (`MaxAge`/`MaxBytes`/`MaxMsgs`) drift — so limit changes take effect on deploy and self-heal (pure `streamLimitsDrifted` helper, unit-tested).
- **`scripts/nats-admin.sh`** — reusable authenticated `nats` CLI wrapper (admin NKEY + PKI-issued mTLS from Vault, same auth as `smoke-test.sh`).

## Live mitigation (already applied)

```
ENV=prod scripts/nats-admin.sh stream edit HA_EVENTS --max-age=48h --max-bytes=512MB --force
```
HA_EVENTS 894 → 118 MiB; account storage 100% → 24%; `insufficient resources` warnings stopped within ~1 min. This persists across NATS restarts, so prod is already healthy; this PR ensures the bounds survive any future stream recreation and apply everywhere.

## Test plan

- `go build ./...`, `go test -tags=fast ./...` — green; golangci-lint 0 issues; shellcheck clean.
- `ENV=prod scripts/nats-admin.sh stream report` connects and lists streams (helper verified live).
- New `TestStreamLimitsDrifted` covers the reconcile trigger.

## Follow-up (not in this PR)

- **Observability:** a Prometheus alert on JetStream storage utilization (>75%) — this incident was only caught after the store filled. Filed against the foundation repo (shared monitoring stack).
- Optional: raise `max_file_store` 1→2 GiB for headroom (needs a NATS restart). Not required — the per-stream caps already prevent account exhaustion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
