### PR TITLE
fix(ada): recompute medication next_due on every dose event

### DIFF
--- a/services/engine/processors/ada/med_events.go
+++ b/services/engine/processors/ada/med_events.go
@@ -71,7 +71,15 @@ func (p *Processor) handleMedicationEvent(ctx context.Context, evt schemas.Cloud
 	}); err != nil {
 		return fmt.Errorf("ada: insert medication event: %w", err)
 	}
-	p.pushMedEventsSensor(ctx)
+	// A watched given dose re-anchors its series to the latest dose, so the watch's
+	// next_due and 24h auto-expire track it (the dashboard re-anchors only locally,
+	// without firing an event). Robust to back-dated doses — always the max-timestamp.
+	if status == "given" && d.SeriesID != "" {
+		if err := p.q.ReanchorSeriesToLatestDose(ctx, d.SeriesID); err != nil {
+			p.log.Warn("ada: re-anchor series", slog.String("error", err.Error()))
+		}
+	}
+	p.pushAllMedSensors(ctx)
 	return nil
 }
 
@@ -137,7 +145,7 @@ func (p *Processor) handleMedEventUpdate(ctx context.Context, evt schemas.CloudE
 	}); err != nil {
 		return fmt.Errorf("ada: update medication event: %w", err)
 	}
-	p.pushMedEventsSensor(ctx)
+	p.pushAllMedSensors(ctx)
 	return nil
 }
 
@@ -150,7 +158,7 @@ func (p *Processor) handleMedEventDelete(ctx context.Context, evt schemas.CloudE
 	if err := p.q.SoftDeleteMedicationEvent(ctx, d.ID); err != nil {
 		return fmt.Errorf("ada: soft-delete medication event: %w", err)
 	}
-	p.pushMedEventsSensor(ctx)
+	p.pushAllMedSensors(ctx)
 	return nil
 }
 
@@ -230,8 +238,17 @@ func (p *Processor) pushMedEventsSensor(ctx context.Context) {
 			AnchorDoseID:  s.AnchorDoseID.String,
 			Status:        s.Status,
 		}
-		if at, ok := eventTime[s.AnchorDoseID.String]; ok {
-			nd := seriesNextDue(at, si.IntervalHours).UTC().Format(time.RFC3339)
+		// next_due tracks the latest watched dose, not the (possibly stale) stored
+		// anchor — the reconcile re-anchors the DB, but project the live value too.
+		anchorTime, ok := time.Time{}, false
+		if latest := latestWatchedDose(rows, s.ID); latest != nil {
+			si.AnchorDoseID = latest.ID
+			anchorTime, ok = latest.Timestamp.Time, true
+		} else if at, found := eventTime[s.AnchorDoseID.String]; found {
+			anchorTime, ok = at, true
+		}
+		if ok {
+			nd := seriesNextDue(anchorTime, si.IntervalHours).UTC().Format(time.RFC3339)
 			si.NextDue = &nd
 		}
 		series = append(series, si)
@@ -245,4 +262,30 @@ func (p *Processor) pushMedEventsSensor(ctx context.Context) {
 	if err := p.ha.PushState(ctx, sensorMedEvents, strconv.Itoa(len(items)), attrs); err != nil {
 		p.log.Warn("ada: push medication events", slog.String("error", err.Error()))
 	}
+}
+
+// pushAllMedSensors re-projects every medication sensor. A dose event shifts the
+// per-med guard (sensor.ada_medications), interval routine next_due
+// (sensor.ada_med_routines), and the dose history + watch next_due
+// (sensor.ada_med_events), so all three must refresh — not just the events sensor.
+func (p *Processor) pushAllMedSensors(ctx context.Context) {
+	p.pushMedicationSensors(ctx) // medications (guard) + med_routines (next_due)
+	p.pushMedEventsSensor(ctx)   // med_events + watch next_due
+}
+
+// latestWatchedDose returns the most recent given dose belonging to a series.
+func latestWatchedDose(events []*store.ListRecentMedicationEventsRow, seriesID string) *store.ListRecentMedicationEventsRow {
+	if seriesID == "" {
+		return nil
+	}
+	var latest *store.ListRecentMedicationEventsRow
+	for _, e := range events {
+		if e.Status != "given" || e.SeriesID.String != seriesID {
+			continue
+		}
+		if latest == nil || e.Timestamp.Time.After(latest.Timestamp.Time) {
+			latest = e
+		}
+	}
+	return latest
 }

--- a/services/engine/processors/ada/med_reconcile.go
+++ b/services/engine/processors/ada/med_reconcile.go
@@ -100,10 +100,19 @@ func (p *Processor) reconcileMedications(ctx context.Context) {
 		series = nil
 	}
 	for _, s := range series {
-		anchor, ok := eventByID[s.AnchorDoseID.String]
-		// No anchor in the 48h window (>48h old, or the dose was deleted) → past the
-		// 24h backstop, expire. Otherwise expire once the anchor crosses the backstop.
-		if !ok || now.Sub(anchor.Timestamp.Time) > seriesExpiryBackstop {
+		latest := latestWatchedDose(events, s.ID)
+		// Re-anchor to the latest watched dose so next_due + expiry track it (the
+		// handler does this live for new doses; this self-heals edits/deletes).
+		if latest != nil && latest.ID != s.AnchorDoseID.String {
+			if err := p.q.ReanchorSeriesToLatestDose(ctx, s.ID); err != nil {
+				p.log.Warn("ada: re-anchor series", slog.String("error", err.Error()))
+			} else {
+				changed = true
+			}
+		}
+		// No watched dose within the 48h window (none, >48h old, or all deleted) → past
+		// the 24h backstop, expire; otherwise expire once the latest crosses the backstop.
+		if latest == nil || now.Sub(latest.Timestamp.Time) > seriesExpiryBackstop {
 			if err := p.q.EndMedicationSeries(ctx, &store.EndMedicationSeriesParams{
 				ID: s.ID, Status: "expired", EndedReason: textFromString("auto_expire"),
 			}); err != nil {
@@ -114,7 +123,7 @@ func (p *Processor) reconcileMedications(ctx context.Context) {
 		}
 	}
 
-	p.remindDueMedications(ctx, now, routines, series, events, eventByID, medActive, medName)
+	p.remindDueMedications(ctx, now, routines, series, events, medActive, medName)
 
 	if changed {
 		p.pushMedEventsSensor(ctx)
@@ -217,7 +226,6 @@ func (p *Processor) remindDueMedications(
 	routines []*store.ListMedicationRoutinesRow,
 	series []*store.ListActiveMedicationSeriesRow,
 	events []*store.ListRecentMedicationEventsRow,
-	eventByID map[string]*store.ListRecentMedicationEventsRow,
 	medActive map[string]bool,
 	medName map[string]string,
 ) {
@@ -248,12 +256,12 @@ func (p *Processor) remindDueMedications(
 		}
 	}
 	for _, s := range series {
-		anchor, ok := eventByID[s.AnchorDoseID.String]
-		if !ok {
+		latest := latestWatchedDose(events, s.ID)
+		if latest == nil {
 			continue
 		}
-		if nd := seriesNextDue(anchor.Timestamp.Time, numericToFloat(s.IntervalHours)); !nd.After(now) {
-			dues = append(dues, due{s.MedicationID, "medremind:series:" + s.ID, s.AnchorDoseID.String})
+		if nd := seriesNextDue(latest.Timestamp.Time, numericToFloat(s.IntervalHours)); !nd.After(now) {
+			dues = append(dues, due{s.MedicationID, "medremind:series:" + s.ID, latest.ID})
 		}
 	}
 	if len(dues) == 0 {

--- a/services/engine/processors/ada/med_reconcile_test.go
+++ b/services/engine/processors/ada/med_reconcile_test.go
@@ -1,0 +1,57 @@
+//go:build fast
+
+package ada
+
+import (
+	"testing"
+	"time"
+
+	"github.com/jackc/pgx/v5/pgtype"
+
+	"github.com/primaryrutabaga/ruby-core/services/engine/processors/ada/store"
+)
+
+func medRow(id, routineID, seriesID, status string, ts time.Time) *store.ListRecentMedicationEventsRow {
+	return &store.ListRecentMedicationEventsRow{
+		ID:        id,
+		Status:    status,
+		Timestamp: pgtype.Timestamptz{Time: ts, Valid: true},
+		RoutineID: pgtype.Text{String: routineID, Valid: routineID != ""},
+		SeriesID:  pgtype.Text{String: seriesID, Valid: seriesID != ""},
+	}
+}
+
+// A watch re-anchors to its most recent given dose (max timestamp), so a later or
+// back-dated watched dose moves next_due — never the original anchor or a skip.
+func TestLatestWatchedDose(t *testing.T) {
+	events := []*store.ListRecentMedicationEventsRow{
+		medRow("d1", "", "s1", "given", tt(10, 0)),
+		medRow("d3", "", "s1", "given", tt(12, 0)), // latest for s1
+		medRow("d2", "", "s1", "given", tt(11, 0)),
+		medRow("other", "", "s2", "given", tt(13, 0)),
+		medRow("skip", "", "s1", "skipped", tt(14, 0)), // skipped never anchors
+	}
+	if got := latestWatchedDose(events, "s1"); got == nil || got.ID != "d3" {
+		t.Errorf("latestWatchedDose(s1) = %v, want d3", got)
+	}
+	if got := latestWatchedDose(events, "missing"); got != nil {
+		t.Errorf("latestWatchedDose(missing) = %v, want nil", got)
+	}
+	if got := latestWatchedDose(events, ""); got != nil {
+		t.Errorf("latestWatchedDose(\"\") = %v, want nil", got)
+	}
+}
+
+// An interval routine's next_due is driven by the latest given dose for the routine
+// (max timestamp), so logging a later/back-dated dose recomputes it.
+func TestLastGivenForRoutine(t *testing.T) {
+	events := []*store.ListRecentMedicationEventsRow{
+		medRow("a", "rt1", "", "given", tt(10, 0)),
+		medRow("c", "rt1", "", "given", tt(12, 0)), // latest for rt1
+		medRow("b", "rt1", "", "given", tt(11, 0)),
+		medRow("x", "rt2", "", "given", tt(13, 0)),
+	}
+	if got := lastGivenForRoutine(events, "rt1"); got == nil || got.ID != "c" {
+		t.Errorf("lastGivenForRoutine(rt1) = %v, want c", got)
+	}
+}

--- a/services/engine/processors/ada/store/medications.sql.go
+++ b/services/engine/processors/ada/store/medications.sql.go
@@ -355,6 +355,24 @@ func (q *Queries) ListRecentMedicationEvents(ctx context.Context, since pgtype.T
 	return items, nil
 }
 
+const reanchorSeriesToLatestDose = `-- name: ReanchorSeriesToLatestDose :exec
+UPDATE medication_temp_series AS s
+SET anchor_dose_id = (
+    SELECT e.id FROM medication_events e
+    WHERE e.series_id = s.id AND e.status = 'given' AND e.deleted_at IS NULL
+    ORDER BY e.timestamp DESC LIMIT 1
+)
+WHERE s.id = $1 AND s.status = 'active' AND s.deleted_at IS NULL
+`
+
+// Move an active watch's anchor to its most recent given dose, so next_due and the
+// auto-expire backstop track the latest watched dose (the dashboard re-anchors
+// locally without firing an event, so the engine infers it from the dose history).
+func (q *Queries) ReanchorSeriesToLatestDose(ctx context.Context, id string) error {
+	_, err := q.db.Exec(ctx, reanchorSeriesToLatestDose, id)
+	return err
+}
+
 const setRoutineStatus = `-- name: SetRoutineStatus :exec
 UPDATE medication_routines SET status = $1 WHERE id = $2 AND deleted_at IS NULL
 `

--- a/services/engine/processors/ada/store/queries/medications.sql
+++ b/services/engine/processors/ada/store/queries/medications.sql
@@ -129,3 +129,15 @@ UPDATE medication_routines SET status = @status WHERE id = @id AND deleted_at IS
 SELECT timestamp FROM medication_events
 WHERE medication_id = @medication_id AND status = 'given' AND deleted_at IS NULL
 ORDER BY timestamp DESC LIMIT 1;
+
+-- name: ReanchorSeriesToLatestDose :exec
+-- Move an active watch's anchor to its most recent given dose, so next_due and the
+-- auto-expire backstop track the latest watched dose (the dashboard re-anchors
+-- locally without firing an event, so the engine infers it from the dose history).
+UPDATE medication_temp_series AS s
+SET anchor_dose_id = (
+    SELECT e.id FROM medication_events e
+    WHERE e.series_id = s.id AND e.status = 'given' AND e.deleted_at IS NULL
+    ORDER BY e.timestamp DESC LIMIT 1
+)
+WHERE s.id = @id AND s.status = 'active' AND s.deleted_at IS NULL;


### PR DESCRIPTION
## Summary

Fixes a bug where an interval schedule's and an active watch's `next_due` went stale when a dose — notably a **back-dated** one logged between the anchoring dose and the computed due time — was registered. Two distinct gaps:

1. **Interval routines** — `next_due` is computed from the latest given dose but projected only on `sensor.ada_med_routines`. The dose-event handlers (`given`/`skipped`/`event.update`/`event.delete`) re-pushed only the *events* sensor, so the routine's `next_due` (and the per-med guard on `sensor.ada_medications`) never refreshed when a dose was logged. They now push **all** medication sensors.

2. **Watches** — `next_due = anchor + interval`, but the engine's `anchor_dose_id` was set once at `series.start` and never moved: the dashboard re-anchors locally on each watched dose without firing an event, so the engine never learned. A watched `given` dose now **re-anchors the series to its latest given dose** (`ReanchorSeriesToLatestDose` — robust to back-dated doses, always the max-timestamp), and both `next_due` and the 24h auto-expire derive from the latest watched dose. The 60s reconcile self-heals the anchor for edits/deletes.

## Verification

- **Dev, the reported scenario:** a watch anchored to `ev-w1` (10:00); logging a second watched dose `ev-w2` (11:00, "in between" the anchor and its due time) **re-anchored the series to `ev-w2`** — so `next_due` advances (16:00 → 17:00).
- Unit tests cover `latestWatchedDose` / `lastGivenForRoutine` picking the max-timestamp given dose (later or back-dated).
- `go build`, full `-race` suite, golangci-lint (0 issues), pre-commit all green.

## Notes

- Independent of #106 (emergency) — different files, merges in any order.
- Builds on the server-owned computations from #104 (0011.3).

🤖 Generated with [Claude Code](https://claude.com/claude-code)