### PR TITLE
feat(ada): Trends aggregation via ada.trends.query -> sensor.ada_trends (ROADMAP-0010.7, #82)

### DIFF
--- a/docs/plans/archived/PLAN-0025-ada-trends.md
+++ b/docs/plans/archived/PLAN-0025-ada-trends.md
@@ -1,0 +1,66 @@
+# PLAN-0025 - Ada Trends aggregation (#82, ADR-0032)
+
+* **Status:** Complete
+* **Date:** 2026-06-18
+* **Project:** ruby-core
+* **Roadmap Item:** docs/roadmap/ROADMAP-0010-ada-hardening-test-data-lifecycle.md (effort 0010.7)
+* **Branch:** feat/ada-trends
+* **Related ADRs:** ADR-0032
+
+---
+
+## Scope
+
+Serve bucketed activity aggregations for the dashboard's Trends view via request/response:
+`ada.trends.query {metric, view, period, request_id}` → boundary-aligned buckets → `sensor.ada_trends`
+echoing the request. The final ROADMAP-0010 effort. Out of scope: promotion to an HA WebSocket
+command (future, contract-compatible per ADR-0032).
+
+## Pre-conditions
+
+* [x] On `feat/ada-trends` (current `origin/main`); ADR-0032 merged.
+* [x] Existing range queries (`GetTodayDiapers`, `GetLast24hFeedings`, `GetTodaySleepSessions`,
+      `GetLast24hTummy`) are reusable with `boundary = prevWindowStart` — no new sqlc needed.
+
+## Steps
+
+### Step 1 — Event contract + route
+
+**Action:** Add `AdaEventTrendsQuery` subject + `AdaTrendsQueryData {metric, view, period, request_id}`
+to `pkg/schemas/ada.go`; add `"ada.trends.query"` to the gateway `eventRoutes`; dispatch from
+`ProcessEvent`.
+**Verification:** `go build ./...`; gateway route test.
+
+### Step 2 — Bucketing + aggregation (pure, testable)
+
+**Action:** Add `trends.go`: `periodSpec` (week 7×1d / month 4×7d / year 12×~30d), `trendBuckets`
+(boundary-aligned to `computeTodayBoundary` + 24h), and `aggregateTrend` (assign events to buckets,
+sum `totals`/`grand`, and `prevGrand` over the prior equal window). Per-metric event builders map
+existing query rows to `{when, segs}` using the consumer's verbatim seg/view keys (diapers→wet/dirty/
+mixed; feeding breast→left/right, bottle→milk/formula, feeds→bf/bo; sleep hours→night/nap,
+wakeups→wakeups; tummy min→min, sessions→sessions).
+**Verification:** `TestTrendBuckets`, `TestAggregateTrend` pass.
+
+### Step 3 — Handler + sensor
+
+**Action:** `handleTrendsQuery` parses, validates, computes the window from the bedtime boundary,
+fetches the metric's rows since `prevWindowStart`, aggregates, and pushes `sensor.ada_trends` with
+`{request_id, metric, view, period, generated_at, buckets:[{segs,total,label}], totals, grand,
+prevGrand}`. Invalid metric/view/period pushes an empty (echoed) response so the dashboard never hangs.
+**Verification:** unit test on a fixed dataset asserts exact bucket values + `prevGrand`.
+
+### Step 4 — Build, lint, fast tests; close the roadmap
+
+**Action:** `go build ./...`; `go test -tags=fast ./...`; golangci-lint. Mark ROADMAP-0010.7 done.
+**Verification:** all green.
+
+## Rollback
+
+Revert the commit; read-only aggregation + one new sensor, no schema/state change. Clean rollback.
+
+## Open Questions
+
+Consumer to confirm against the `buildTrend()` mock (the established repoint-and-verify step):
+the **wakeup** semantic (implemented as night sleep sessions beyond the first per night-window), the
+**bf/bo** classification (by feed source), and **bucket label** formats. Seg/view keys match the
+consumer's verbatim table; sleep `hours` seg keys (night/nap) were flagged in ADR-0032.

--- a/docs/roadmap/ROADMAP-0010-ada-hardening-test-data-lifecycle.md
+++ b/docs/roadmap/ROADMAP-0010-ada-hardening-test-data-lifecycle.md
@@ -1,10 +1,10 @@
 # Make Ada trustworthy end-to-end and safely validatable before birth
 
-* **Status:** Planned
+* **Status:** Complete
 * **Date:** 2026-06-18
 * **Project:** ruby-core
 * **Related ADRs:** ADR-0031 (test-data model), ADR-0032 (trends acquisition), ADR-0033 (projection integrity)
-* **Linked Plan:** PLAN-0018 … PLAN-0024 (one per effort; each created and committed on its own effort branch before that effort executes)
+* **Linked Plan:** PLAN-0018 … PLAN-0025 (one per effort, archived under docs/plans/archived/). Note: 0010.1 was already resolved on `main` by PR #72 before this roadmap landed.
 
 ---
 
@@ -42,7 +42,7 @@ Add `test BOOLEAN NOT NULL DEFAULT false` to every Ada table; persist the flag f
 
 Env-parameterized `make` targets: a seed target that writes a representative, fully `test`-flagged, ~14-month dataset aligned to a `DOB=` (and writes the matching HA `input_datetime.ada_test_dob`, `ada_live_test=on`, `ada_born=off`); and a guarded clear target that deletes only `test=true` rows (dry-run/count-first, `CONFIRM=yes`, prod-safety prompt, pre-delete snapshot). Includes a one-time guarded purge of pre-existing junk and a §4 reliability harness. This effort contains the only destructive operations and must not be bundled with feature delivery. Out of scope: automated/scheduled Postgres backups (ROADMAP-0011).
 
-### 0010.7 — Trends aggregation (#82, ADR-0032)
+### 0010.7 — Trends aggregation (#82, ADR-0032) — DONE (PLAN-0025)
 
 Request/response over the existing channel: `ada.trends.query {metric, view, period, request_id}` → boundary-aligned bucket computation → `sensor.ada_trends` echoing `request_id` + resolved params + `generated_at`. Out of scope: promotion to an HA WebSocket command (future, contract-compatible).
 

--- a/pkg/schemas/ada.go
+++ b/pkg/schemas/ada.go
@@ -22,6 +22,7 @@ const (
 	AdaEventBedtimeConfig       = "ha.events.ada.config_bedtime"
 	AdaEventGrowthLogged        = "ha.events.ada.growth_logged"
 	AdaEventFeedingClaimed      = "ha.events.ada.feeding_claimed"
+	AdaEventTrendsQuery         = "ha.events.ada.trends_query"
 
 	// Edit/delete (#77, #78, #79). Updates are full-resolution replacements.
 	AdaEventFeedingUpdate = "ha.events.ada.feeding_updated"
@@ -270,6 +271,17 @@ type AdaFeedingClaimedData struct {
 	GotItUser string `json:"got_it_user"`
 	Timestamp string `json:"timestamp,omitempty"`
 	LoggedBy  string `json:"logged_by,omitempty"`
+}
+
+// AdaTrendsQueryData is the request for a bucketed activity aggregation (#82, ADR-0032).
+// The dashboard mints an opaque RequestID per query; ruby-core echoes it in
+// sensor.ada_trends so the dashboard renders only the response to its latest request.
+// Metric ∈ diapers|feeding|sleep|tummy; View depends on Metric; Period ∈ week|month|year.
+type AdaTrendsQueryData struct {
+	Metric    string `json:"metric"`
+	View      string `json:"view"`
+	Period    string `json:"period"`
+	RequestID string `json:"request_id"`
 }
 
 // AdaGrowthLoggedData is the payload for a logged growth measurement.

--- a/services/engine/README.md
+++ b/services/engine/README.md
@@ -26,6 +26,8 @@ The `ada.born` event persists Ada's birth datetime to the `ada_profile` table. T
 
 Recorded events can be corrected or removed via `ada.{feeding,diaper,sleep,tummy,growth}.update` (full-resolution replacement) and `ada.{...}.delete {id}` (soft-delete via `deleted_at`), each recomputing the derived sensors. Every row carries a `test BOOLEAN` marker (ADR-0031): test data behaves identically in every projection but is selectable for bulk teardown by the seed/clear tooling — see [docs/runbooks/ada-test-data.md](../../docs/runbooks/ada-test-data.md).
 
+The Trends view is served by request/response (ADR-0032): the dashboard fires `ada.trends.query {metric, view, period, request_id}`; the engine computes boundary-aligned buckets (week 7×1-day, month 4×7-day, year 12×~30-day) and publishes the result — `{request_id, metric, view, period, generated_at, buckets, totals, grand, prevGrand}` — to `sensor.ada_trends`, echoing the `request_id` so the dashboard renders only its latest request.
+
 ## Configuration
 
 | Variable | Default | Notes |

--- a/services/engine/processors/ada/processor.go
+++ b/services/engine/processors/ada/processor.go
@@ -250,6 +250,8 @@ func (p *Processor) ProcessEvent(subject string, data []byte) error {
 		return p.handleGrowthUpdate(ctx, evt)
 	case schemas.AdaEventGrowthDelete:
 		return p.handleGrowthDelete(ctx, evt)
+	case schemas.AdaEventTrendsQuery:
+		return p.handleTrendsQuery(ctx, evt)
 	case "ha.events.input_number.ada_alert_threshold_h":
 		return p.handleThresholdChange(ctx, evt)
 	default:

--- a/services/engine/processors/ada/trends.go
+++ b/services/engine/processors/ada/trends.go
@@ -1,0 +1,376 @@
+package ada
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"math"
+	"sort"
+	"time"
+
+	"github.com/primaryrutabaga/ruby-core/pkg/schemas"
+	"github.com/primaryrutabaga/ruby-core/services/engine/processors/ada/store"
+)
+
+// Trends aggregation (#82, ADR-0032). The dashboard fires ada.trends.query and reads
+// the bucketed result back from sensor.ada_trends, matched by request_id. Buckets are
+// aligned to the bedtime boundary (sensor.ada_today_boundary): week = 7×1-day, month =
+// 4×7-day, year = 12×~30-day, with the most recent bucket covering the current day-window.
+
+const sensorTrends = "sensor.ada_trends"
+
+// bucketWindow is one [start, end) bucket with its display label.
+type bucketWindow struct {
+	start time.Time
+	end   time.Time
+	label string
+}
+
+// trendEvent is one row's additive contribution to one or more segments at a point in time.
+type trendEvent struct {
+	when time.Time
+	segs map[string]float64
+}
+
+// trendBucket is the response shape per bucket (mirrors TrendData).
+type trendBucket struct {
+	Segs  map[string]float64 `json:"segs"`
+	Total float64            `json:"total"`
+	Label string             `json:"label"`
+}
+
+// trendResponse is the full payload published to sensor.ada_trends (mirrors TrendData).
+type trendResponse struct {
+	RequestID   string             `json:"request_id"`
+	Metric      string             `json:"metric"`
+	View        string             `json:"view"`
+	Period      string             `json:"period"`
+	GeneratedAt string             `json:"generated_at"`
+	Buckets     []trendBucket      `json:"buckets"`
+	Totals      map[string]float64 `json:"totals"`
+	Grand       float64            `json:"grand"`
+	PrevGrand   float64            `json:"prevGrand"`
+}
+
+// periodSpec returns the bucket width and count for a period.
+func periodSpec(period string) (width time.Duration, count int, ok bool) {
+	switch period {
+	case "week":
+		return 24 * time.Hour, 7, true
+	case "month":
+		return 7 * 24 * time.Hour, 4, true
+	case "year":
+		return 30 * 24 * time.Hour, 12, true
+	}
+	return 0, 0, false
+}
+
+// trendBuckets returns the boundary-aligned buckets for a period, the most recent ending
+// at windowEnd (the next bedtime boundary, so the current partial day-window is included).
+func trendBuckets(period string, windowEnd time.Time) []bucketWindow {
+	w, n, ok := periodSpec(period)
+	if !ok {
+		return nil
+	}
+	out := make([]bucketWindow, n)
+	for i := 0; i < n; i++ {
+		start := windowEnd.Add(-time.Duration(n-i) * w)
+		end := windowEnd.Add(-time.Duration(n-1-i) * w)
+		out[i] = bucketWindow{start: start, end: end, label: bucketLabel(period, start)}
+	}
+	return out
+}
+
+// bucketLabel renders a bucket's display label from its start. The dashboard may relabel;
+// these are reasonable defaults to confirm against the buildTrend() mock.
+func bucketLabel(period string, start time.Time) string {
+	switch period {
+	case "week":
+		return start.Format("Mon")
+	case "month":
+		return start.Format("1/2")
+	case "year":
+		return start.Format("Jan")
+	}
+	return start.Format("1/2")
+}
+
+// aggregateTrend assigns events to buckets and computes per-segment totals, the grand
+// total (current window), and prevGrand (events before the window, i.e. the prior equal
+// window — callers fetch events back to prevWindowStart). Values are rounded for display.
+func aggregateTrend(events []trendEvent, buckets []bucketWindow, segKeys []string) (out []trendBucket, totals map[string]float64, grand, prevGrand float64) {
+	out = make([]trendBucket, len(buckets))
+	totals = make(map[string]float64, len(segKeys))
+	for _, k := range segKeys {
+		totals[k] = 0
+	}
+	for i, b := range buckets {
+		segs := make(map[string]float64, len(segKeys))
+		for _, k := range segKeys {
+			segs[k] = 0
+		}
+		out[i] = trendBucket{Segs: segs, Label: b.label}
+	}
+	if len(buckets) == 0 {
+		return out, totals, 0, 0
+	}
+	windowStart := buckets[0].start
+
+	for _, e := range events {
+		if e.when.Before(windowStart) {
+			for _, v := range e.segs {
+				prevGrand += v
+			}
+			continue
+		}
+		for i := range buckets {
+			if !e.when.Before(buckets[i].start) && e.when.Before(buckets[i].end) {
+				for k, v := range e.segs {
+					out[i].Segs[k] += v
+					out[i].Total += v
+					totals[k] += v
+					grand += v
+				}
+				break
+			}
+		}
+	}
+
+	for i := range out {
+		for k := range out[i].Segs {
+			out[i].Segs[k] = round1(out[i].Segs[k])
+		}
+		out[i].Total = round1(out[i].Total)
+	}
+	for k := range totals {
+		totals[k] = round1(totals[k])
+	}
+	return out, totals, round1(grand), round1(prevGrand)
+}
+
+func round1(f float64) float64 { return math.Round(f*10) / 10 }
+
+// trendSegKeys returns the stacked-segment keys for a (metric, view), or ok=false if the
+// pair is not supported. Keys are the consumer's verbatim identifiers (#82).
+func trendSegKeys(metric, view string) ([]string, bool) {
+	switch metric {
+	case "diapers":
+		if view == "count" {
+			return []string{"wet", "dirty", "mixed"}, true
+		}
+	case "feeding":
+		switch view {
+		case "breast":
+			return []string{"left", "right"}, true
+		case "bottle":
+			return []string{"milk", "formula"}, true
+		case "feeds":
+			return []string{"bf", "bo"}, true
+		}
+	case "sleep":
+		switch view {
+		case "hours":
+			return []string{"night", "nap"}, true
+		case "wakeups":
+			return []string{"wakeups"}, true
+		}
+	case "tummy":
+		switch view {
+		case "min":
+			return []string{"min"}, true
+		case "sessions":
+			return []string{"sessions"}, true
+		}
+	}
+	return nil, false
+}
+
+// ── Handler ─────────────────────────────────────────────────────────────────────
+
+func (p *Processor) handleTrendsQuery(ctx context.Context, evt schemas.CloudEvent) error {
+	var d schemas.AdaTrendsQueryData
+	if err := remarshal(evt.Data, &d); err != nil {
+		return fmt.Errorf("ada: decode trends_query: %w", err)
+	}
+
+	resp := trendResponse{
+		RequestID:   d.RequestID,
+		Metric:      d.Metric,
+		View:        d.View,
+		Period:      d.Period,
+		GeneratedAt: time.Now().UTC().Format(time.RFC3339),
+		Buckets:     []trendBucket{},
+		Totals:      map[string]float64{},
+	}
+
+	segKeys, okSeg := trendSegKeys(d.Metric, d.View)
+	_, n, okPeriod := periodSpec(d.Period)
+	if !okSeg || !okPeriod {
+		p.log.Warn("ada: trends query unsupported — returning empty result",
+			slog.String("metric", d.Metric), slog.String("view", d.View), slog.String("period", d.Period))
+		p.pushTrends(ctx, resp) // echo an empty response so the dashboard does not hang
+		return nil
+	}
+
+	w, _, _ := periodSpec(d.Period)
+	cfg := p.loadSleepConfig(ctx)
+	b0 := computeTodayBoundary(cfg.BedtimeHHMM)
+	windowEnd := b0.Add(24 * time.Hour)
+	buckets := trendBuckets(d.Period, windowEnd)
+	windowStart := buckets[0].start
+	prevStart := windowStart.Add(-time.Duration(n) * w)
+
+	events, err := p.trendEvents(ctx, d.Metric, d.View, prevStart, b0)
+	if err != nil {
+		return fmt.Errorf("ada: load trends events: %w", err)
+	}
+
+	resp.Buckets, resp.Totals, resp.Grand, resp.PrevGrand = aggregateTrend(events, buckets, segKeys)
+	p.pushTrends(ctx, resp)
+	return nil
+}
+
+// trendEvents fetches the metric's rows since prevStart (reusing the rolling-window
+// queries, which have no upper bound and therefore reach to now) and maps them to
+// additive trend events. b0 is the current bedtime boundary, used for wakeup grouping.
+func (p *Processor) trendEvents(ctx context.Context, metric, view string, prevStart, b0 time.Time) ([]trendEvent, error) {
+	since := toTimestamptz(prevStart)
+	switch metric {
+	case "diapers":
+		rows, err := p.q.GetTodayDiapers(ctx, since)
+		if err != nil {
+			return nil, err
+		}
+		return diaperEvents(rows), nil
+	case "feeding":
+		rows, err := p.q.GetLast24hFeedings(ctx, since)
+		if err != nil {
+			return nil, err
+		}
+		return feedingEvents(rows, view), nil
+	case "sleep":
+		rows, err := p.q.GetTodaySleepSessions(ctx, since)
+		if err != nil {
+			return nil, err
+		}
+		return sleepEvents(rows, view, b0), nil
+	case "tummy":
+		rows, err := p.q.GetLast24hTummy(ctx, since)
+		if err != nil {
+			return nil, err
+		}
+		return tummyEvents(rows, view), nil
+	}
+	return nil, nil
+}
+
+func diaperEvents(rows []*store.GetTodayDiapersRow) []trendEvent {
+	out := make([]trendEvent, 0, len(rows))
+	for _, r := range rows {
+		out = append(out, trendEvent{when: r.Timestamp.Time, segs: map[string]float64{r.Type: 1}})
+	}
+	return out
+}
+
+func feedingEvents(rows []*store.GetLast24hFeedingsRow, view string) []trendEvent {
+	out := make([]trendEvent, 0, len(rows))
+	for _, r := range rows {
+		var segs map[string]float64
+		switch view {
+		case "breast":
+			segs = map[string]float64{"left": float64(r.LeftDurationS) / 60, "right": float64(r.RightDurationS) / 60}
+		case "bottle":
+			segs = map[string]float64{"milk": r.BreastMilkOz, "formula": r.FormulaOz}
+		case "feeds":
+			if isBottleSource(r.Source) {
+				segs = map[string]float64{"bo": 1}
+			} else {
+				segs = map[string]float64{"bf": 1}
+			}
+		}
+		out = append(out, trendEvent{when: r.Timestamp.Time, segs: segs})
+	}
+	return out
+}
+
+func sleepEvents(rows []*store.GetTodaySleepSessionsRow, view string, b0 time.Time) []trendEvent {
+	if view == "wakeups" {
+		return sleepWakeupEvents(rows, b0)
+	}
+	out := make([]trendEvent, 0, len(rows))
+	for _, r := range rows {
+		hrs := r.EndTime.Time.Sub(r.StartTime.Time).Hours()
+		if hrs < 0 {
+			hrs = 0
+		}
+		seg := "nap"
+		if r.SleepType == "night" {
+			seg = "night"
+		}
+		out = append(out, trendEvent{when: r.StartTime.Time, segs: map[string]float64{seg: hrs}})
+	}
+	return out
+}
+
+// sleepWakeupEvents counts night-sleep sessions beyond the first within each night-window
+// (a bedtime-to-bedtime day) as wakeups. Definition to confirm against the buildTrend() mock.
+func sleepWakeupEvents(rows []*store.GetTodaySleepSessionsRow, b0 time.Time) []trendEvent {
+	type night struct {
+		start  time.Time
+		dayIdx int
+	}
+	var nights []night
+	for _, r := range rows {
+		if r.SleepType != "night" {
+			continue
+		}
+		st := r.StartTime.Time
+		nights = append(nights, night{start: st, dayIdx: int(math.Floor(st.Sub(b0).Hours() / 24))})
+	}
+	sort.Slice(nights, func(i, j int) bool { return nights[i].start.Before(nights[j].start) })
+	seen := make(map[int]bool)
+	out := make([]trendEvent, 0)
+	for _, nt := range nights {
+		if seen[nt.dayIdx] {
+			out = append(out, trendEvent{when: nt.start, segs: map[string]float64{"wakeups": 1}})
+		} else {
+			seen[nt.dayIdx] = true
+		}
+	}
+	return out
+}
+
+func tummyEvents(rows []*store.GetLast24hTummyRow, view string) []trendEvent {
+	out := make([]trendEvent, 0, len(rows))
+	for _, r := range rows {
+		var segs map[string]float64
+		if view == "sessions" {
+			segs = map[string]float64{"sessions": 1}
+		} else {
+			segs = map[string]float64{"min": float64(r.DurationS) / 60}
+		}
+		out = append(out, trendEvent{when: r.StartTime.Time, segs: segs})
+	}
+	return out
+}
+
+func (p *Processor) pushTrends(ctx context.Context, resp trendResponse) {
+	b, err := json.Marshal(resp)
+	if err != nil {
+		p.log.Warn("ada: marshal trends response", slog.String("error", err.Error()))
+		return
+	}
+	var attrs map[string]any
+	if err := json.Unmarshal(b, &attrs); err != nil {
+		p.log.Warn("ada: trends response to attrs", slog.String("error", err.Error()))
+		return
+	}
+	state := resp.RequestID
+	if state == "" {
+		state = "ok"
+	}
+	if err := p.ha.PushState(ctx, sensorTrends, state, attrs); err != nil {
+		p.log.Warn("ada: push trends", slog.String("error", err.Error()))
+	}
+}

--- a/services/engine/processors/ada/trends_test.go
+++ b/services/engine/processors/ada/trends_test.go
@@ -1,0 +1,106 @@
+//go:build fast
+
+package ada
+
+import (
+	"testing"
+	"time"
+)
+
+func TestTrendBuckets_Week(t *testing.T) {
+	windowEnd := time.Date(2026, 6, 18, 19, 0, 0, 0, time.UTC)
+	bs := trendBuckets("week", windowEnd)
+	if len(bs) != 7 {
+		t.Fatalf("week buckets = %d, want 7", len(bs))
+	}
+	if !bs[6].end.Equal(windowEnd) {
+		t.Errorf("last bucket end = %v, want %v", bs[6].end, windowEnd)
+	}
+	if !bs[6].start.Equal(windowEnd.Add(-24 * time.Hour)) {
+		t.Errorf("last bucket start = %v, want windowEnd-24h", bs[6].start)
+	}
+	if !bs[0].start.Equal(windowEnd.Add(-7 * 24 * time.Hour)) {
+		t.Errorf("first bucket start = %v, want windowEnd-7d", bs[0].start)
+	}
+	// contiguous
+	for i := 1; i < len(bs); i++ {
+		if !bs[i].start.Equal(bs[i-1].end) {
+			t.Errorf("bucket %d not contiguous with %d", i, i-1)
+		}
+	}
+}
+
+func TestTrendBuckets_MonthYearCounts(t *testing.T) {
+	windowEnd := time.Date(2026, 6, 18, 19, 0, 0, 0, time.UTC)
+	if got := len(trendBuckets("month", windowEnd)); got != 4 {
+		t.Errorf("month buckets = %d, want 4", got)
+	}
+	if got := len(trendBuckets("year", windowEnd)); got != 12 {
+		t.Errorf("year buckets = %d, want 12", got)
+	}
+	if trendBuckets("bogus", windowEnd) != nil {
+		t.Error("unknown period should yield nil buckets")
+	}
+}
+
+func TestAggregateTrend(t *testing.T) {
+	windowEnd := time.Date(2026, 6, 18, 19, 0, 0, 0, time.UTC)
+	buckets := trendBuckets("week", windowEnd)
+	segKeys := []string{"wet", "dirty", "mixed"}
+
+	events := []trendEvent{
+		{when: windowEnd.Add(-1 * time.Hour), segs: map[string]float64{"wet": 1}},        // bucket 6
+		{when: windowEnd.Add(-1 * time.Hour), segs: map[string]float64{"dirty": 1}},      // bucket 6
+		{when: windowEnd.Add(-25 * time.Hour), segs: map[string]float64{"wet": 1}},       // bucket 5
+		{when: windowEnd.Add(-8 * 24 * time.Hour), segs: map[string]float64{"mixed": 1}}, // prev window
+	}
+
+	out, totals, grand, prevGrand := aggregateTrend(events, buckets, segKeys)
+
+	if grand != 3 {
+		t.Errorf("grand = %v, want 3", grand)
+	}
+	if prevGrand != 1 {
+		t.Errorf("prevGrand = %v, want 1", prevGrand)
+	}
+	if out[6].Total != 2 {
+		t.Errorf("bucket[6].total = %v, want 2", out[6].Total)
+	}
+	if out[5].Total != 1 {
+		t.Errorf("bucket[5].total = %v, want 1", out[5].Total)
+	}
+	if totals["wet"] != 2 || totals["dirty"] != 1 || totals["mixed"] != 0 {
+		t.Errorf("totals = %v, want wet=2 dirty=1 mixed=0", totals)
+	}
+}
+
+func TestTrendSegKeys(t *testing.T) {
+	ok := map[[2]string][]string{
+		{"diapers", "count"}:  {"wet", "dirty", "mixed"},
+		{"feeding", "breast"}: {"left", "right"},
+		{"feeding", "bottle"}: {"milk", "formula"},
+		{"feeding", "feeds"}:  {"bf", "bo"},
+		{"sleep", "hours"}:    {"night", "nap"},
+		{"sleep", "wakeups"}:  {"wakeups"},
+		{"tummy", "min"}:      {"min"},
+		{"tummy", "sessions"}: {"sessions"},
+	}
+	for k, want := range ok {
+		got, valid := trendSegKeys(k[0], k[1])
+		if !valid || len(got) != len(want) {
+			t.Errorf("trendSegKeys(%q,%q) = %v,%v; want %v", k[0], k[1], got, valid, want)
+			continue
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("trendSegKeys(%q,%q)[%d] = %q, want %q", k[0], k[1], i, got[i], want[i])
+			}
+		}
+	}
+	if _, valid := trendSegKeys("bogus", "x"); valid {
+		t.Error("unknown metric should be invalid")
+	}
+	if _, valid := trendSegKeys("sleep", "bogus"); valid {
+		t.Error("unknown sleep view should be invalid")
+	}
+}

--- a/services/gateway/ada/publish.go
+++ b/services/gateway/ada/publish.go
@@ -33,6 +33,7 @@ var eventRoutes = map[string]string{
 	"ada.config.bedtime":      schemas.AdaEventBedtimeConfig,
 	"ada.growth.log":          schemas.AdaEventGrowthLogged,
 	"ada.feeding.claimed":     schemas.AdaEventFeedingClaimed,
+	"ada.trends.query":        schemas.AdaEventTrendsQuery,
 	"ada.feeding.update":      schemas.AdaEventFeedingUpdate,
 	"ada.feeding.delete":      schemas.AdaEventFeedingDelete,
 	"ada.diaper.update":       schemas.AdaEventDiaperUpdate,

--- a/services/gateway/ada/publish_test.go
+++ b/services/gateway/ada/publish_test.go
@@ -20,6 +20,13 @@ func TestEventRoutesFeedingClaimed(t *testing.T) {
 	}
 }
 
+// TestEventRoutesTrendsQuery verifies the trends query event routes to its subject (#82).
+func TestEventRoutesTrendsQuery(t *testing.T) {
+	if got := eventRoutes["ada.trends.query"]; got != schemas.AdaEventTrendsQuery {
+		t.Errorf("ada.trends.query routes to %q, want %q", got, schemas.AdaEventTrendsQuery)
+	}
+}
+
 // TestEventRoutesEditDelete verifies all ten edit/delete write-path events route to
 // their subjects (#77/#78/#79).
 func TestEventRoutesEditDelete(t *testing.T) {


### PR DESCRIPTION
## Summary

Implements ROADMAP-0010 effort **0010.7 — Trends aggregation** (#82, ADR-0032). This is the **final** effort; the roadmap is now complete.

Closes #82.

## What changed

The dashboard fires `ada.trends.query {metric, view, period, request_id}`; the engine computes **boundary-aligned buckets** and publishes the result to **`sensor.ada_trends`**:

- **Bucketing** (aligned to the bedtime boundary, `sensor.ada_today_boundary`): Week = 7×1-day, Month = 4×7-day, Year = 12×~30-day, most recent bucket covering the current day-window.
- **Response** mirrors `TrendData`: `{request_id, metric, view, period, generated_at, buckets:[{segs, total, label}], totals, grand, prevGrand}` — `request_id` echoed so the dashboard renders only its latest request; `prevGrand` is the same view/period over the prior equal window (for the delta arrow).
- **Seg/view keys** are the consumer's verbatim identifiers: diapers `count` (wet/dirty/mixed); feeding `breast` (left/right min), `bottle` (milk/formula oz), `feeds` (bf/bo counts); sleep `hours` (night/nap), `wakeups`; tummy `min`, `sessions`.
- Reuses the existing rolling-window queries with `boundary = prevWindowStart` — **no new sqlc, no migration**. Invalid metric/view/period returns an empty echoed response so the dashboard never hangs.
- Bucketing + aggregation (`trends.go`) are **pure and unit-tested** (`TestTrendBuckets`, `TestAggregateTrend`, `TestTrendSegKeys`, route test).

## Test plan

- `go build ./...`, `go test -tags=fast ./...` — green; golangci-lint 0 issues; `pre-commit run --all-files` clean.

## Consumer-contract changes (homeassistant repo)

Per ADR-0032, repoint `buildTrend()` at `sensor.ada_trends` (mint `request_id`, read back the matching response, ignore stale). **No `TrendData` shape change.** Three semantics to confirm against the existing `buildTrend()` mock — these are my reasonable choices, easy to adjust:
- **wakeups** = night sleep sessions beyond the first within each night-window (bedtime-to-bedtime day).
- **bf/bo** classified by feed `source` (breast* → bf; bottle*/mixed → bo).
- **bucket labels** (weekday / M-D / month abbrev) — display only.

(Sleep `hours` seg keys `night`/`nap` were flagged in ADR-0032 and are implemented as such.)

## Roadmap

Marks **ROADMAP-0010 Complete**. Efforts 0010.1–0010.6 are already live (v0.16.1 / v0.17.0); this is the last one.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
