### PR TITLE
feat(ada): medication dose events + history/edit-delete (ROADMAP-0011.2)

### DIFF
--- a/pkg/schemas/ada.go
+++ b/pkg/schemas/ada.go
@@ -42,6 +42,15 @@ const (
 	AdaEventMedicationDelete        = "ha.events.ada.medication_delete"
 	AdaEventMedicationRoutineUpsert = "ha.events.ada.medication_routine_upsert"
 	AdaEventMedicationRoutineDelete = "ha.events.ada.medication_routine_delete"
+
+	// Dose events + temporary series (effort 0011.2). given/skipped are
+	// caregiver-logged doses; series start/end bracket an as-needed watch.
+	AdaEventMedicationGiven       = "ha.events.ada.medication_given"
+	AdaEventMedicationSkipped     = "ha.events.ada.medication_skipped"
+	AdaEventMedicationSeriesStart = "ha.events.ada.medication_series_start"
+	AdaEventMedicationSeriesEnd   = "ha.events.ada.medication_series_end"
+	AdaEventMedicationEventUpdate = "ha.events.ada.medication_event_update"
+	AdaEventMedicationEventDelete = "ha.events.ada.medication_event_delete"
 )
 
 // AdaDeleteData is the payload for every ada.<area>.delete event — a single id.
@@ -85,6 +94,52 @@ type AdaMedicationRoutineUpsertData struct {
 	End           AdaRoutineEnd `json:"end"`
 	Status        string        `json:"status"` // active|completed
 	LoggedBy      string        `json:"logged_by,omitempty"`
+}
+
+// AdaMedicationEventData is the dose-event payload (ada.medication.given / skipped) —
+// the full MedEvent. Only `given` carries the dose snapshot; `skipped` carries none.
+// Actor is the caregiver (== logged_by); system-emitted `missed` rows are actorless.
+type AdaMedicationEventData struct {
+	ID                   string   `json:"id"`
+	MedicationID         string   `json:"medication_id"`
+	Status               string   `json:"status"` // given|skipped
+	Timestamp            string   `json:"timestamp"`
+	RoutineID            string   `json:"routine_id,omitempty"`
+	SlotTime             string   `json:"slot_time,omitempty"`
+	Actor                string   `json:"actor,omitempty"`
+	DoseAmount           *float64 `json:"dose_amount,omitempty"`
+	DoseUnit             string   `json:"dose_unit,omitempty"`
+	Source               string   `json:"source,omitempty"` // scheduled|prn
+	WithinWindowOverride bool     `json:"within_window_override,omitempty"`
+	SeriesID             string   `json:"series_id,omitempty"`
+	StartedWatch         bool     `json:"started_watch,omitempty"`
+	Notes                string   `json:"notes,omitempty"`
+	LoggedBy             string   `json:"logged_by,omitempty"`
+}
+
+// AdaMedicationSeriesStartData opens an as-needed watch anchored to a given dose.
+type AdaMedicationSeriesStartData struct {
+	ID            string  `json:"id"`
+	MedicationID  string  `json:"medication_id"`
+	IntervalHours float64 `json:"interval_hours"`
+	AnchorDoseID  string  `json:"anchor_dose_id"`
+	LoggedBy      string  `json:"logged_by,omitempty"`
+}
+
+// AdaMedicationSeriesEndData closes a watch. EndedReason ∈ planned | dismissed.
+type AdaMedicationSeriesEndData struct {
+	ID           string `json:"id"`
+	MedicationID string `json:"medication_id"`
+	EndedReason  string `json:"ended_reason"`
+	LoggedBy     string `json:"logged_by,omitempty"`
+}
+
+// AdaMedicationEventUpdateData is a history dose correction (timestamp + amount).
+type AdaMedicationEventUpdateData struct {
+	ID         string   `json:"id"`
+	Timestamp  string   `json:"timestamp"`
+	DoseAmount *float64 `json:"dose_amount"`
+	LoggedBy   string   `json:"logged_by,omitempty"`
 }
 
 // AdaFeedingUpdateData is the full-resolution replacement payload for a feeding (#79).

--- a/services/engine/processors/ada/med_events.go
+++ b/services/engine/processors/ada/med_events.go
@@ -1,0 +1,238 @@
+package ada
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"strconv"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/primaryrutabaga/ruby-core/pkg/schemas"
+	"github.com/primaryrutabaga/ruby-core/services/engine/processors/ada/store"
+)
+
+// Medication dose events + temporary series (ROADMAP-0011 effort 0011.2, ADR-0037).
+// Dose events are TRACKING: they use eventTestOrPreBirth(evt), so all pre-birth
+// practice doses are test=true and wiped at birth. given/skipped are
+// caregiver-logged; system-emitted `missed` arrives in effort 0011.3.
+
+const (
+	sensorMedEvents = "sensor.ada_med_events"
+	// medEventsWindow bounds the projected event history. 7 days comfortably
+	// covers today's timeline plus any guard-relevant last dose (min-interval is
+	// hours, never days) without projecting unbounded history.
+	medEventsWindow = 7 * 24 * time.Hour
+)
+
+// handleMedicationEvent persists a given/skipped dose. The dose snapshot
+// (dose_amount + dose_unit) records what was actually administered.
+func (p *Processor) handleMedicationEvent(ctx context.Context, evt schemas.CloudEvent) error {
+	var d schemas.AdaMedicationEventData
+	if err := remarshal(evt.Data, &d); err != nil {
+		return fmt.Errorf("ada: decode medication event: %w", err)
+	}
+	if d.ID == "" || d.MedicationID == "" {
+		return fmt.Errorf("ada: medication event missing id/medication_id")
+	}
+	ts, err := parseRFC3339(d.Timestamp)
+	if err != nil {
+		return fmt.Errorf("ada: parse medication event timestamp: %w", err)
+	}
+	status := d.Status
+	if status == "" { // fall back to the event type if the payload omitted it
+		if evt.Type == schemas.AdaEventMedicationSkipped {
+			status = "skipped"
+		} else {
+			status = "given"
+		}
+	}
+	actor := d.Actor
+	if actor == "" {
+		actor = d.LoggedBy
+	}
+	if err := p.q.InsertMedicationEvent(ctx, &store.InsertMedicationEventParams{
+		ID:                   d.ID,
+		MedicationID:         d.MedicationID,
+		Status:               status,
+		Timestamp:            toTimestamptz(ts),
+		RoutineID:            textFromString(d.RoutineID),
+		SlotTime:             textFromString(d.SlotTime),
+		DoseAmount:           numericFromFloatPtr(d.DoseAmount),
+		DoseUnit:             textFromString(d.DoseUnit),
+		Source:               textFromString(d.Source),
+		WithinWindowOverride: d.WithinWindowOverride,
+		SeriesID:             textFromString(d.SeriesID),
+		StartedWatch:         d.StartedWatch,
+		Notes:                textFromString(d.Notes),
+		LoggedBy:             actor,
+		Test:                 p.eventTestOrPreBirth(evt),
+	}); err != nil {
+		return fmt.Errorf("ada: insert medication event: %w", err)
+	}
+	p.pushMedEventsSensor(ctx)
+	return nil
+}
+
+// handleMedicationSeriesStart opens an as-needed watch anchored to a given dose.
+func (p *Processor) handleMedicationSeriesStart(ctx context.Context, evt schemas.CloudEvent) error {
+	var d schemas.AdaMedicationSeriesStartData
+	if err := remarshal(evt.Data, &d); err != nil {
+		return fmt.Errorf("ada: decode medication_series_start: %w", err)
+	}
+	if d.ID == "" || d.MedicationID == "" {
+		return fmt.Errorf("ada: medication_series_start missing id/medication_id")
+	}
+	if err := p.q.InsertMedicationSeries(ctx, &store.InsertMedicationSeriesParams{
+		ID:            d.ID,
+		MedicationID:  d.MedicationID,
+		IntervalHours: numericFromFloat(d.IntervalHours),
+		AnchorDoseID:  textFromString(d.AnchorDoseID),
+		LoggedBy:      d.LoggedBy,
+		Test:          p.eventTestOrPreBirth(evt),
+	}); err != nil {
+		return fmt.Errorf("ada: insert medication series: %w", err)
+	}
+	p.pushMedEventsSensor(ctx)
+	return nil
+}
+
+// handleMedicationSeriesEnd closes a watch: planned → resolved, dismissed → disregarded.
+func (p *Processor) handleMedicationSeriesEnd(ctx context.Context, evt schemas.CloudEvent) error {
+	var d schemas.AdaMedicationSeriesEndData
+	if err := remarshal(evt.Data, &d); err != nil {
+		return fmt.Errorf("ada: decode medication_series_end: %w", err)
+	}
+	status := "resolved"
+	if d.EndedReason == "dismissed" {
+		status = "disregarded"
+	}
+	if err := p.q.EndMedicationSeries(ctx, &store.EndMedicationSeriesParams{
+		ID:          d.ID,
+		Status:      status,
+		EndedReason: textFromString(d.EndedReason),
+	}); err != nil {
+		return fmt.Errorf("ada: end medication series: %w", err)
+	}
+	p.pushMedEventsSensor(ctx)
+	return nil
+}
+
+// handleMedEventUpdate corrects a logged dose (timestamp + amount); identity and
+// the rest of the snapshot are immutable.
+func (p *Processor) handleMedEventUpdate(ctx context.Context, evt schemas.CloudEvent) error {
+	var d schemas.AdaMedicationEventUpdateData
+	if err := remarshal(evt.Data, &d); err != nil {
+		return fmt.Errorf("ada: decode medication_event_update: %w", err)
+	}
+	ts, err := parseRFC3339(d.Timestamp)
+	if err != nil {
+		return fmt.Errorf("ada: parse medication_event_update timestamp: %w", err)
+	}
+	if err := p.q.UpdateMedicationEvent(ctx, &store.UpdateMedicationEventParams{
+		ID:         d.ID,
+		Timestamp:  toTimestamptz(ts),
+		DoseAmount: numericFromFloatPtr(d.DoseAmount),
+	}); err != nil {
+		return fmt.Errorf("ada: update medication event: %w", err)
+	}
+	p.pushMedEventsSensor(ctx)
+	return nil
+}
+
+// handleMedEventDelete soft-deletes a logged dose.
+func (p *Processor) handleMedEventDelete(ctx context.Context, evt schemas.CloudEvent) error {
+	var d schemas.AdaDeleteData
+	if err := remarshal(evt.Data, &d); err != nil {
+		return fmt.Errorf("ada: decode medication_event_delete: %w", err)
+	}
+	if err := p.q.SoftDeleteMedicationEvent(ctx, d.ID); err != nil {
+		return fmt.Errorf("ada: soft-delete medication event: %w", err)
+	}
+	p.pushMedEventsSensor(ctx)
+	return nil
+}
+
+// ── Projection ────────────────────────────────────────────────────────────────
+
+// medEventItem mirrors the adaMeds.ts MedEvent type (logged_by surfaces as `actor`).
+type medEventItem struct {
+	ID                   string   `json:"id"`
+	MedicationID         string   `json:"medication_id"`
+	Status               string   `json:"status"`
+	Timestamp            string   `json:"timestamp"`
+	RoutineID            string   `json:"routine_id,omitempty"`
+	SlotTime             string   `json:"slot_time,omitempty"`
+	Actor                string   `json:"actor,omitempty"`
+	DoseAmount           *float64 `json:"dose_amount,omitempty"`
+	DoseUnit             string   `json:"dose_unit,omitempty"`
+	Source               string   `json:"source,omitempty"`
+	WithinWindowOverride bool     `json:"within_window_override,omitempty"`
+	SeriesID             string   `json:"series_id,omitempty"`
+	StartedWatch         bool     `json:"started_watch,omitempty"`
+}
+
+// seriesItem mirrors the adaMeds.ts TemporarySeries type. Carried as the `series`
+// attribute on sensor.ada_med_events (no dedicated series sensor in the contract).
+type seriesItem struct {
+	ID            string  `json:"id"`
+	MedicationID  string  `json:"medication_id"`
+	IntervalHours float64 `json:"interval_hours"`
+	AnchorDoseID  string  `json:"anchor_dose_id"`
+	Status        string  `json:"status"`
+}
+
+// pushMedEventsSensor projects the recent dose events + active watches to
+// sensor.ada_med_events. No-op when HA push is disabled (ADR-0033).
+func (p *Processor) pushMedEventsSensor(ctx context.Context) {
+	since := pgtype.Timestamptz{Time: time.Now().UTC().Add(-medEventsWindow), Valid: true}
+	rows, err := p.q.ListRecentMedicationEvents(ctx, since)
+	if err != nil {
+		p.log.Warn("ada: list medication events", slog.String("error", err.Error()))
+		return
+	}
+	items := make([]medEventItem, 0, len(rows))
+	for _, r := range rows {
+		items = append(items, medEventItem{
+			ID:                   r.ID,
+			MedicationID:         r.MedicationID,
+			Status:               r.Status,
+			Timestamp:            r.Timestamp.Time.UTC().Format(time.RFC3339),
+			RoutineID:            r.RoutineID.String,
+			SlotTime:             r.SlotTime.String,
+			Actor:                r.LoggedBy,
+			DoseAmount:           numericToFloatPtr(r.DoseAmount),
+			DoseUnit:             r.DoseUnit.String,
+			Source:               r.Source.String,
+			WithinWindowOverride: r.WithinWindowOverride,
+			SeriesID:             r.SeriesID.String,
+			StartedWatch:         r.StartedWatch,
+		})
+	}
+
+	seriesRows, err := p.q.ListActiveMedicationSeries(ctx)
+	if err != nil {
+		p.log.Warn("ada: list active medication series", slog.String("error", err.Error()))
+		seriesRows = nil
+	}
+	series := make([]seriesItem, 0, len(seriesRows))
+	for _, s := range seriesRows {
+		series = append(series, seriesItem{
+			ID:            s.ID,
+			MedicationID:  s.MedicationID,
+			IntervalHours: numericToFloat(s.IntervalHours),
+			AnchorDoseID:  s.AnchorDoseID.String,
+			Status:        s.Status,
+		})
+	}
+
+	attrs := map[string]any{
+		"items":        items,
+		"series":       series,
+		"last_updated": time.Now().UTC().Format(time.RFC3339),
+	}
+	if err := p.ha.PushState(ctx, sensorMedEvents, strconv.Itoa(len(items)), attrs); err != nil {
+		p.log.Warn("ada: push medication events", slog.String("error", err.Error()))
+	}
+}

--- a/services/engine/processors/ada/medications.go
+++ b/services/engine/processors/ada/medications.go
@@ -7,7 +7,6 @@ import (
 	"strconv"
 	"time"
 
-	"github.com/google/uuid"
 	"github.com/jackc/pgx/v5/pgtype"
 
 	"github.com/primaryrutabaga/ruby-core/pkg/schemas"
@@ -17,7 +16,9 @@ import (
 // Medication registry + dosing routines (ROADMAP-0011 effort 0011.1, ADR-0037).
 // Registry and routines are standing config: they use eventTest(evt) only (no
 // pre-birth forcing), so a real entry made before birth survives the clean-slate.
-// Dose events, computations, and emergency land in later efforts.
+//
+// ids are dashboard-provided strings (m-/rt-/... prefixed), not UUIDs — the
+// dashboard is the id authority, so the engine stores them verbatim.
 
 const (
 	sensorMedications = "sensor.ada_medications"
@@ -30,12 +31,11 @@ func (p *Processor) handleMedicationUpsert(ctx context.Context, evt schemas.Clou
 	if err := remarshal(evt.Data, &d); err != nil {
 		return fmt.Errorf("ada: decode medication_upsert: %w", err)
 	}
-	id, err := parseUUID(d.ID)
-	if err != nil {
-		return fmt.Errorf("ada: medication_upsert id: %w", err)
+	if d.ID == "" {
+		return fmt.Errorf("ada: medication_upsert missing id")
 	}
 	if err := p.q.UpsertMedication(ctx, &store.UpsertMedicationParams{
-		ID:               id,
+		ID:               d.ID,
 		Name:             d.Name,
 		Route:            d.Route,
 		MeasureUnit:      d.MeasureUnit,
@@ -54,9 +54,9 @@ func (p *Processor) handleMedicationUpsert(ctx context.Context, evt schemas.Clou
 // handleMedicationDelete soft-deletes a medication and cascades to its routines
 // and any active series in one transaction (app-level cascade, ADR-0037 #2).
 func (p *Processor) handleMedicationDelete(ctx context.Context, evt schemas.CloudEvent) error {
-	id, err := p.decodeDeleteID(evt, "medication")
-	if err != nil {
-		return err
+	var d schemas.AdaDeleteData
+	if err := remarshal(evt.Data, &d); err != nil {
+		return fmt.Errorf("ada: decode medication_delete: %w", err)
 	}
 	tx, err := p.pool.Begin(ctx)
 	if err != nil {
@@ -64,13 +64,13 @@ func (p *Processor) handleMedicationDelete(ctx context.Context, evt schemas.Clou
 	}
 	defer func() { _ = tx.Rollback(ctx) }()
 	qtx := p.q.WithTx(tx)
-	if err := qtx.SoftDeleteMedication(ctx, id); err != nil {
+	if err := qtx.SoftDeleteMedication(ctx, d.ID); err != nil {
 		return fmt.Errorf("ada: soft-delete medication: %w", err)
 	}
-	if err := qtx.SoftDeleteRoutinesForMedication(ctx, id); err != nil {
+	if err := qtx.SoftDeleteRoutinesForMedication(ctx, d.ID); err != nil {
 		return fmt.Errorf("ada: soft-delete medication routines: %w", err)
 	}
-	if err := qtx.SoftDeleteSeriesForMedication(ctx, id); err != nil {
+	if err := qtx.SoftDeleteSeriesForMedication(ctx, d.ID); err != nil {
 		return fmt.Errorf("ada: soft-delete medication series: %w", err)
 	}
 	if err := tx.Commit(ctx); err != nil {
@@ -86,13 +86,8 @@ func (p *Processor) handleMedicationRoutineUpsert(ctx context.Context, evt schem
 	if err := remarshal(evt.Data, &d); err != nil {
 		return fmt.Errorf("ada: decode medication_routine_upsert: %w", err)
 	}
-	id, err := parseUUID(d.ID)
-	if err != nil {
-		return fmt.Errorf("ada: routine id: %w", err)
-	}
-	medID, err := parseUUID(d.MedicationID)
-	if err != nil {
-		return fmt.Errorf("ada: routine medication_id: %w", err)
+	if d.ID == "" || d.MedicationID == "" {
+		return fmt.Errorf("ada: medication_routine_upsert missing id/medication_id")
 	}
 	fixedTimes := d.FixedTimes
 	if fixedTimes == nil {
@@ -107,8 +102,8 @@ func (p *Processor) handleMedicationRoutineUpsert(ctx context.Context, evt schem
 		status = "active"
 	}
 	if err := p.q.UpsertMedicationRoutine(ctx, &store.UpsertMedicationRoutineParams{
-		ID:            id,
-		MedicationID:  medID,
+		ID:            d.ID,
+		MedicationID:  d.MedicationID,
 		DoseAmount:    numericFromFloat(d.DoseAmount),
 		ScheduleType:  d.ScheduleType,
 		FixedTimes:    fixedTimes,
@@ -127,11 +122,11 @@ func (p *Processor) handleMedicationRoutineUpsert(ctx context.Context, evt schem
 
 // handleMedicationRoutineDelete soft-deletes a single routine.
 func (p *Processor) handleMedicationRoutineDelete(ctx context.Context, evt schemas.CloudEvent) error {
-	id, err := p.decodeDeleteID(evt, "medication_routine")
-	if err != nil {
-		return err
+	var d schemas.AdaDeleteData
+	if err := remarshal(evt.Data, &d); err != nil {
+		return fmt.Errorf("ada: decode medication_routine_delete: %w", err)
 	}
-	if err := p.q.SoftDeleteRoutine(ctx, id); err != nil {
+	if err := p.q.SoftDeleteRoutine(ctx, d.ID); err != nil {
 		return fmt.Errorf("ada: soft-delete medication routine: %w", err)
 	}
 	p.pushMedicationSensors(ctx)
@@ -187,7 +182,7 @@ func (p *Processor) pushMedications(ctx context.Context) {
 	items := make([]medicationItem, 0, len(rows))
 	for _, r := range rows {
 		items = append(items, medicationItem{
-			ID:               uuid.UUID(r.ID.Bytes).String(),
+			ID:               r.ID,
 			Name:             r.Name,
 			Route:            r.Route,
 			MeasureUnit:      r.MeasureUnit,
@@ -215,8 +210,8 @@ func (p *Processor) pushMedRoutines(ctx context.Context) {
 			ft = []string{}
 		}
 		items = append(items, routineItem{
-			ID:            uuid.UUID(r.ID.Bytes).String(),
-			MedicationID:  uuid.UUID(r.MedicationID.Bytes).String(),
+			ID:            r.ID,
+			MedicationID:  r.MedicationID,
 			DoseAmount:    numericToFloat(r.DoseAmount),
 			ScheduleType:  r.ScheduleType,
 			FixedTimes:    ft,

--- a/services/engine/processors/ada/medications_test.go
+++ b/services/engine/processors/ada/medications_test.go
@@ -74,6 +74,41 @@ func TestRoutineUpsertDecode(t *testing.T) {
 	}
 }
 
+// A `given` dose carries the full MedEvent incl. the dose snapshot; a `skipped`
+// one carries no dose. Optional fields must round-trip, dose_amount as nullable.
+func TestMedicationEventDecode(t *testing.T) {
+	var given schemas.AdaMedicationEventData
+	if err := remarshal(map[string]any{
+		"id": "ev-1718900000000", "medication_id": "m-1", "status": "given",
+		"timestamp": "2026-06-20T16:00:00Z", "actor": "Katie",
+		"dose_amount": 1.25, "dose_unit": "mL", "source": "prn",
+		"series_id": "s-1", "started_watch": true,
+	}, &given); err != nil {
+		t.Fatalf("remarshal given: %v", err)
+	}
+	if given.Status != "given" || given.DoseAmount == nil || *given.DoseAmount != 1.25 {
+		t.Errorf("given decode wrong: status=%q dose=%v", given.Status, given.DoseAmount)
+	}
+	if given.Source != "prn" || given.SeriesID != "s-1" || !given.StartedWatch {
+		t.Errorf("given optional fields wrong: %+v", given)
+	}
+
+	var skipped schemas.AdaMedicationEventData
+	if err := remarshal(map[string]any{
+		"id": "ev-2", "medication_id": "m-1", "status": "skipped",
+		"timestamp": "2026-06-20T18:00:00Z", "actor": "Michael",
+		"routine_id": "rt-1", "slot_time": "18:00",
+	}, &skipped); err != nil {
+		t.Fatalf("remarshal skipped: %v", err)
+	}
+	if skipped.Status != "skipped" || skipped.DoseAmount != nil {
+		t.Errorf("skipped should carry no dose: %+v", skipped)
+	}
+	if skipped.RoutineID != "rt-1" || skipped.SlotTime != "18:00" {
+		t.Errorf("skipped slot fields wrong: %+v", skipped)
+	}
+}
+
 // A medication's nullable safety limits must decode as nil (no limit), never zero.
 func TestMedicationUpsertNullableLimits(t *testing.T) {
 	var d schemas.AdaMedicationUpsertData

--- a/services/engine/processors/ada/processor.go
+++ b/services/engine/processors/ada/processor.go
@@ -270,6 +270,16 @@ func (p *Processor) ProcessEvent(subject string, data []byte) error {
 		return p.handleMedicationRoutineUpsert(ctx, evt)
 	case schemas.AdaEventMedicationRoutineDelete:
 		return p.handleMedicationRoutineDelete(ctx, evt)
+	case schemas.AdaEventMedicationGiven, schemas.AdaEventMedicationSkipped:
+		return p.handleMedicationEvent(ctx, evt)
+	case schemas.AdaEventMedicationSeriesStart:
+		return p.handleMedicationSeriesStart(ctx, evt)
+	case schemas.AdaEventMedicationSeriesEnd:
+		return p.handleMedicationSeriesEnd(ctx, evt)
+	case schemas.AdaEventMedicationEventUpdate:
+		return p.handleMedEventUpdate(ctx, evt)
+	case schemas.AdaEventMedicationEventDelete:
+		return p.handleMedEventDelete(ctx, evt)
 	case "ha.events.input_number.ada_alert_threshold_h":
 		return p.handleThresholdChange(ctx, evt)
 	default:
@@ -1229,6 +1239,7 @@ func (p *Processor) refreshAllSensors(ctx context.Context) {
 	p.pushGrowthSensors(ctx) // includes pushGrowthHistory
 	p.pushGrowthCurves(ctx)
 	p.pushMedicationSensors(ctx)
+	p.pushMedEventsSensor(ctx)
 }
 
 // pushLastEventSensors pushes sensors derived from the most recent event of each

--- a/services/engine/processors/ada/store/medications.sql.go
+++ b/services/engine/processors/ada/store/medications.sql.go
@@ -19,8 +19,8 @@ ORDER BY created_at
 `
 
 type ListMedicationRoutinesRow struct {
-	ID            pgtype.UUID
-	MedicationID  pgtype.UUID
+	ID            string
+	MedicationID  string
 	DoseAmount    pgtype.Numeric
 	ScheduleType  string
 	FixedTimes    []string
@@ -72,7 +72,7 @@ ORDER BY name
 `
 
 type ListMedicationsRow struct {
-	ID               pgtype.UUID
+	ID               string
 	Name             string
 	Route            string
 	MeasureUnit      string
@@ -117,7 +117,7 @@ const softDeleteMedication = `-- name: SoftDeleteMedication :exec
 UPDATE medications SET deleted_at = NOW() WHERE id = $1 AND deleted_at IS NULL
 `
 
-func (q *Queries) SoftDeleteMedication(ctx context.Context, id pgtype.UUID) error {
+func (q *Queries) SoftDeleteMedication(ctx context.Context, id string) error {
 	_, err := q.db.Exec(ctx, softDeleteMedication, id)
 	return err
 }
@@ -126,7 +126,7 @@ const softDeleteRoutine = `-- name: SoftDeleteRoutine :exec
 UPDATE medication_routines SET deleted_at = NOW() WHERE id = $1 AND deleted_at IS NULL
 `
 
-func (q *Queries) SoftDeleteRoutine(ctx context.Context, id pgtype.UUID) error {
+func (q *Queries) SoftDeleteRoutine(ctx context.Context, id string) error {
 	_, err := q.db.Exec(ctx, softDeleteRoutine, id)
 	return err
 }
@@ -135,7 +135,7 @@ const softDeleteRoutinesForMedication = `-- name: SoftDeleteRoutinesForMedicatio
 UPDATE medication_routines SET deleted_at = NOW() WHERE medication_id = $1 AND deleted_at IS NULL
 `
 
-func (q *Queries) SoftDeleteRoutinesForMedication(ctx context.Context, medicationID pgtype.UUID) error {
+func (q *Queries) SoftDeleteRoutinesForMedication(ctx context.Context, medicationID string) error {
 	_, err := q.db.Exec(ctx, softDeleteRoutinesForMedication, medicationID)
 	return err
 }
@@ -144,7 +144,7 @@ const softDeleteSeriesForMedication = `-- name: SoftDeleteSeriesForMedication :e
 UPDATE medication_temp_series SET deleted_at = NOW() WHERE medication_id = $1 AND deleted_at IS NULL
 `
 
-func (q *Queries) SoftDeleteSeriesForMedication(ctx context.Context, medicationID pgtype.UUID) error {
+func (q *Queries) SoftDeleteSeriesForMedication(ctx context.Context, medicationID string) error {
 	_, err := q.db.Exec(ctx, softDeleteSeriesForMedication, medicationID)
 	return err
 }
@@ -165,7 +165,7 @@ ON CONFLICT (id) DO UPDATE
 `
 
 type UpsertMedicationParams struct {
-	ID               pgtype.UUID
+	ID               string
 	Name             string
 	Route            string
 	MeasureUnit      string
@@ -212,8 +212,8 @@ ON CONFLICT (id) DO UPDATE
 `
 
 type UpsertMedicationRoutineParams struct {
-	ID            pgtype.UUID
-	MedicationID  pgtype.UUID
+	ID            string
+	MedicationID  string
 	DoseAmount    pgtype.Numeric
 	ScheduleType  string
 	FixedTimes    []string

--- a/services/engine/processors/ada/store/medications.sql.go
+++ b/services/engine/processors/ada/store/medications.sql.go
@@ -11,6 +11,160 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
+const endMedicationSeries = `-- name: EndMedicationSeries :exec
+UPDATE medication_temp_series
+SET status = $1, ended_reason = $2
+WHERE id = $3 AND deleted_at IS NULL
+`
+
+type EndMedicationSeriesParams struct {
+	Status      string
+	EndedReason pgtype.Text
+	ID          string
+}
+
+func (q *Queries) EndMedicationSeries(ctx context.Context, arg *EndMedicationSeriesParams) error {
+	_, err := q.db.Exec(ctx, endMedicationSeries, arg.Status, arg.EndedReason, arg.ID)
+	return err
+}
+
+const insertMedicationEvent = `-- name: InsertMedicationEvent :exec
+
+INSERT INTO medication_events (id, medication_id, status, timestamp, routine_id, slot_time,
+    dose_amount, dose_unit, source, within_window_override, series_id, started_watch, notes, logged_by, test)
+VALUES ($1, $2, $3, $4, $5, $6,
+    $7, $8, $9, $10, $11, $12, $13, $14, $15)
+ON CONFLICT (id) DO UPDATE
+    SET status                 = EXCLUDED.status,
+        timestamp              = EXCLUDED.timestamp,
+        routine_id             = EXCLUDED.routine_id,
+        slot_time              = EXCLUDED.slot_time,
+        dose_amount            = EXCLUDED.dose_amount,
+        dose_unit              = EXCLUDED.dose_unit,
+        source                 = EXCLUDED.source,
+        within_window_override = EXCLUDED.within_window_override,
+        series_id              = EXCLUDED.series_id,
+        started_watch          = EXCLUDED.started_watch,
+        notes                  = EXCLUDED.notes,
+        logged_by              = EXCLUDED.logged_by,
+        deleted_at             = NULL
+`
+
+type InsertMedicationEventParams struct {
+	ID                   string
+	MedicationID         string
+	Status               string
+	Timestamp            pgtype.Timestamptz
+	RoutineID            pgtype.Text
+	SlotTime             pgtype.Text
+	DoseAmount           pgtype.Numeric
+	DoseUnit             pgtype.Text
+	Source               pgtype.Text
+	WithinWindowOverride bool
+	SeriesID             pgtype.Text
+	StartedWatch         bool
+	Notes                pgtype.Text
+	LoggedBy             string
+	Test                 bool
+}
+
+// ── Dose events + temporary series (ROADMAP-0011 effort 0011.2) ────────────────
+func (q *Queries) InsertMedicationEvent(ctx context.Context, arg *InsertMedicationEventParams) error {
+	_, err := q.db.Exec(ctx, insertMedicationEvent,
+		arg.ID,
+		arg.MedicationID,
+		arg.Status,
+		arg.Timestamp,
+		arg.RoutineID,
+		arg.SlotTime,
+		arg.DoseAmount,
+		arg.DoseUnit,
+		arg.Source,
+		arg.WithinWindowOverride,
+		arg.SeriesID,
+		arg.StartedWatch,
+		arg.Notes,
+		arg.LoggedBy,
+		arg.Test,
+	)
+	return err
+}
+
+const insertMedicationSeries = `-- name: InsertMedicationSeries :exec
+INSERT INTO medication_temp_series (id, medication_id, interval_hours, anchor_dose_id, status, logged_by, test)
+VALUES ($1, $2, $3, $4, 'active', $5, $6)
+ON CONFLICT (id) DO UPDATE
+    SET interval_hours = EXCLUDED.interval_hours,
+        anchor_dose_id = EXCLUDED.anchor_dose_id,
+        status         = 'active',
+        logged_by      = EXCLUDED.logged_by,
+        deleted_at     = NULL
+`
+
+type InsertMedicationSeriesParams struct {
+	ID            string
+	MedicationID  string
+	IntervalHours pgtype.Numeric
+	AnchorDoseID  pgtype.Text
+	LoggedBy      string
+	Test          bool
+}
+
+func (q *Queries) InsertMedicationSeries(ctx context.Context, arg *InsertMedicationSeriesParams) error {
+	_, err := q.db.Exec(ctx, insertMedicationSeries,
+		arg.ID,
+		arg.MedicationID,
+		arg.IntervalHours,
+		arg.AnchorDoseID,
+		arg.LoggedBy,
+		arg.Test,
+	)
+	return err
+}
+
+const listActiveMedicationSeries = `-- name: ListActiveMedicationSeries :many
+SELECT id, medication_id, interval_hours, anchor_dose_id, status, ended_reason
+FROM medication_temp_series
+WHERE deleted_at IS NULL AND status = 'active'
+ORDER BY created_at
+`
+
+type ListActiveMedicationSeriesRow struct {
+	ID            string
+	MedicationID  string
+	IntervalHours pgtype.Numeric
+	AnchorDoseID  pgtype.Text
+	Status        string
+	EndedReason   pgtype.Text
+}
+
+func (q *Queries) ListActiveMedicationSeries(ctx context.Context) ([]*ListActiveMedicationSeriesRow, error) {
+	rows, err := q.db.Query(ctx, listActiveMedicationSeries)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*ListActiveMedicationSeriesRow
+	for rows.Next() {
+		var i ListActiveMedicationSeriesRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.MedicationID,
+			&i.IntervalHours,
+			&i.AnchorDoseID,
+			&i.Status,
+			&i.EndedReason,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const listMedicationRoutines = `-- name: ListMedicationRoutines :many
 SELECT id, medication_id, dose_amount, schedule_type, fixed_times, interval_hours, end_type, end_value, status, logged_by, test
 FROM medication_routines
@@ -113,12 +267,81 @@ func (q *Queries) ListMedications(ctx context.Context) ([]*ListMedicationsRow, e
 	return items, nil
 }
 
+const listRecentMedicationEvents = `-- name: ListRecentMedicationEvents :many
+SELECT id, medication_id, status, timestamp, routine_id, slot_time, dose_amount, dose_unit,
+    source, within_window_override, series_id, started_watch, notes, logged_by
+FROM medication_events
+WHERE deleted_at IS NULL AND timestamp >= $1
+ORDER BY timestamp DESC
+`
+
+type ListRecentMedicationEventsRow struct {
+	ID                   string
+	MedicationID         string
+	Status               string
+	Timestamp            pgtype.Timestamptz
+	RoutineID            pgtype.Text
+	SlotTime             pgtype.Text
+	DoseAmount           pgtype.Numeric
+	DoseUnit             pgtype.Text
+	Source               pgtype.Text
+	WithinWindowOverride bool
+	SeriesID             pgtype.Text
+	StartedWatch         bool
+	Notes                pgtype.Text
+	LoggedBy             string
+}
+
+func (q *Queries) ListRecentMedicationEvents(ctx context.Context, since pgtype.Timestamptz) ([]*ListRecentMedicationEventsRow, error) {
+	rows, err := q.db.Query(ctx, listRecentMedicationEvents, since)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*ListRecentMedicationEventsRow
+	for rows.Next() {
+		var i ListRecentMedicationEventsRow
+		if err := rows.Scan(
+			&i.ID,
+			&i.MedicationID,
+			&i.Status,
+			&i.Timestamp,
+			&i.RoutineID,
+			&i.SlotTime,
+			&i.DoseAmount,
+			&i.DoseUnit,
+			&i.Source,
+			&i.WithinWindowOverride,
+			&i.SeriesID,
+			&i.StartedWatch,
+			&i.Notes,
+			&i.LoggedBy,
+		); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const softDeleteMedication = `-- name: SoftDeleteMedication :exec
 UPDATE medications SET deleted_at = NOW() WHERE id = $1 AND deleted_at IS NULL
 `
 
 func (q *Queries) SoftDeleteMedication(ctx context.Context, id string) error {
 	_, err := q.db.Exec(ctx, softDeleteMedication, id)
+	return err
+}
+
+const softDeleteMedicationEvent = `-- name: SoftDeleteMedicationEvent :exec
+UPDATE medication_events SET deleted_at = NOW() WHERE id = $1 AND deleted_at IS NULL
+`
+
+func (q *Queries) SoftDeleteMedicationEvent(ctx context.Context, id string) error {
+	_, err := q.db.Exec(ctx, softDeleteMedicationEvent, id)
 	return err
 }
 
@@ -146,6 +369,25 @@ UPDATE medication_temp_series SET deleted_at = NOW() WHERE medication_id = $1 AN
 
 func (q *Queries) SoftDeleteSeriesForMedication(ctx context.Context, medicationID string) error {
 	_, err := q.db.Exec(ctx, softDeleteSeriesForMedication, medicationID)
+	return err
+}
+
+const updateMedicationEvent = `-- name: UpdateMedicationEvent :exec
+UPDATE medication_events
+SET timestamp = $1, dose_amount = $2
+WHERE id = $3 AND deleted_at IS NULL
+`
+
+type UpdateMedicationEventParams struct {
+	Timestamp  pgtype.Timestamptz
+	DoseAmount pgtype.Numeric
+	ID         string
+}
+
+// History dose correction: timestamp + dose only. The actor (logged_by) is the
+// immutable record of who administered the dose and is never rewritten by an edit.
+func (q *Queries) UpdateMedicationEvent(ctx context.Context, arg *UpdateMedicationEventParams) error {
+	_, err := q.db.Exec(ctx, updateMedicationEvent, arg.Timestamp, arg.DoseAmount, arg.ID)
 	return err
 }
 

--- a/services/engine/processors/ada/store/migrations/000008_medications_emergency.up.sql
+++ b/services/engine/processors/ada/store/migrations/000008_medications_emergency.up.sql
@@ -5,16 +5,18 @@
 -- emergency card rows. Field names mirror adaMeds.ts / adaEmergency.ts so the
 -- future dashboard read-seam repoint is a pure binding swap.
 --
--- test/deleted_at/created_at follow the established Ada conventions (ADR-0031
--- test-data; soft-delete). All tables carry a `WHERE test=true` partial index
--- for cheap clear/birth scans. series_id (on events) and anchor_dose_id (on
--- series) are loose UUIDs, not FKs: the dose and its series arrive as independent
+-- ids are TEXT, not UUID: the dashboard is the id authority and generates string
+-- ids (m-/rt-/ev-/s-/ec- prefixed millisecond timestamps), so the engine stores
+-- them verbatim. test/deleted_at/created_at follow the established Ada conventions
+-- (ADR-0031 test-data; soft-delete). All tables carry a `WHERE test=true` partial
+-- index for cheap clear/birth scans. series_id (on events) and anchor_dose_id (on
+-- series) are loose refs, not FKs: the dose and its series arrive as independent
 -- events and reference each other, so app-level integrity avoids a circular FK.
 
 -- medications: identity + optional safety limits ONLY. No dose, no schedule —
 -- a contextual infant dose lives on the routine or the dose event, never here.
 CREATE TABLE IF NOT EXISTS medications (
-    id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    id                 TEXT PRIMARY KEY,
     name               TEXT NOT NULL,
     route              TEXT NOT NULL,                       -- oral|drops|topical|suppository
     measure_unit       TEXT NOT NULL,                       -- mL|mg|drops|supp
@@ -31,8 +33,8 @@ CREATE TABLE IF NOT EXISTS medications (
 -- sends `end` as a nested {type, value?}; persisted here as end_type + end_value
 -- (value stringified — number for max_doses, date string for end_date).
 CREATE TABLE IF NOT EXISTS medication_routines (
-    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    medication_id  UUID NOT NULL REFERENCES medications(id) ON DELETE CASCADE,
+    id             TEXT PRIMARY KEY,
+    medication_id  TEXT NOT NULL REFERENCES medications(id) ON DELETE CASCADE,
     dose_amount    NUMERIC(8,3) NOT NULL,
     schedule_type  TEXT NOT NULL,                           -- fixed_times|interval
     fixed_times    TEXT[] NOT NULL DEFAULT '{}',            -- ["08:00","13:00"] for fixed_times
@@ -50,17 +52,17 @@ CREATE TABLE IF NOT EXISTS medication_routines (
 -- caregiver-logged; missed is system-emitted (actorless) per ADR-0038.
 -- dose_amount/dose_unit are a SNAPSHOT of what was actually given.
 CREATE TABLE IF NOT EXISTS medication_events (
-    id                     UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    medication_id          UUID NOT NULL REFERENCES medications(id) ON DELETE CASCADE,
+    id                     TEXT PRIMARY KEY,
+    medication_id          TEXT NOT NULL REFERENCES medications(id) ON DELETE CASCADE,
     status                 TEXT NOT NULL,                   -- given|skipped|missed
     timestamp              TIMESTAMPTZ NOT NULL,
-    routine_id             UUID,                            -- the routine this resolves, if scheduled
+    routine_id             TEXT,                            -- the routine this resolves, if scheduled
     slot_time              TEXT,                            -- "HH:MM" fixed slot this resolves
     dose_amount            NUMERIC(8,3),                    -- given only (snapshot)
     dose_unit              TEXT,                            -- given only (snapshot)
     source                 TEXT,                            -- scheduled|prn (given only)
     within_window_override BOOLEAN NOT NULL DEFAULT false,
-    series_id              UUID,                            -- loose ref to medication_temp_series
+    series_id              TEXT,                            -- loose ref to medication_temp_series
     started_watch          BOOLEAN NOT NULL DEFAULT false,  -- this dose opened a new watch
     notes                  TEXT,
     logged_by              TEXT NOT NULL DEFAULT '',         -- actor; '' for system missed
@@ -72,10 +74,10 @@ CREATE TABLE IF NOT EXISTS medication_events (
 -- medication_temp_series: an as-needed watch. Holds no clock — next-due reads
 -- the anchor dose. anchor_dose_id is a loose ref to a given medication_event.
 CREATE TABLE IF NOT EXISTS medication_temp_series (
-    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
-    medication_id  UUID NOT NULL REFERENCES medications(id) ON DELETE CASCADE,
+    id             TEXT PRIMARY KEY,
+    medication_id  TEXT NOT NULL REFERENCES medications(id) ON DELETE CASCADE,
     interval_hours NUMERIC(8,3) NOT NULL,
-    anchor_dose_id UUID,                                    -- references a given dose, not a clock
+    anchor_dose_id TEXT,                                    -- references a given dose, not a clock
     status         TEXT NOT NULL DEFAULT 'active',          -- active|resolved|disregarded|expired
     ended_reason   TEXT,                                    -- planned|dismissed|auto_expire
     logged_by      TEXT NOT NULL DEFAULT '',
@@ -87,7 +89,7 @@ CREATE TABLE IF NOT EXISTS medication_temp_series (
 -- emergency_rows: the ordered emergency card. Live-field rows resolve their
 -- value client-side off existing sensors; we persist rows + order only.
 CREATE TABLE IF NOT EXISTS emergency_rows (
-    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    id          TEXT PRIMARY KEY,
     sort_order  INTEGER NOT NULL DEFAULT 0,
     type        TEXT NOT NULL,                              -- contact|live_field
     label       TEXT NOT NULL DEFAULT '',

--- a/services/engine/processors/ada/store/migrations/000008_medications_emergency.up.sql
+++ b/services/engine/processors/ada/store/migrations/000008_medications_emergency.up.sql
@@ -5,18 +5,16 @@
 -- emergency card rows. Field names mirror adaMeds.ts / adaEmergency.ts so the
 -- future dashboard read-seam repoint is a pure binding swap.
 --
--- ids are TEXT, not UUID: the dashboard is the id authority and generates string
--- ids (m-/rt-/ev-/s-/ec- prefixed millisecond timestamps), so the engine stores
--- them verbatim. test/deleted_at/created_at follow the established Ada conventions
--- (ADR-0031 test-data; soft-delete). All tables carry a `WHERE test=true` partial
--- index for cheap clear/birth scans. series_id (on events) and anchor_dose_id (on
--- series) are loose refs, not FKs: the dose and its series arrive as independent
+-- test/deleted_at/created_at follow the established Ada conventions (ADR-0031
+-- test-data; soft-delete). All tables carry a `WHERE test=true` partial index
+-- for cheap clear/birth scans. series_id (on events) and anchor_dose_id (on
+-- series) are loose UUIDs, not FKs: the dose and its series arrive as independent
 -- events and reference each other, so app-level integrity avoids a circular FK.
 
 -- medications: identity + optional safety limits ONLY. No dose, no schedule —
 -- a contextual infant dose lives on the routine or the dose event, never here.
 CREATE TABLE IF NOT EXISTS medications (
-    id                 TEXT PRIMARY KEY,
+    id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     name               TEXT NOT NULL,
     route              TEXT NOT NULL,                       -- oral|drops|topical|suppository
     measure_unit       TEXT NOT NULL,                       -- mL|mg|drops|supp
@@ -33,8 +31,8 @@ CREATE TABLE IF NOT EXISTS medications (
 -- sends `end` as a nested {type, value?}; persisted here as end_type + end_value
 -- (value stringified — number for max_doses, date string for end_date).
 CREATE TABLE IF NOT EXISTS medication_routines (
-    id             TEXT PRIMARY KEY,
-    medication_id  TEXT NOT NULL REFERENCES medications(id) ON DELETE CASCADE,
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    medication_id  UUID NOT NULL REFERENCES medications(id) ON DELETE CASCADE,
     dose_amount    NUMERIC(8,3) NOT NULL,
     schedule_type  TEXT NOT NULL,                           -- fixed_times|interval
     fixed_times    TEXT[] NOT NULL DEFAULT '{}',            -- ["08:00","13:00"] for fixed_times
@@ -52,17 +50,17 @@ CREATE TABLE IF NOT EXISTS medication_routines (
 -- caregiver-logged; missed is system-emitted (actorless) per ADR-0038.
 -- dose_amount/dose_unit are a SNAPSHOT of what was actually given.
 CREATE TABLE IF NOT EXISTS medication_events (
-    id                     TEXT PRIMARY KEY,
-    medication_id          TEXT NOT NULL REFERENCES medications(id) ON DELETE CASCADE,
+    id                     UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    medication_id          UUID NOT NULL REFERENCES medications(id) ON DELETE CASCADE,
     status                 TEXT NOT NULL,                   -- given|skipped|missed
     timestamp              TIMESTAMPTZ NOT NULL,
-    routine_id             TEXT,                            -- the routine this resolves, if scheduled
+    routine_id             UUID,                            -- the routine this resolves, if scheduled
     slot_time              TEXT,                            -- "HH:MM" fixed slot this resolves
     dose_amount            NUMERIC(8,3),                    -- given only (snapshot)
     dose_unit              TEXT,                            -- given only (snapshot)
     source                 TEXT,                            -- scheduled|prn (given only)
     within_window_override BOOLEAN NOT NULL DEFAULT false,
-    series_id              TEXT,                            -- loose ref to medication_temp_series
+    series_id              UUID,                            -- loose ref to medication_temp_series
     started_watch          BOOLEAN NOT NULL DEFAULT false,  -- this dose opened a new watch
     notes                  TEXT,
     logged_by              TEXT NOT NULL DEFAULT '',         -- actor; '' for system missed
@@ -74,10 +72,10 @@ CREATE TABLE IF NOT EXISTS medication_events (
 -- medication_temp_series: an as-needed watch. Holds no clock — next-due reads
 -- the anchor dose. anchor_dose_id is a loose ref to a given medication_event.
 CREATE TABLE IF NOT EXISTS medication_temp_series (
-    id             TEXT PRIMARY KEY,
-    medication_id  TEXT NOT NULL REFERENCES medications(id) ON DELETE CASCADE,
+    id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    medication_id  UUID NOT NULL REFERENCES medications(id) ON DELETE CASCADE,
     interval_hours NUMERIC(8,3) NOT NULL,
-    anchor_dose_id TEXT,                                    -- references a given dose, not a clock
+    anchor_dose_id UUID,                                    -- references a given dose, not a clock
     status         TEXT NOT NULL DEFAULT 'active',          -- active|resolved|disregarded|expired
     ended_reason   TEXT,                                    -- planned|dismissed|auto_expire
     logged_by      TEXT NOT NULL DEFAULT '',
@@ -89,7 +87,7 @@ CREATE TABLE IF NOT EXISTS medication_temp_series (
 -- emergency_rows: the ordered emergency card. Live-field rows resolve their
 -- value client-side off existing sensors; we persist rows + order only.
 CREATE TABLE IF NOT EXISTS emergency_rows (
-    id          TEXT PRIMARY KEY,
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     sort_order  INTEGER NOT NULL DEFAULT 0,
     type        TEXT NOT NULL,                              -- contact|live_field
     label       TEXT NOT NULL DEFAULT '',

--- a/services/engine/processors/ada/store/migrations/000009_medication_text_ids.down.sql
+++ b/services/engine/processors/ada/store/migrations/000009_medication_text_ids.down.sql
@@ -1,0 +1,42 @@
+-- Reverse 000009: TEXT ids back to UUID. Best-effort — the tables are empty, so the
+-- ::uuid casts have no rows to fail on; if any non-UUID string id were present this
+-- would error (by design — those ids cannot be represented as UUID).
+ALTER TABLE medication_routines    DROP CONSTRAINT IF EXISTS medication_routines_medication_id_fkey;
+ALTER TABLE medication_events      DROP CONSTRAINT IF EXISTS medication_events_medication_id_fkey;
+ALTER TABLE medication_temp_series DROP CONSTRAINT IF EXISTS medication_temp_series_medication_id_fkey;
+
+ALTER TABLE emergency_rows
+    ALTER COLUMN id TYPE UUID USING id::uuid,
+    ALTER COLUMN id SET DEFAULT gen_random_uuid();
+
+ALTER TABLE medication_temp_series
+    ALTER COLUMN anchor_dose_id TYPE UUID USING anchor_dose_id::uuid,
+    ALTER COLUMN medication_id TYPE UUID USING medication_id::uuid,
+    ALTER COLUMN id TYPE UUID USING id::uuid,
+    ALTER COLUMN id SET DEFAULT gen_random_uuid();
+
+ALTER TABLE medication_events
+    ALTER COLUMN series_id TYPE UUID USING series_id::uuid,
+    ALTER COLUMN routine_id TYPE UUID USING routine_id::uuid,
+    ALTER COLUMN medication_id TYPE UUID USING medication_id::uuid,
+    ALTER COLUMN id TYPE UUID USING id::uuid,
+    ALTER COLUMN id SET DEFAULT gen_random_uuid();
+
+ALTER TABLE medication_routines
+    ALTER COLUMN medication_id TYPE UUID USING medication_id::uuid,
+    ALTER COLUMN id TYPE UUID USING id::uuid,
+    ALTER COLUMN id SET DEFAULT gen_random_uuid();
+
+ALTER TABLE medications
+    ALTER COLUMN id TYPE UUID USING id::uuid,
+    ALTER COLUMN id SET DEFAULT gen_random_uuid();
+
+ALTER TABLE medication_routines
+    ADD CONSTRAINT medication_routines_medication_id_fkey
+    FOREIGN KEY (medication_id) REFERENCES medications(id) ON DELETE CASCADE;
+ALTER TABLE medication_events
+    ADD CONSTRAINT medication_events_medication_id_fkey
+    FOREIGN KEY (medication_id) REFERENCES medications(id) ON DELETE CASCADE;
+ALTER TABLE medication_temp_series
+    ADD CONSTRAINT medication_temp_series_medication_id_fkey
+    FOREIGN KEY (medication_id) REFERENCES medications(id) ON DELETE CASCADE;

--- a/services/engine/processors/ada/store/migrations/000009_medication_text_ids.up.sql
+++ b/services/engine/processors/ada/store/migrations/000009_medication_text_ids.up.sql
@@ -1,0 +1,48 @@
+-- Medication/Emergency ids are dashboard-provided strings (m-/rt-/ev-/s-/ec-
+-- prefixed millisecond timestamps), not UUIDs. 000008 created the tables with UUID
+-- ids before this was understood and has already deployed, so the column types are
+-- corrected here rather than by amending 000008. The tables are empty in every
+-- environment — under the UUID schema the engine rejected every string id, so no
+-- dose/registry row ever persisted — so this type change touches no data.
+
+-- Drop the three medication_id foreign keys so the referenced/ referencing columns
+-- can change type, then re-add them after.
+ALTER TABLE medication_routines    DROP CONSTRAINT IF EXISTS medication_routines_medication_id_fkey;
+ALTER TABLE medication_events      DROP CONSTRAINT IF EXISTS medication_events_medication_id_fkey;
+ALTER TABLE medication_temp_series DROP CONSTRAINT IF EXISTS medication_temp_series_medication_id_fkey;
+
+ALTER TABLE medications
+    ALTER COLUMN id DROP DEFAULT,
+    ALTER COLUMN id TYPE TEXT USING id::text;
+
+ALTER TABLE medication_routines
+    ALTER COLUMN id DROP DEFAULT,
+    ALTER COLUMN id TYPE TEXT USING id::text,
+    ALTER COLUMN medication_id TYPE TEXT USING medication_id::text;
+
+ALTER TABLE medication_events
+    ALTER COLUMN id DROP DEFAULT,
+    ALTER COLUMN id TYPE TEXT USING id::text,
+    ALTER COLUMN medication_id TYPE TEXT USING medication_id::text,
+    ALTER COLUMN routine_id TYPE TEXT USING routine_id::text,
+    ALTER COLUMN series_id TYPE TEXT USING series_id::text;
+
+ALTER TABLE medication_temp_series
+    ALTER COLUMN id DROP DEFAULT,
+    ALTER COLUMN id TYPE TEXT USING id::text,
+    ALTER COLUMN medication_id TYPE TEXT USING medication_id::text,
+    ALTER COLUMN anchor_dose_id TYPE TEXT USING anchor_dose_id::text;
+
+ALTER TABLE emergency_rows
+    ALTER COLUMN id DROP DEFAULT,
+    ALTER COLUMN id TYPE TEXT USING id::text;
+
+ALTER TABLE medication_routines
+    ADD CONSTRAINT medication_routines_medication_id_fkey
+    FOREIGN KEY (medication_id) REFERENCES medications(id) ON DELETE CASCADE;
+ALTER TABLE medication_events
+    ADD CONSTRAINT medication_events_medication_id_fkey
+    FOREIGN KEY (medication_id) REFERENCES medications(id) ON DELETE CASCADE;
+ALTER TABLE medication_temp_series
+    ADD CONSTRAINT medication_temp_series_medication_id_fkey
+    FOREIGN KEY (medication_id) REFERENCES medications(id) ON DELETE CASCADE;

--- a/services/engine/processors/ada/store/models.go
+++ b/services/engine/processors/ada/store/models.go
@@ -32,7 +32,7 @@ type Diaper struct {
 }
 
 type EmergencyRow struct {
-	ID        pgtype.UUID
+	ID        string
 	SortOrder int32
 	Type      string
 	Label     string
@@ -90,7 +90,7 @@ type GrowthMeasurement struct {
 }
 
 type Medication struct {
-	ID               pgtype.UUID
+	ID               string
 	Name             string
 	Route            string
 	MeasureUnit      string
@@ -104,17 +104,17 @@ type Medication struct {
 }
 
 type MedicationEvent struct {
-	ID                   pgtype.UUID
-	MedicationID         pgtype.UUID
+	ID                   string
+	MedicationID         string
 	Status               string
 	Timestamp            pgtype.Timestamptz
-	RoutineID            pgtype.UUID
+	RoutineID            pgtype.Text
 	SlotTime             pgtype.Text
 	DoseAmount           pgtype.Numeric
 	DoseUnit             pgtype.Text
 	Source               pgtype.Text
 	WithinWindowOverride bool
-	SeriesID             pgtype.UUID
+	SeriesID             pgtype.Text
 	StartedWatch         bool
 	Notes                pgtype.Text
 	LoggedBy             string
@@ -124,8 +124,8 @@ type MedicationEvent struct {
 }
 
 type MedicationRoutine struct {
-	ID            pgtype.UUID
-	MedicationID  pgtype.UUID
+	ID            string
+	MedicationID  string
 	DoseAmount    pgtype.Numeric
 	ScheduleType  string
 	FixedTimes    []string
@@ -140,10 +140,10 @@ type MedicationRoutine struct {
 }
 
 type MedicationTempSeries struct {
-	ID            pgtype.UUID
-	MedicationID  pgtype.UUID
+	ID            string
+	MedicationID  string
 	IntervalHours pgtype.Numeric
-	AnchorDoseID  pgtype.UUID
+	AnchorDoseID  pgtype.Text
 	Status        string
 	EndedReason   pgtype.Text
 	LoggedBy      string

--- a/services/engine/processors/ada/store/queries/medications.sql
+++ b/services/engine/processors/ada/store/queries/medications.sql
@@ -54,3 +54,63 @@ ORDER BY created_at;
 
 -- name: SoftDeleteRoutine :exec
 UPDATE medication_routines SET deleted_at = NOW() WHERE id = @id AND deleted_at IS NULL;
+
+-- ── Dose events + temporary series (ROADMAP-0011 effort 0011.2) ────────────────
+
+-- name: InsertMedicationEvent :exec
+INSERT INTO medication_events (id, medication_id, status, timestamp, routine_id, slot_time,
+    dose_amount, dose_unit, source, within_window_override, series_id, started_watch, notes, logged_by, test)
+VALUES (@id, @medication_id, @status, @timestamp, @routine_id, @slot_time,
+    @dose_amount, @dose_unit, @source, @within_window_override, @series_id, @started_watch, @notes, @logged_by, @test)
+ON CONFLICT (id) DO UPDATE
+    SET status                 = EXCLUDED.status,
+        timestamp              = EXCLUDED.timestamp,
+        routine_id             = EXCLUDED.routine_id,
+        slot_time              = EXCLUDED.slot_time,
+        dose_amount            = EXCLUDED.dose_amount,
+        dose_unit              = EXCLUDED.dose_unit,
+        source                 = EXCLUDED.source,
+        within_window_override = EXCLUDED.within_window_override,
+        series_id              = EXCLUDED.series_id,
+        started_watch          = EXCLUDED.started_watch,
+        notes                  = EXCLUDED.notes,
+        logged_by              = EXCLUDED.logged_by,
+        deleted_at             = NULL;
+
+-- name: UpdateMedicationEvent :exec
+-- History dose correction: timestamp + dose only. The actor (logged_by) is the
+-- immutable record of who administered the dose and is never rewritten by an edit.
+UPDATE medication_events
+SET timestamp = @timestamp, dose_amount = @dose_amount
+WHERE id = @id AND deleted_at IS NULL;
+
+-- name: SoftDeleteMedicationEvent :exec
+UPDATE medication_events SET deleted_at = NOW() WHERE id = @id AND deleted_at IS NULL;
+
+-- name: ListRecentMedicationEvents :many
+SELECT id, medication_id, status, timestamp, routine_id, slot_time, dose_amount, dose_unit,
+    source, within_window_override, series_id, started_watch, notes, logged_by
+FROM medication_events
+WHERE deleted_at IS NULL AND timestamp >= @since
+ORDER BY timestamp DESC;
+
+-- name: InsertMedicationSeries :exec
+INSERT INTO medication_temp_series (id, medication_id, interval_hours, anchor_dose_id, status, logged_by, test)
+VALUES (@id, @medication_id, @interval_hours, @anchor_dose_id, 'active', @logged_by, @test)
+ON CONFLICT (id) DO UPDATE
+    SET interval_hours = EXCLUDED.interval_hours,
+        anchor_dose_id = EXCLUDED.anchor_dose_id,
+        status         = 'active',
+        logged_by      = EXCLUDED.logged_by,
+        deleted_at     = NULL;
+
+-- name: EndMedicationSeries :exec
+UPDATE medication_temp_series
+SET status = @status, ended_reason = @ended_reason
+WHERE id = @id AND deleted_at IS NULL;
+
+-- name: ListActiveMedicationSeries :many
+SELECT id, medication_id, interval_hours, anchor_dose_id, status, ended_reason
+FROM medication_temp_series
+WHERE deleted_at IS NULL AND status = 'active'
+ORDER BY created_at;

--- a/services/gateway/ada/publish.go
+++ b/services/gateway/ada/publish.go
@@ -50,6 +50,14 @@ var eventRoutes = map[string]string{
 	"ada.medication.delete":         schemas.AdaEventMedicationDelete,
 	"ada.medication.routine.upsert": schemas.AdaEventMedicationRoutineUpsert,
 	"ada.medication.routine.delete": schemas.AdaEventMedicationRoutineDelete,
+
+	// Dose events + series (effort 0011.2).
+	"ada.medication.given":        schemas.AdaEventMedicationGiven,
+	"ada.medication.skipped":      schemas.AdaEventMedicationSkipped,
+	"ada.medication.series.start": schemas.AdaEventMedicationSeriesStart,
+	"ada.medication.series.end":   schemas.AdaEventMedicationSeriesEnd,
+	"ada.medication.event.update": schemas.AdaEventMedicationEventUpdate,
+	"ada.medication.event.delete": schemas.AdaEventMedicationEventDelete,
 }
 
 // Publish wraps payload in a CloudEvent and publishes to the appropriate


### PR DESCRIPTION
## Summary

Second effort (0011.2) of **ROADMAP-0011** — the dosing surface of the dashboard's Medication feature persists server-side (ADR-0037). Plus a **prod-critical id-type fix** discovered while building it (see below). Server-owned safety computations (`missed`/due/guard, ADR-0038) are the next effort (0011.3).

## ⚠️ Includes a fix for a prod bug in #100

The dashboard generates **string ids** (`m-`/`rt-`/`ev-`/`s-`/`ec-` prefixed millisecond timestamps), **not UUIDs**. #100's `000008` used `id UUID` + `parseUUID()`, so the deployed engine NAK-ed every real medication event to the DLQ (it only passed review because it was tested with fabricated UUIDs). Because `000008` had already deployed (prod at schema v8, UUID, all 5 meds tables empty), this PR **leaves `000008` as deployed and converts the ids to `TEXT` in a new `000009` ALTER migration** — validated against a prod-like schema (UUID→TEXT: all 10 id/ref columns convert, the 3 `medication_id` FKs are preserved, string-id inserts succeed, the down-migration reverses). Zero data risk — the tables are empty.

## What's in this PR

- **Dose events** — `ada.medication.given` / `ada.medication.skipped` (the full MedEvent, with the `dose_amount`/`dose_unit` snapshot of what was administered). Dose events are **tracking**: `eventTestOrPreBirth`, so pre-birth practice doses are `test=true` and wiped at birth.
- **Temporary series** — `ada.medication.series.start` / `series.end` (an as-needed watch): planned→resolved, dismissed→disregarded.
- **Edit/delete** — `event.update` corrects timestamp + dose only; the **actor (`logged_by`) is immutable** and never rewritten by an edit. `event.delete` soft-deletes.
- **Projection** — `sensor.ada_med_events`: `items[]` mirror the `adaMeds.ts` MedEvent type (`logged_by`→`actor`) over a 7-day window; active watches ride the same sensor's **`series`** attribute (there is no dedicated series sensor in the §4 contract — the HA agent should confirm that's where the card expects them).
- **`000009`** id-type fix (above).

## Verification (end-to-end on dev, real dashboard-format ids)

- `given` persists with the dose snapshot; `skipped` carries slot/routine, no dose; `series.start/end` status mapping; `event.update` changes timestamp+dose and **preserves the actor**; `event.delete` soft-deletes.
- Real `m-`/`rt-`/`ev-`/`s-` ids round-trip (the bug #100 would have hit).
- `000009` validated on a prod-like UUID schema; dev advanced to v9.
- `go build`, full `-race` suite, golangci-lint, gitleaks, shellcheck all pass; new decode/round-trip unit tests.

## Notes

- **Deploy this to repair prod**: since #100 deployed the UUID schema, meds events have been failing to the DLQ. `000009` + these handlers fix it. (The dashboard's client-local store still holds those actions, so nothing is permanently lost.)
- **Known limitation (flagged, not fixed here):** the engine's worker pool can process a rapid log-then-edit out of order (a sub-second edit lost if it races ahead of the insert). Reachable for meds (client-generated ids) but not feedings/diapers (server-assigned UUIDs read back from a sensor). Candidate follow-up.
- **Docs** (README/runbook) ride effort 0011.4 per PLAN-0028; Pre-PR checklist deferred to that PR.
- Commit history has a minor `000008` edit→revert oscillation (the id fix was first attempted as an amend before #100's deploy was known); squash-merge collapses it if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)