### PR TITLE
feat(ada): clean slate at birth — force test pre-birth + wipe tracking on ada.born (ADR-0035)

### DIFF
--- a/docs/adr/0035-ada-clean-slate-at-birth.md
+++ b/docs/adr/0035-ada-clean-slate-at-birth.md
@@ -1,0 +1,87 @@
+# ADR-0035 - Ada clean slate at birth: pre-birth test marking and auto-clear on ada.born
+
+* **Status:** Accepted
+* **Date:** 2026-06-18
+* **Supersedes:** *(extends ADR-0031 test-data model)*
+* **Superseded by:** *(none)*
+
+---
+
+## Context
+
+Before Ada is born, every Ada event in the system is, by definition, test data — the dashboard is
+being exercised for validation, not recording a real baby. ADR-0031 added a `test BOOLEAN` marker
+and made the engine persist a `test` flag carried on the event payload (the dashboard stamps
+`test:true` while `input_boolean.ada_live_test` is on).
+
+In practice this left two gaps that matter for go-live:
+
+1. **Pre-birth events are not reliably flagged.** The flag depends entirely on the dashboard
+   stamping it. A prod inspection on 2026-06-18 found 371 of 374 Ada events flagged `test=false`
+   (real) — only the most recent few, after stamping was switched on, were `test=true`. Two distinct
+   classes of unflagged data exist: events fired without the stamp / with `live_test` off, **and**
+   data created out-of-band via the HA API (e.g. a seeded WHO growth channel and verification events)
+   that bypassed the dashboard's stamping helper entirely. A `test=true`-only clear would leave all
+   of that behind — and the seeded growth series would bleed into Ada's real chart.
+2. **`ada.born` does nothing but save the birth profile.** There is no automatic teardown, so the
+   accumulated pre-birth data would carry into the real record unless an operator remembers to run
+   `make ada-db-clear-test` at exactly the right moment.
+
+The goal: when the real `ada.born` fires, Ada's history starts from a guaranteed clean slate, with
+no dependence on the dashboard toggle or operator timing.
+
+## Alternatives Considered
+
+**Rely on the dashboard stamping + an operator-run clear at birth** — Status quo. Fragile: depends
+on `live_test` staying on and on the operator running the clear at the right instant; the 371
+mis-flagged rows show the dashboard path is not sufficient on its own.
+
+**Auto-clear only `test=true` on first birth** — Relies on every pre-birth row being correctly
+flagged at the one-shot birth moment. Even with the backfill and pre-birth forcing below, this stays
+dependent on the flag being perfect, and would silently miss any out-of-band class of unflagged data.
+
+**Force `test=true` pre-birth + backfill existing rows + wipe ALL tracking data on first birth
+(chosen).** The pre-birth forcing and backfill keep the `test` flag accurate (so the operator-run
+clear works during testing); the birth clear itself deletes *all* tracking data rather than keying
+on the flag, which is robust regardless of how any pre-birth row was created. Config/settings are
+preserved. Safe because nothing real can predate birth and the clear is gated to the first birth.
+
+## Decision
+
+1. While Ada is **not yet born** (no `ada_profile` row), the engine MUST flag every Ada event
+   `test=true` regardless of the payload flag (`test = eventTest(evt) || !born`), and existing
+   pre-birth rows MUST be backfilled to `test=true` (migration `000007`). This keeps the `test` flag
+   accurate so the operator-run `make ada-db-clear-test` is comprehensive during testing.
+2. On the **first** `ada.born` only — detected by the `ada_profile` row being absent before this
+   event — the engine MUST delete **all** rows from the Ada tracking tables (feedings + cascaded
+   children, diapers, sleep, tummy, growth), not only `test=true` rows, then refresh sensors, save
+   the profile, and mark itself born. Deleting everything (rather than keying on the flag) catches
+   both dashboard-stamped test data and out-of-band/API-seeded data that never carried a flag, and is
+   safe because nothing real can predate birth.
+3. The birth clear MUST preserve config/settings tables (`ada_config`, persons/caretakers,
+   channels) — those are configuration the family may have set during validation, not tracking data.
+4. A re-fired `ada.born` (profile already present) MUST be a no-op and MUST NOT clear anything.
+5. After birth, the engine MUST honor the payload flag as before (post-birth real events record
+   `test=false`); the dashboard turns `live_test` off and fires `ada.born` exactly once at birth.
+
+## Consequences
+
+### Positive
+
+* Deterministic clean slate the instant the real birth is recorded — no dependence on the dashboard
+  toggle or operator timing.
+* Pre-birth data is guaranteed selectable/clearable; the `test` flag finally means what it should.
+
+### Negative
+
+* The first-birth clear is destructive and **irreversible** (the engine cannot snapshot). This is
+  acceptable because the data being cleared is, by definition, test data — but an operator who wants
+  to keep a copy of the pre-birth test dataset MUST run `make ada-db-snapshot ENV=prod` before the
+  birth. The `000007` backfill is likewise irreversible (the original `test=false` values are lost).
+* Adds an in-memory `born` flag and a `GetProfile` check at startup to the engine.
+
+### Neutral
+
+* The operator-run `make ada-db-clear-test` remains for clearing test data during ongoing testing;
+  the birth clear is the automatic counterpart for the one-time go-live transition.
+* Extends ADR-0031 (test-data model); the birth event becomes a lifecycle boundary in the data model.

--- a/docs/plans/archived/PLAN-0026-ada-clean-slate-at-birth.md
+++ b/docs/plans/archived/PLAN-0026-ada-clean-slate-at-birth.md
@@ -1,0 +1,69 @@
+# PLAN-0026 - Ada clean slate at birth (ADR-0035)
+
+* **Status:** Complete
+* **Date:** 2026-06-18
+* **Project:** ruby-core
+* **Roadmap Item:** none (go-live readiness; follows ROADMAP-0010)
+* **Branch:** feat/ada-birth-clean-slate
+* **Related ADRs:** ADR-0035, ADR-0031
+
+---
+
+## Scope
+
+Guarantee a clean Ada history at birth: force `test=true` on all pre-birth events, backfill existing
+pre-birth rows, and auto-clear `test=true` data on the first `ada.born`. Out of scope: changing the
+operator-run `make ada-db-clear-test` (kept for ongoing testing); a snapshot inside the birth clear
+(operator runs `make ada-db-snapshot` if they want a pre-birth backup).
+
+## Pre-conditions
+
+* [x] On `feat/ada-birth-clean-slate` (current `origin/main`).
+* [x] Verified: prod has 371 `test=false` pre-birth rows; `ada_profile` empty (real birth not
+      blocked); `ada_born=off`, `ada_live_test=on`.
+
+## Steps
+
+### Step 1 — Backfill migration
+
+**Action:** `000007_backfill_test_flag.up.sql` sets `test = true` on all existing rows of the five
+Ada tables (`WHERE test = false`). `.down.sql` is a no-op (original values are unrecoverable —
+documented).
+**Verification:** on a scratch DB seeded with mixed test flags, after migrate-up all rows are
+`test=true`.
+
+### Step 2 — Force test pre-birth
+
+**Action:** Add an atomic `born` flag to the `Processor`, set in `Initialize` from `GetProfile`
+(born = profile exists). Replace `eventTest(evt)` at every insert site with
+`p.eventTestOrPreBirth(evt)` (`= eventTest(evt) || !born`), threading the bool through
+`insertTummyAndPush`.
+**Verification:** `go build ./...`; new `TestEventTestOrPreBirth` (born=false forces true; born=true
+honors payload).
+
+### Step 3 — Auto-clear on first birth
+
+**Action:** Add per-table `DeleteAll*` (`DELETE FROM <table>`) queries; regenerate sqlc. Rewrite
+`handleBornEvent`: if `GetProfile` returns a row → already born, set `born=true`, return (no clear).
+If absent → `UpsertProfile`, run `clearTracking` (delete ALL tracking rows — not only `test=true`,
+so out-of-band/API-seeded data is also caught; config tables untouched), set `born=true`,
+`refreshAllSensors`. Gated so a re-fired birth never clears.
+**Verification:** build; manual: firing `ada.born` once on a test DB wipes all tracking, keeps
+config, saves the profile; a second `ada.born` is a no-op.
+
+### Step 4 — Docs, build, lint, tests
+
+**Action:** Update `docs/runbooks/ada-test-data.md` (birth clean-slate behavior + pre-birth snapshot
+note). `go build ./...`; `go test -tags=fast ./...`; golangci-lint.
+**Verification:** all green.
+
+## Rollback
+
+Code is a clean revert. The `000007` backfill and the birth clear are **irreversible** data
+operations (by design — the data is test data). Reverting the code after the backfill leaves rows
+`test=true` (harmless). There is no rollback for a birth clear once fired; an operator wanting a
+pre-birth backup runs `make ada-db-snapshot ENV=prod` first.
+
+## Open Questions
+
+None — approach approved (test=true + backfill).

--- a/docs/runbooks/ada-test-data.md
+++ b/docs/runbooks/ada-test-data.md
@@ -62,6 +62,21 @@ Guards: dry-run unless `CONFIRM=yes`; `ENV=prod` additionally prompts for the da
 snapshot is taken before any delete; every statement is `WHERE test = true`, so real data is never
 touched. The prod engine is restarted afterward to recompute sensors.
 
+## Birth clean slate (automatic, ADR-0035)
+
+Pre-birth, the engine **forces `test=true` on every Ada event** (regardless of the dashboard's
+`live_test` toggle), and the `000007` migration backfilled all pre-existing rows to `test=true`.
+This keeps the `test` flag accurate so the operator clear above is comprehensive during testing.
+
+The **first** `ada.born` (when no `ada_profile` row exists yet) automatically **deletes ALL Ada
+tracking data** — feeds, diapers, sleep, tummy, growth — not only `test=true` rows, so it also
+catches any API-seeded data that never carried a flag. **Config is preserved** (caretakers, bedtime/
+boundary, tummy target, alert threshold). Ada's real record starts from a clean slate. A re-fired
+`ada.born` (profile already present) is a no-op and never clears anything.
+
+This clear is **irreversible** and the engine cannot snapshot. If you want to keep a copy of the
+pre-birth test dataset, run `make ada-db-snapshot ENV=prod` **before** confirming the birth.
+
 ## One-time junk purge (pre-existing non-test rows)
 
 Junk created before the `test` column exists is `test = false`, so the clear target will not remove

--- a/services/engine/README.md
+++ b/services/engine/README.md
@@ -22,7 +22,7 @@ Four sensors carry a 24-hour rolling history array as their `entries[]` attribut
 
 When a caregiver claims a due feed (`ada.feeding.claimed`), the engine owns the claim lifecycle: it sets `input_boolean.ada_feeding_claimed` on and projects the claimer to `sensor.ada_feeding_claimed_by`, then clears both when the next feed is completed.
 
-The `ada.born` event persists Ada's birth datetime to the `ada_profile` table. The table is singleton-constrained (at most one row) and idempotent — repeated fires are silently ignored. `birth_at` is stored as a UTC timestamp and is available as a future query boundary for filtering pre-birth data.
+The `ada.born` event persists Ada's birth datetime to the singleton `ada_profile` table. On the **first** birth only (profile previously absent), the engine wipes all pre-birth tracking data — feeds/diapers/sleep/tummy/growth — so Ada's real record starts from a clean slate (ADR-0035); config (caretakers, bedtime, targets) is preserved, and a re-fired `ada.born` is a no-op. Relatedly, while not yet born the engine forces `test=true` on every event so pre-birth data is always selectable as test data regardless of the dashboard toggle.
 
 Recorded events can be corrected or removed via `ada.{feeding,diaper,sleep,tummy,growth}.update` (full-resolution replacement) and `ada.{...}.delete {id}` (soft-delete via `deleted_at`), each recomputing the derived sensors. Every row carries a `test BOOLEAN` marker (ADR-0031): test data behaves identically in every projection but is selectable for bulk teardown by the seed/clear tooling — see [docs/runbooks/ada-test-data.md](../../docs/runbooks/ada-test-data.md).
 

--- a/services/engine/processors/ada/edit_delete.go
+++ b/services/engine/processors/ada/edit_delete.go
@@ -26,6 +26,14 @@ func eventTest(evt schemas.CloudEvent) bool {
 	return t
 }
 
+// eventTestOrPreBirth is the test flag to persist for a new event: the payload flag,
+// OR forced true while Ada is not yet born (ADR-0035) — so every pre-birth event is
+// guaranteed test data regardless of the dashboard's live_test toggle, and the first
+// ada.born clears a complete clean slate.
+func (p *Processor) eventTestOrPreBirth(evt schemas.CloudEvent) bool {
+	return eventTest(evt) || !p.born.Load()
+}
+
 // parseUUID parses a dashboard-supplied id string into a pgtype.UUID.
 func parseUUID(s string) (pgtype.UUID, error) {
 	u, err := uuid.Parse(s)

--- a/services/engine/processors/ada/edit_delete_test.go
+++ b/services/engine/processors/ada/edit_delete_test.go
@@ -8,6 +8,28 @@ import (
 	"github.com/primaryrutabaga/ruby-core/pkg/schemas"
 )
 
+func TestEventTestOrPreBirth(t *testing.T) {
+	var p Processor
+
+	// Pre-birth: every event is forced test, regardless of the payload flag (ADR-0035).
+	p.born.Store(false)
+	if !p.eventTestOrPreBirth(schemas.CloudEvent{Data: map[string]any{}}) {
+		t.Error("pre-birth, no flag: want test=true")
+	}
+	if !p.eventTestOrPreBirth(schemas.CloudEvent{Data: map[string]any{"test": false}}) {
+		t.Error("pre-birth, payload test=false: want test=true (forced)")
+	}
+
+	// Post-birth: honor the payload flag.
+	p.born.Store(true)
+	if p.eventTestOrPreBirth(schemas.CloudEvent{Data: map[string]any{}}) {
+		t.Error("post-birth, no flag: want test=false")
+	}
+	if !p.eventTestOrPreBirth(schemas.CloudEvent{Data: map[string]any{"test": true}}) {
+		t.Error("post-birth, payload test=true: want test=true")
+	}
+}
+
 func TestEventTest(t *testing.T) {
 	cases := []struct {
 		name string

--- a/services/engine/processors/ada/growth.go
+++ b/services/engine/processors/ada/growth.go
@@ -67,7 +67,7 @@ func (p *Processor) handleGrowthLogged(ctx context.Context, evt schemas.CloudEve
 		LengthPct:           numericFromFloatPtr(lengthPct),
 		HeadPct:             numericFromFloatPtr(headPct),
 		LoggedBy:            d.LoggedBy,
-		Test:                eventTest(evt),
+		Test:                p.eventTestOrPreBirth(evt),
 	}); err != nil {
 		return fmt.Errorf("ada: insert growth measurement: %w", err)
 	}

--- a/services/engine/processors/ada/processor.go
+++ b/services/engine/processors/ada/processor.go
@@ -12,6 +12,7 @@ import (
 	"strconv"
 	"strings"
 	"sync"
+	"sync/atomic"
 	"time"
 
 	"github.com/google/uuid"
@@ -101,6 +102,9 @@ type Processor struct {
 	lastFullRefresh time.Time // time of last full sensor restore (for 4h safety net)
 	alertMu         sync.Mutex
 	alertTimer      *time.Timer
+	// born is true once Ada's birth profile exists. While false (pre-birth), every
+	// event is forced test=true; the first ada.born clears the test slate (ADR-0035).
+	born atomic.Bool
 }
 
 // compile-time interface check
@@ -129,6 +133,12 @@ func (p *Processor) Subscriptions() []string {
 func (p *Processor) Initialize(cfg processor.Config) error {
 	p.q = store.New(cfg.Pool)
 	p.pool = cfg.Pool
+
+	// Determine born state from the profile so pre-birth events are forced test=true
+	// (ADR-0035). Any error (incl. no rows) is treated as not-born.
+	if _, err := p.q.GetProfile(context.Background()); err == nil {
+		p.born.Store(true)
+	}
 	p.ha = adaha.NewClient(cfg.HA.URL, cfg.HA.Token, p.log)
 	// Assume HA is connected at startup; gateway.health will correct if not.
 	p.lastHAConnected = true
@@ -309,7 +319,7 @@ func (p *Processor) handleFeedingEnded(ctx context.Context, evt schemas.CloudEve
 		Timestamp: toTimestamptz(sessionStart),
 		Source:    source,
 		LoggedBy:  d.LoggedBy,
-		Test:      eventTest(evt),
+		Test:      p.eventTestOrPreBirth(evt),
 	})
 	if err != nil {
 		return fmt.Errorf("ada: insert feeding_ended: %w", err)
@@ -397,7 +407,7 @@ func (p *Processor) handleFeedingLogged(ctx context.Context, evt schemas.CloudEv
 		Timestamp: toTimestamptz(startTime),
 		Source:    source,
 		LoggedBy:  d.LoggedBy,
-		Test:      eventTest(evt),
+		Test:      p.eventTestOrPreBirth(evt),
 	})
 	if err != nil {
 		return fmt.Errorf("ada: insert feeding_logged: %w", err)
@@ -442,7 +452,7 @@ func (p *Processor) handleFeedingLoggedPast(ctx context.Context, evt schemas.Clo
 		Timestamp: toTimestamptz(startTime),
 		Source:    source,
 		LoggedBy:  d.LoggedBy,
-		Test:      eventTest(evt),
+		Test:      p.eventTestOrPreBirth(evt),
 	})
 	if err != nil {
 		return fmt.Errorf("ada: insert feeding_logged_past: %w", err)
@@ -624,7 +634,7 @@ func (p *Processor) handleDiaperLogged(ctx context.Context, evt schemas.CloudEve
 		Timestamp: toTimestamptz(ts),
 		Type:      d.Type,
 		LoggedBy:  d.LoggedBy,
-		Test:      eventTest(evt),
+		Test:      p.eventTestOrPreBirth(evt),
 	}); err != nil {
 		return fmt.Errorf("ada: insert diaper: %w", err)
 	}
@@ -657,7 +667,7 @@ func (p *Processor) handleSleepStarted(ctx context.Context, evt schemas.CloudEve
 		StartTime: toTimestamptz(startTime),
 		SleepType: sleepType,
 		LoggedBy:  d.LoggedBy,
-		Test:      eventTest(evt),
+		Test:      p.eventTestOrPreBirth(evt),
 	}); err != nil {
 		return fmt.Errorf("ada: insert sleep start: %w", err)
 	}
@@ -712,7 +722,7 @@ func (p *Processor) handleSleepLogged(ctx context.Context, evt schemas.CloudEven
 		EndTime:   toTimestamptz(endTime),
 		SleepType: sleepType,
 		LoggedBy:  d.LoggedBy,
-		Test:      eventTest(evt),
+		Test:      p.eventTestOrPreBirth(evt),
 	}); err != nil {
 		return fmt.Errorf("ada: insert sleep session: %w", err)
 	}
@@ -728,7 +738,7 @@ func (p *Processor) handleTummyEnded(ctx context.Context, evt schemas.CloudEvent
 	if err := remarshal(evt.Data, &d); err != nil {
 		return fmt.Errorf("ada: decode tummy_ended: %w", err)
 	}
-	return p.insertTummyAndPush(ctx, d.StartTime, d.EndTime, d.DurationS, d.LoggedBy, eventTest(evt))
+	return p.insertTummyAndPush(ctx, d.StartTime, d.EndTime, d.DurationS, d.LoggedBy, p.eventTestOrPreBirth(evt))
 }
 
 func (p *Processor) handleTummyLogged(ctx context.Context, evt schemas.CloudEvent) error {
@@ -736,7 +746,7 @@ func (p *Processor) handleTummyLogged(ctx context.Context, evt schemas.CloudEven
 	if err := remarshal(evt.Data, &d); err != nil {
 		return fmt.Errorf("ada: decode tummy_logged: %w", err)
 	}
-	return p.insertTummyAndPush(ctx, d.StartTime, d.EndTime, d.DurationS, d.LoggedBy, eventTest(evt))
+	return p.insertTummyAndPush(ctx, d.StartTime, d.EndTime, d.DurationS, d.LoggedBy, p.eventTestOrPreBirth(evt))
 }
 
 func (p *Processor) insertTummyAndPush(ctx context.Context, startStr, endStr string, durationS int, loggedBy string, test bool) error {
@@ -777,15 +787,59 @@ func (p *Processor) handleBornEvent(ctx context.Context, evt schemas.CloudEvent)
 		return fmt.Errorf("ada: parse birth_at %q: %w", d.BirthAt, err)
 	}
 
+	// First-birth gate: if a profile already exists this is a re-fire — already born,
+	// never clear (ADR-0035). Only the absent→set transition triggers the clean slate.
+	if _, err := p.q.GetProfile(ctx); err == nil {
+		p.born.Store(true)
+		p.log.Info("ada: born event ignored — already born")
+		return nil
+	} else if !errors.Is(err, pgx.ErrNoRows) {
+		return fmt.Errorf("ada: check profile for born: %w", err)
+	}
+
 	if err := p.q.UpsertProfile(ctx, toTimestamptz(birthAt)); err != nil {
 		return fmt.Errorf("ada: upsert profile: %w", err)
 	}
 
-	p.log.Info("ada: birth profile saved",
+	// Clean slate: wipe ALL pre-birth tracking data — nothing real can predate birth,
+	// so this is safe and catches both dashboard test data and API-seeded data that
+	// never carried a test flag (ADR-0035). Config (caretakers, bedtime, targets) is
+	// kept; the first-birth gate above means this only ever runs pre-birth.
+	cleared := p.clearTracking(ctx)
+	p.born.Store(true)
+	p.refreshAllSensors(ctx)
+
+	p.log.Info("ada: birth recorded — pre-birth tracking cleared, clean slate",
 		slog.String("birth_at", birthAt.UTC().Format(time.RFC3339)),
 		slog.String("logged_by", d.LoggedBy),
+		slog.Bool("tracking_cleared", cleared),
 	)
 	return nil
+}
+
+// clearTracking hard-deletes all rows from the Ada tracking tables (feeding children
+// cascade). Config tables are untouched. Each table is best-effort: a failure is
+// logged and the rest proceed, so a single error never blocks recording the birth.
+// Returns whether all deletes succeeded.
+func (p *Processor) clearTracking(ctx context.Context) bool {
+	ok := true
+	deletes := []struct {
+		name string
+		fn   func(context.Context) error
+	}{
+		{"feedings", p.q.DeleteAllFeedings},
+		{"diapers", p.q.DeleteAllDiapers},
+		{"sleep", p.q.DeleteAllSleep},
+		{"tummy", p.q.DeleteAllTummy},
+		{"growth", p.q.DeleteAllGrowth},
+	}
+	for _, dl := range deletes {
+		if err := dl.fn(ctx); err != nil {
+			ok = false
+			p.log.Warn("ada: clear tracking failed", slog.String("table", dl.name), slog.String("error", err.Error()))
+		}
+	}
+	return ok
 }
 
 // ── People and channel handlers ───────────────────────────────────────────────

--- a/services/engine/processors/ada/store/diapers.sql.go
+++ b/services/engine/processors/ada/store/diapers.sql.go
@@ -11,6 +11,15 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const deleteAllDiapers = `-- name: DeleteAllDiapers :exec
+DELETE FROM diapers
+`
+
+func (q *Queries) DeleteAllDiapers(ctx context.Context) error {
+	_, err := q.db.Exec(ctx, deleteAllDiapers)
+	return err
+}
+
 const getLastDiaper = `-- name: GetLastDiaper :one
 SELECT timestamp, type FROM diapers
 WHERE deleted_at IS NULL

--- a/services/engine/processors/ada/store/feedings.sql.go
+++ b/services/engine/processors/ada/store/feedings.sql.go
@@ -41,6 +41,17 @@ func (q *Queries) AddFeedingBottleDetailAmounts(ctx context.Context, arg *AddFee
 	return err
 }
 
+const deleteAllFeedings = `-- name: DeleteAllFeedings :exec
+DELETE FROM feedings
+`
+
+// Hard-delete every feeding (children cascade). Used by the first ada.born to
+// clear the pre-birth slate (ADR-0035), and selectable for ongoing test teardown.
+func (q *Queries) DeleteAllFeedings(ctx context.Context) error {
+	_, err := q.db.Exec(ctx, deleteAllFeedings)
+	return err
+}
+
 const deleteFeedingBottleDetail = `-- name: DeleteFeedingBottleDetail :exec
 DELETE FROM feeding_bottle_detail WHERE feeding_id = $1
 `

--- a/services/engine/processors/ada/store/growth.sql.go
+++ b/services/engine/processors/ada/store/growth.sql.go
@@ -11,6 +11,15 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const deleteAllGrowth = `-- name: DeleteAllGrowth :exec
+DELETE FROM growth_measurements
+`
+
+func (q *Queries) DeleteAllGrowth(ctx context.Context) error {
+	_, err := q.db.Exec(ctx, deleteAllGrowth)
+	return err
+}
+
 const getAllGrowthMeasurements = `-- name: GetAllGrowthMeasurements :many
 SELECT id, measured_at, weight_oz, length_in, head_circumference_in,
        source, weight_pct, length_pct, head_pct, logged_by

--- a/services/engine/processors/ada/store/migrations/000007_backfill_test_flag.down.sql
+++ b/services/engine/processors/ada/store/migrations/000007_backfill_test_flag.down.sql
@@ -1,0 +1,4 @@
+-- No-op: the 000007 backfill is irreversible — the original test=false values were
+-- not retained, so they cannot be restored. The test column itself is dropped by the
+-- 000006 down migration.
+SELECT 1;

--- a/services/engine/processors/ada/store/migrations/000007_backfill_test_flag.up.sql
+++ b/services/engine/processors/ada/store/migrations/000007_backfill_test_flag.up.sql
@@ -1,0 +1,10 @@
+-- Backfill: flag all existing Ada rows as test data (ADR-0035).
+-- Pre-birth, every Ada event is test data by definition, but rows written before
+-- the test marker was reliably stamped landed test=false. This one-time backfill
+-- marks them test=true so the first ada.born clears a complete clean slate.
+-- Irreversible: original test=false values are not recoverable (down is a no-op).
+UPDATE feedings            SET test = true WHERE test = false;
+UPDATE diapers             SET test = true WHERE test = false;
+UPDATE sleep_sessions      SET test = true WHERE test = false;
+UPDATE tummy_time_sessions SET test = true WHERE test = false;
+UPDATE growth_measurements SET test = true WHERE test = false;

--- a/services/engine/processors/ada/store/queries/diapers.sql
+++ b/services/engine/processors/ada/store/queries/diapers.sql
@@ -32,3 +32,6 @@ WHERE id = @id AND deleted_at IS NULL;
 
 -- name: SoftDeleteDiaper :exec
 UPDATE diapers SET deleted_at = NOW() WHERE id = @id AND deleted_at IS NULL;
+
+-- name: DeleteAllDiapers :exec
+DELETE FROM diapers;

--- a/services/engine/processors/ada/store/queries/feedings.sql
+++ b/services/engine/processors/ada/store/queries/feedings.sql
@@ -90,3 +90,8 @@ FROM feedings f
 LEFT JOIN feeding_bottle_detail d ON d.feeding_id = f.id
 WHERE f.deleted_at IS NULL
   AND f.timestamp >= @boundary;
+
+-- name: DeleteAllFeedings :exec
+-- Hard-delete every feeding (children cascade). Used by the first ada.born to
+-- clear the pre-birth slate (ADR-0035), and selectable for ongoing test teardown.
+DELETE FROM feedings;

--- a/services/engine/processors/ada/store/queries/growth.sql
+++ b/services/engine/processors/ada/store/queries/growth.sql
@@ -43,3 +43,6 @@ WHERE id = $1 AND deleted_at IS NULL;
 
 -- name: SoftDeleteGrowthMeasurement :exec
 UPDATE growth_measurements SET deleted_at = NOW() WHERE id = $1 AND deleted_at IS NULL;
+
+-- name: DeleteAllGrowth :exec
+DELETE FROM growth_measurements;

--- a/services/engine/processors/ada/store/queries/sleep.sql
+++ b/services/engine/processors/ada/store/queries/sleep.sql
@@ -72,3 +72,6 @@ WHERE id = @id AND deleted_at IS NULL;
 
 -- name: SoftDeleteSleepSession :exec
 UPDATE sleep_sessions SET deleted_at = NOW() WHERE id = @id AND deleted_at IS NULL;
+
+-- name: DeleteAllSleep :exec
+DELETE FROM sleep_sessions;

--- a/services/engine/processors/ada/store/queries/tummy.sql
+++ b/services/engine/processors/ada/store/queries/tummy.sql
@@ -26,3 +26,6 @@ WHERE id = @id AND deleted_at IS NULL;
 
 -- name: SoftDeleteTummySession :exec
 UPDATE tummy_time_sessions SET deleted_at = NOW() WHERE id = @id AND deleted_at IS NULL;
+
+-- name: DeleteAllTummy :exec
+DELETE FROM tummy_time_sessions;

--- a/services/engine/processors/ada/store/sleep.sql.go
+++ b/services/engine/processors/ada/store/sleep.sql.go
@@ -11,6 +11,15 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const deleteAllSleep = `-- name: DeleteAllSleep :exec
+DELETE FROM sleep_sessions
+`
+
+func (q *Queries) DeleteAllSleep(ctx context.Context) error {
+	_, err := q.db.Exec(ctx, deleteAllSleep)
+	return err
+}
+
 const getActiveSleepSession = `-- name: GetActiveSleepSession :one
 SELECT start_time FROM sleep_sessions
 WHERE end_time IS NULL AND deleted_at IS NULL

--- a/services/engine/processors/ada/store/tummy.sql.go
+++ b/services/engine/processors/ada/store/tummy.sql.go
@@ -11,6 +11,15 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const deleteAllTummy = `-- name: DeleteAllTummy :exec
+DELETE FROM tummy_time_sessions
+`
+
+func (q *Queries) DeleteAllTummy(ctx context.Context) error {
+	_, err := q.db.Exec(ctx, deleteAllTummy)
+	return err
+}
+
 const getLast24hTummy = `-- name: GetLast24hTummy :many
 SELECT id, start_time, end_time, duration_s, logged_by
 FROM tummy_time_sessions


### PR DESCRIPTION
## Summary

Guarantees a clean Ada history at birth (go-live readiness). Implements ADR-0035.

Prompted by a pre-go-live audit: of 374 prod Ada events, **371 were flagged `test=false`** (the dashboard `test:true` stamping had only just been switched on), plus out-of-band/API-seeded data (a WHO growth channel, verification events) that never carried a flag. And `ada.born` only saved the birth profile — no teardown. So the accumulated pre-birth validation data would have bled into Ada's real record.

## Change

- **Force `test=true` pre-birth.** While not-yet-born (no `ada_profile` row), the engine flags every event `test=true` regardless of the payload (`eventTestOrPreBirth`). Migration `000007` backfills the existing rows. This keeps the `test` flag accurate so the operator-run `make ada-db-clear-test` is comprehensive during testing.
- **Wipe all tracking on first birth.** `handleBornEvent`, on the *first* birth only (profile absent → set), hard-deletes **all** Ada tracking data — feeds/diapers/sleep/tummy/growth (feeding children cascade) — not only `test=true` rows, so API-seeded data is caught too. Then refreshes sensors and marks born. **Config (caretakers, bedtime/boundary, targets) is preserved.** A re-fired `ada.born` is a no-op and never clears.

The birth handler does not read any test flag on the `ada.born` event itself — it gates on the profile row and parses `birth_at` — so the birth signal can never be swept or ignored.

## Test plan

- `go build ./...`, `go test -tags=fast ./...` — green; golangci-lint 0 issues; `pre-commit run --all-files` clean.
- Migration `000007` validated on a scratch DB (a `test=false` row flips to `test=true`).
- Birth clear validated on a scratch DB: both a `test=true` and a `test=false`/API row were wiped; an `ada_config` row survived.
- `eventTestOrPreBirth` unit-tested (pre-birth forces true; post-birth honors payload).

## Deploy / go-live notes

- On the next release, migration `000007` backfills prod on engine startup (flags all current Ada rows `test=true`); pre-birth events are then forced test.
- The birth clear and the backfill are **irreversible** (the engine cannot snapshot). To keep a copy of the pre-birth test dataset, run `make ada-db-snapshot ENV=prod` before this deploys / before the birth.

## Consumer (homeassistant) — confirmed contract

The dashboard fires `ada.born {birth_at, logged_by}` (no test flag) once from the real countdown, and turns `input_boolean.ada_live_test` off at birth. "She's here!" is countdown-only-reachable, so it cannot fire in test mode. An optional defensive `test:false` stamp on `ada.born` is harmless but not required (the engine ignores the flag on that event).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
