### PR TITLE
fix(nats): auto-recover NATS after host reboot (ADR-0039)

### DIFF
--- a/deploy/base/nats/wait-for-certs.sh
+++ b/deploy/base/nats/wait-for-certs.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# wait-for-certs.sh — NATS entrypoint guard (ADR-0039 / PLAN-0029).
+#
+# Blocks until the Vault-issued TLS material is present in the shared
+# nats-certs volume, then exec's nats-server with the supplied args. This
+# decouples NATS startup from the nats-init one-shot's completion state,
+# which is NOT re-established on host reboot — so NATS auto-recovers after a
+# cold boot using the already-persisted cert, instead of being held down by a
+# stale `depends_on: service_completed_successfully` gate.
+#
+# Bounded wait (~120s). On timeout the script exits non-zero so the
+# `restart: unless-stopped` policy retries it: a flapping container is a
+# louder signal to monitoring than one silently hung forever.
+set -eu
+
+CERTS_DIR="${CERTS_DIR:-/etc/nats/certs}"
+TIMEOUT="${CERT_WAIT_TIMEOUT:-120}"
+INTERVAL=2
+elapsed=0
+
+while :; do
+	if [ -s "${CERTS_DIR}/server-cert.pem" ] &&
+		[ -s "${CERTS_DIR}/server-key.pem" ] &&
+		[ -s "${CERTS_DIR}/ca.pem" ]; then
+		echo "wait-for-certs: TLS material present in ${CERTS_DIR} — starting nats-server"
+		break
+	fi
+
+	if [ "${elapsed}" -ge "${TIMEOUT}" ]; then
+		echo "wait-for-certs: timed out after ${TIMEOUT}s waiting for certs in ${CERTS_DIR} — exiting for restart" >&2
+		exit 1
+	fi
+
+	echo "wait-for-certs: waiting for TLS material in ${CERTS_DIR} (${elapsed}s/${TIMEOUT}s)…"
+	sleep "${INTERVAL}"
+	elapsed=$((elapsed + INTERVAL))
+done
+
+exec nats-server "$@"

--- a/deploy/dev/compose.dev.yaml
+++ b/deploy/dev/compose.dev.yaml
@@ -43,9 +43,10 @@ services:
     image: nats:2.10-alpine
     container_name: ruby-core-dev-nats
     restart: unless-stopped
-    depends_on:
-      nats-init:
-        condition: service_completed_successfully
+    # No nats-init gate: its `service_completed_successfully` state is not
+    # re-established on host reboot, which blocked NATS from auto-starting
+    # (ADR-0039). NATS now waits for its cert via the wait-for-certs.sh
+    # entrypoint, so it recovers on reboot from the persisted cert.
     ports:
       # Client port (TLS) — localhost only
       - "127.0.0.1:4222:4222"
@@ -58,6 +59,10 @@ services:
       - ../base/nats/nats.conf:/etc/nats/nats.conf:ro
       # TLS certificates and auth.conf (fetched/generated from Vault by nats-init)
       - nats-certs:/etc/nats/certs:ro
+      # Startup guard: blocks until the cert above exists, then exec's
+      # nats-server — decouples startup from nats-init (ADR-0039).
+      - ../base/nats/wait-for-certs.sh:/usr/local/bin/wait-for-certs.sh:ro
+    entrypoint: ["/usr/local/bin/wait-for-certs.sh"]
     command: ["-c", "/etc/nats/nats.conf"]
     networks:
       - default

--- a/deploy/dev/vault-agent/post-render.sh
+++ b/deploy/dev/vault-agent/post-render.sh
@@ -65,21 +65,36 @@ mv "$KEY_TMP"  "$CERTS_DIR/server-key.pem"
 mv "$CA_TMP"   "$CERTS_DIR/ca.pem"
 rm -f "$BUNDLE"
 
-# SIGHUP NATS via the Docker API. /kill (not /restart) with signal=SIGHUP
-# triggers NATS's config reload without dropping existing connections.
-# NATS validates the new cert during reload; if it's malformed it keeps the
-# old config (server/reload.go's validateOptions runs before Apply).
-HTTP_CODE=$(curl --silent --unix-socket /var/run/docker.sock \
-  -X POST --max-time 10 \
-  -o /dev/null -w '%{http_code}' \
-  "http://localhost/containers/${NATS_CONTAINER}/kill?signal=SIGHUP" || echo "000")
+# Reload or recover NATS via the Docker API, depending on its current state:
+#   - running → POST /kill?signal=SIGHUP: NATS reloads TLS in place without
+#     dropping existing connections (server/reload.go validates the new cert
+#     before Apply; a malformed cert keeps the old config).
+#   - stopped → POST /start: bring NATS up with the freshly written cert. This
+#     is the boot-recovery path (ADR-0039) — a SIGHUP cannot start a stopped
+#     container, so the renewer must start it rather than deadlock retrying.
+# Only a genuine Docker API/transport error is fatal; NATS being down is an
+# expected, recoverable state and must not fail the render.
+SOCK=/var/run/docker.sock
+API="http://localhost/containers/${NATS_CONTAINER}"
 
-case "$HTTP_CODE" in
-  204)
-    echo "post-render: cert+key+ca written to ${CERTS_DIR}; SIGHUP sent to ${NATS_CONTAINER}"
-    ;;
-  *)
-    echo "post-render: write OK but SIGHUP call returned HTTP $HTTP_CODE" >&2
-    exit 1
-    ;;
-esac
+RUNNING=$(curl --silent --unix-socket "$SOCK" --max-time 10 "${API}/json" |
+  grep -o '"Running":[a-z]*' | head -n1 | cut -d: -f2)
+
+if [ "$RUNNING" = "true" ]; then
+  HTTP_CODE=$(curl --silent --unix-socket "$SOCK" -X POST --max-time 10 \
+    -o /dev/null -w '%{http_code}' "${API}/kill?signal=SIGHUP" || echo "000")
+  case "$HTTP_CODE" in
+    204) echo "post-render: cert written to ${CERTS_DIR}; SIGHUP reloaded ${NATS_CONTAINER}" ;;
+    *) echo "post-render: cert written but SIGHUP of ${NATS_CONTAINER} returned HTTP $HTTP_CODE" >&2; exit 1 ;;
+  esac
+elif [ "$RUNNING" = "false" ]; then
+  HTTP_CODE=$(curl --silent --unix-socket "$SOCK" -X POST --max-time 10 \
+    -o /dev/null -w '%{http_code}' "${API}/start" || echo "000")
+  case "$HTTP_CODE" in
+    204 | 304) echo "post-render: cert written to ${CERTS_DIR}; ${NATS_CONTAINER} was stopped — started it (ADR-0039 recovery)" ;;
+    *) echo "post-render: cert written but start of ${NATS_CONTAINER} returned HTTP $HTTP_CODE" >&2; exit 1 ;;
+  esac
+else
+  echo "post-render: cert written but could not read ${NATS_CONTAINER} state from Docker API" >&2
+  exit 1
+fi

--- a/deploy/prod/compose.prod.yaml
+++ b/deploy/prod/compose.prod.yaml
@@ -41,9 +41,10 @@ services:
     image: nats:2.10-alpine
     container_name: ruby-core-prod-nats
     restart: unless-stopped
-    depends_on:
-      nats-init:
-        condition: service_completed_successfully
+    # No nats-init gate: its `service_completed_successfully` state is not
+    # re-established on host reboot, which blocked NATS from auto-starting
+    # (ADR-0039). NATS now waits for its cert via the wait-for-certs.sh
+    # entrypoint, so it recovers on reboot from the persisted cert.
     ports:
       # Client port (TLS only) - offset from dev (4222) to allow coexistence
       - "127.0.0.1:4223:4222"
@@ -57,6 +58,10 @@ services:
       - ../base/nats/nats.conf:/etc/nats/nats.conf:ro
       # TLS certificates and auth.conf (fetched/generated from Vault by nats-init)
       - nats-certs:/etc/nats/certs:ro
+      # Startup guard: blocks until the cert above exists, then exec's
+      # nats-server — decouples startup from nats-init (ADR-0039).
+      - ../base/nats/wait-for-certs.sh:/usr/local/bin/wait-for-certs.sh:ro
+    entrypoint: ["/usr/local/bin/wait-for-certs.sh"]
     command: ["-c", "/etc/nats/nats.conf"]
     networks:
       - default

--- a/deploy/prod/vault-agent/post-render.sh
+++ b/deploy/prod/vault-agent/post-render.sh
@@ -65,21 +65,36 @@ mv "$KEY_TMP"  "$CERTS_DIR/server-key.pem"
 mv "$CA_TMP"   "$CERTS_DIR/ca.pem"
 rm -f "$BUNDLE"
 
-# SIGHUP NATS via the Docker API. /kill (not /restart) with signal=SIGHUP
-# triggers NATS's config reload without dropping existing connections.
-# NATS validates the new cert during reload; if it's malformed it keeps the
-# old config (server/reload.go's validateOptions runs before Apply).
-HTTP_CODE=$(curl --silent --unix-socket /var/run/docker.sock \
-  -X POST --max-time 10 \
-  -o /dev/null -w '%{http_code}' \
-  "http://localhost/containers/${NATS_CONTAINER}/kill?signal=SIGHUP" || echo "000")
+# Reload or recover NATS via the Docker API, depending on its current state:
+#   - running → POST /kill?signal=SIGHUP: NATS reloads TLS in place without
+#     dropping existing connections (server/reload.go validates the new cert
+#     before Apply; a malformed cert keeps the old config).
+#   - stopped → POST /start: bring NATS up with the freshly written cert. This
+#     is the boot-recovery path (ADR-0039) — a SIGHUP cannot start a stopped
+#     container, so the renewer must start it rather than deadlock retrying.
+# Only a genuine Docker API/transport error is fatal; NATS being down is an
+# expected, recoverable state and must not fail the render.
+SOCK=/var/run/docker.sock
+API="http://localhost/containers/${NATS_CONTAINER}"
 
-case "$HTTP_CODE" in
-  204)
-    echo "post-render: cert+key+ca written to ${CERTS_DIR}; SIGHUP sent to ${NATS_CONTAINER}"
-    ;;
-  *)
-    echo "post-render: write OK but SIGHUP call returned HTTP $HTTP_CODE" >&2
-    exit 1
-    ;;
-esac
+RUNNING=$(curl --silent --unix-socket "$SOCK" --max-time 10 "${API}/json" |
+  grep -o '"Running":[a-z]*' | head -n1 | cut -d: -f2)
+
+if [ "$RUNNING" = "true" ]; then
+  HTTP_CODE=$(curl --silent --unix-socket "$SOCK" -X POST --max-time 10 \
+    -o /dev/null -w '%{http_code}' "${API}/kill?signal=SIGHUP" || echo "000")
+  case "$HTTP_CODE" in
+    204) echo "post-render: cert written to ${CERTS_DIR}; SIGHUP reloaded ${NATS_CONTAINER}" ;;
+    *) echo "post-render: cert written but SIGHUP of ${NATS_CONTAINER} returned HTTP $HTTP_CODE" >&2; exit 1 ;;
+  esac
+elif [ "$RUNNING" = "false" ]; then
+  HTTP_CODE=$(curl --silent --unix-socket "$SOCK" -X POST --max-time 10 \
+    -o /dev/null -w '%{http_code}' "${API}/start" || echo "000")
+  case "$HTTP_CODE" in
+    204 | 304) echo "post-render: cert written to ${CERTS_DIR}; ${NATS_CONTAINER} was stopped — started it (ADR-0039 recovery)" ;;
+    *) echo "post-render: cert written but start of ${NATS_CONTAINER} returned HTTP $HTTP_CODE" >&2; exit 1 ;;
+  esac
+else
+  echo "post-render: cert written but could not read ${NATS_CONTAINER} state from Docker API" >&2
+  exit 1
+fi

--- a/deploy/staging/compose.staging.yaml
+++ b/deploy/staging/compose.staging.yaml
@@ -55,9 +55,10 @@ services:
     image: nats:2.10-alpine
     container_name: ruby-core-staging-nats
     restart: unless-stopped
-    depends_on:
-      nats-init:
-        condition: service_completed_successfully
+    # No nats-init gate: its `service_completed_successfully` state is not
+    # re-established on host reboot, which blocked NATS from auto-starting
+    # (ADR-0039). NATS now waits for its cert via the wait-for-certs.sh
+    # entrypoint, so it recovers on reboot from the persisted cert.
     ports:
       # Staging client port — offset from prod (4223) to allow coexistence
       - "127.0.0.1:4224:4222"
@@ -68,6 +69,10 @@ services:
       - staging-nats-data:/data/jetstream
       - ../base/nats/nats.conf:/etc/nats/nats.conf:ro
       - nats-certs:/etc/nats/certs:ro
+      # Startup guard: blocks until the cert above exists, then exec's
+      # nats-server — decouples startup from nats-init (ADR-0039).
+      - ../base/nats/wait-for-certs.sh:/usr/local/bin/wait-for-certs.sh:ro
+    entrypoint: ["/usr/local/bin/wait-for-certs.sh"]
     command: ["-c", "/etc/nats/nats.conf"]
     healthcheck:
       test: ["CMD", "wget", "--spider", "-q", "http://localhost:8222/healthz"]

--- a/deploy/staging/vault-agent/post-render.sh
+++ b/deploy/staging/vault-agent/post-render.sh
@@ -65,21 +65,36 @@ mv "$KEY_TMP"  "$CERTS_DIR/server-key.pem"
 mv "$CA_TMP"   "$CERTS_DIR/ca.pem"
 rm -f "$BUNDLE"
 
-# SIGHUP NATS via the Docker API. /kill (not /restart) with signal=SIGHUP
-# triggers NATS's config reload without dropping existing connections.
-# NATS validates the new cert during reload; if it's malformed it keeps the
-# old config (server/reload.go's validateOptions runs before Apply).
-HTTP_CODE=$(curl --silent --unix-socket /var/run/docker.sock \
-  -X POST --max-time 10 \
-  -o /dev/null -w '%{http_code}' \
-  "http://localhost/containers/${NATS_CONTAINER}/kill?signal=SIGHUP" || echo "000")
+# Reload or recover NATS via the Docker API, depending on its current state:
+#   - running → POST /kill?signal=SIGHUP: NATS reloads TLS in place without
+#     dropping existing connections (server/reload.go validates the new cert
+#     before Apply; a malformed cert keeps the old config).
+#   - stopped → POST /start: bring NATS up with the freshly written cert. This
+#     is the boot-recovery path (ADR-0039) — a SIGHUP cannot start a stopped
+#     container, so the renewer must start it rather than deadlock retrying.
+# Only a genuine Docker API/transport error is fatal; NATS being down is an
+# expected, recoverable state and must not fail the render.
+SOCK=/var/run/docker.sock
+API="http://localhost/containers/${NATS_CONTAINER}"
 
-case "$HTTP_CODE" in
-  204)
-    echo "post-render: cert+key+ca written to ${CERTS_DIR}; SIGHUP sent to ${NATS_CONTAINER}"
-    ;;
-  *)
-    echo "post-render: write OK but SIGHUP call returned HTTP $HTTP_CODE" >&2
-    exit 1
-    ;;
-esac
+RUNNING=$(curl --silent --unix-socket "$SOCK" --max-time 10 "${API}/json" |
+  grep -o '"Running":[a-z]*' | head -n1 | cut -d: -f2)
+
+if [ "$RUNNING" = "true" ]; then
+  HTTP_CODE=$(curl --silent --unix-socket "$SOCK" -X POST --max-time 10 \
+    -o /dev/null -w '%{http_code}' "${API}/kill?signal=SIGHUP" || echo "000")
+  case "$HTTP_CODE" in
+    204) echo "post-render: cert written to ${CERTS_DIR}; SIGHUP reloaded ${NATS_CONTAINER}" ;;
+    *) echo "post-render: cert written but SIGHUP of ${NATS_CONTAINER} returned HTTP $HTTP_CODE" >&2; exit 1 ;;
+  esac
+elif [ "$RUNNING" = "false" ]; then
+  HTTP_CODE=$(curl --silent --unix-socket "$SOCK" -X POST --max-time 10 \
+    -o /dev/null -w '%{http_code}' "${API}/start" || echo "000")
+  case "$HTTP_CODE" in
+    204 | 304) echo "post-render: cert written to ${CERTS_DIR}; ${NATS_CONTAINER} was stopped — started it (ADR-0039 recovery)" ;;
+    *) echo "post-render: cert written but start of ${NATS_CONTAINER} returned HTTP $HTTP_CODE" >&2; exit 1 ;;
+  esac
+else
+  echo "post-render: cert written but could not read ${NATS_CONTAINER} state from Docker API" >&2
+  exit 1
+fi

--- a/docs/adr/0039-nats-boot-time-recovery.md
+++ b/docs/adr/0039-nats-boot-time-recovery.md
@@ -1,0 +1,107 @@
+# ADR-0039 - NATS Boot-Time Recovery: Decouple Startup from the nats-init One-Shot Gate
+
+* **Status:** Proposed
+* **Date:** 2026-06-26
+* **Supersedes:** *none*
+* **Superseded by:** *none*
+
+---
+
+## Context
+
+After a host power outage (2026-06-23) and a follow-up controlled reboot (2026-06-26),
+the ruby-core NATS servers (dev/staging/prod) failed to restart automatically — despite
+each carrying `restart: unless-stopped`. The NATS containers stayed `Exited` until started
+by hand, which left every dependent service (gateway/engine/notifier/presence/audit-sink)
+crash-looping — they cannot fetch their NKEY seed or connect without NATS — and the
+cert-renewer sidecar stuck in a retry loop.
+
+**Root cause (confirmed by comparative inspection of which containers the daemon
+auto-started at boot):** the `nats` service declares
+`depends_on: { nats-init: { condition: service_completed_successfully } }`. `nats-init` is a
+`restart: "no"` one-shot that bootstraps the NATS TLS material into the **persistent**
+`nats-certs` volume on first deploy. On reboot, `nats-init` does not re-run, so its
+"completed successfully" state is never re-established in the current boot — and the Docker
+daemon will not start a container whose `service_completed_successfully` dependency is
+unsatisfied. The cert already persists in the named volume, so NATS would start fine; only
+the stale one-shot gate holds it down.
+
+The asymmetry is diagnostic: at boot the daemon **did** start the services that depend on
+`nats: service_healthy` (they came up and crash-looped), and **did** start the cert-renewer
+(no `depends_on`). Only the containers gated on the *completed one-shot* were held. Manually
+`docker start`-ing NATS — which bypasses `depends_on` entirely — brought it up instantly
+using the already-present cert.
+
+A second, compounding fault: the cert-renewer's `post-render.sh` recovery path can only
+`SIGHUP` a **running** NATS. When NATS is stopped, the Docker API `kill?signal=SIGHUP` call
+returns a non-204 and the script `exit 1`s — so the one service that reliably survives a
+reboot can never bring NATS back; it just retry-loops. The system therefore has **no
+self-healing path** after a cold boot.
+
+This is the ruby-core analogue of the foundation Vault boot-race (foundation#110): a
+multi-service dependency chain whose ordering guarantees exist only under `docker compose up`
+and evaporate under the daemon's restart-on-boot.
+
+## Alternatives Considered
+
+**Host-level systemd boot unit (`docker compose up -d` on boot)** — Reliably re-imposes the
+intended start order, but lives outside the repo, requires host sudo, and leaves the in-repo
+anti-pattern in place. Retained as optional defense-in-depth, not the primary fix.
+
+**Make `nats-init` re-run on every boot (`restart: on-failure`/`always`)** — A one-shot that
+loops is itself an anti-pattern, and it does not address the gate semantics cleanly. The cert
+already persists, so re-running the bootstrap on every boot is unnecessary work.
+
+**Remove `nats-init` entirely and fold cert-fetch into the NATS entrypoint** — Larger change
+that mixes cert-issuance concerns into the NATS container and loses the clean separation of
+first-deploy bootstrap from runtime. Over-scoped for the problem.
+
+**Change the dependency condition to `service_started`** — Still a declared gate; it happens
+to be ignored by the daemon on boot today, but that is implementation-dependent behavior, not
+a guarantee. An explicit wait-for-cert in the NATS entrypoint is the robust correctness
+mechanism.
+
+## Decision
+
+1. The `nats` service **MUST NOT** gate its container startup on `nats-init`'s
+   `service_completed_successfully` condition. The hard `depends_on` gate **MUST** be removed
+   from all three environment compose files.
+
+2. The `nats` service **MUST** guard its own startup with an entrypoint that waits for its
+   TLS material (`server-cert.pem`, `server-key.pem`, `ca.pem`) to be present and non-empty
+   in the `nats-certs` volume before exec'ing `nats-server`. This makes NATS tolerant of start
+   ordering on both fresh deploy (waits for `nats-init` to populate the volume) and reboot
+   (cert already present → starts immediately).
+
+3. The cert-renewer `post-render.sh` **MUST** be able to recover a stopped NATS: after writing
+   the cert bundle, if the NATS container is running it **MUST** `SIGHUP` it (reload in place);
+   if it is not running it **MUST** start it. `post-render.sh` **MUST NOT** hard-fail
+   (deadlock) solely because NATS was unreachable at signal time.
+
+4. `nats-init` **SHOULD** retain `restart: "no"` and its first-deploy bootstrap role,
+   unchanged.
+
+## Consequences
+
+### Positive
+
+* NATS auto-recovers after a cold boot with no human intervention, regardless of daemon
+  restart ordering — closing the failure mode that took down ruby-core in the 2026-06-23
+  outage.
+* The cert-renewer becomes a genuine self-healing agent for NATS, eliminating the deadlock.
+* Removes a latent boot anti-pattern; the comparative-inspection method recorded here
+  documents how to detect the same class of fault elsewhere.
+
+### Negative
+
+* NATS startup now includes a wait loop. On a genuinely certless fresh deploy with Vault
+  unavailable, NATS waits (with logged progress and a bounded timeout) rather than failing
+  fast — trading fast-fail for self-heal-when-ready.
+* The cert-renewer now exercises container **start** (not just signal) over NATS via the
+  Docker socket it already mounts — a slightly broader blast radius for that sidecar, though
+  no new privilege is granted (the socket mount is unchanged).
+
+### Neutral
+
+* Formalizes the persistent `nats-certs` volume as the source of truth for NATS TLS material
+  at boot, with `nats-init` reduced to a first-deploy bootstrap rather than a per-boot gate.

--- a/docs/plans/PLAN-0029-nats-boot-resilience.md
+++ b/docs/plans/PLAN-0029-nats-boot-resilience.md
@@ -1,0 +1,114 @@
+# PLAN-0029 - NATS Boot Resilience
+
+* **Status:** Draft
+* **Date:** 2026-06-26
+* **Project:** ruby-core
+* **Roadmap Item:** none (operational reliability fix arising from the 2026-06-23 outage)
+* **Branch:** fix/nats-boot-resilience
+* **Related ADRs:** ADR-0039
+
+---
+
+## Scope
+
+Make the ruby-core NATS servers recover automatically after a host reboot, and make the
+cert-renewer able to heal a stopped NATS — removing the `service_completed_successfully`
+one-shot gate that holds NATS down on boot (see ADR-0039).
+
+**In scope:** the `nats` service definition, a new wait-for-cert entrypoint, and
+`post-render.sh`, across dev/staging/prod.
+
+**Out of scope:** the optional host-level systemd boot unit (a foundation/host concern,
+tracked separately); navi's separate network-attach issue; and the foundation Vault static-IP
+fix (already applied).
+
+---
+
+## Pre-conditions
+
+* [ ] On branch `fix/nats-boot-resilience` off `main` (`v0.24.1`).
+* [ ] Vault reachable and unsealed (foundation static-IP fix applied).
+* [ ] The persistent `nats-certs` volumes contain current cert material (they do — NATS is
+      currently running).
+
+---
+
+## Steps
+
+### Step 1 — Add a wait-for-cert entrypoint for NATS
+
+**Action:** Add `deploy/base/nats/wait-for-certs.sh` (POSIX `sh`, executable): waits — bounded
+to ~120s, logging progress — until `/etc/nats/certs/server-cert.pem`, `server-key.pem`, and
+`ca.pem` all exist and are non-empty, then `exec nats-server "$@"`. On timeout, exit non-zero
+(so `restart: unless-stopped` retries with visibility rather than deadlocking — see Open
+Questions).
+
+**Verification:** `sh -n deploy/base/nats/wait-for-certs.sh` parses clean; run against a
+populated dir it exec's `nats-server`; against an empty dir it logs "waiting for certs…" and
+loops.
+
+### Step 2 — Wire the entrypoint into the nats service and remove the gate (×3 envs)
+
+**Action:** In `deploy/{dev,staging,prod}/compose.{dev,staging,prod}.yaml`, on the `nats`
+service: mount `../base/nats/wait-for-certs.sh:/usr/local/bin/wait-for-certs.sh:ro`, set
+`entrypoint: ["/usr/local/bin/wait-for-certs.sh"]`, keep
+`command: ["-c", "/etc/nats/nats.conf"]`, and **remove** the
+`depends_on: { nats-init: { condition: service_completed_successfully } }` block (replace with
+a comment referencing ADR-0039).
+
+**Verification:** `docker compose -f deploy/<env>/compose.<env>.yaml config` renders without
+error and shows the new `entrypoint` and no `service_completed_successfully` gate on `nats`.
+
+### Step 3 — Make post-render.sh recover a stopped NATS (×3 envs)
+
+**Action:** In `deploy/{dev,staging,prod}/vault-agent/post-render.sh`, after the cert `mv`s:
+query `GET /containers/<NATS_CONTAINER>/json`; if `.State.Running == true` →
+`POST /kill?signal=SIGHUP` (as today); else → `POST /containers/<NATS_CONTAINER>/start`. Log
+the action taken. Only `exit 1` on a genuine Docker API/transport error — never merely because
+NATS was down.
+
+**Verification:** `sh -n post-render.sh` parses clean. Functional test in Step 5.
+
+### Step 4 — Fresh-deploy ordering test (dev)
+
+**Action:** On dev, recreate with an emptied cert volume in a throwaway test and confirm NATS
+waits for the cert, then comes healthy after `nats-init` populates it.
+
+**Verification:** `docker logs ruby-core-dev-nats` shows the wait loop then `Server is ready`;
+`docker ps` shows `ruby-core-dev-nats` healthy.
+
+### Step 5 — Self-heal test (dev, no reboot)
+
+**Action:** `docker stop ruby-core-dev-nats`, then trigger a cert-renewer render cycle (e.g.
+`docker restart ruby-core-dev-nats-cert-renewer`) and confirm `post-render.sh` starts NATS
+back up.
+
+**Verification:** cert-renewer log shows a "NATS was stopped — started <container>" line;
+`docker ps` shows `ruby-core-dev-nats` running again with **no** manual `docker start`.
+
+### Step 6 — Controlled-reboot acceptance (the real test)
+
+**Action:** After dev/staging validation and merge+deploy, schedule a controlled host reboot
+(console reachable).
+
+**Verification:** post-reboot, all three NATS come up unattended (StartedAt at the boot
+timestamp, healthy), the dependent services connect without crash-looping, and no manual
+intervention is required. This mirrors the original failure and is the acceptance criterion.
+
+---
+
+## Rollback
+
+Revert the branch's commits and redeploy the previous image/compose. The change is
+config + scripts only — `nats-certs` and the JetStream data volumes are untouched — so
+rollback is `git revert` + `docker compose up -d`. No data migration, no stateful change.
+
+---
+
+## Open Questions
+
+* **Entrypoint wait-timeout behavior.** On a genuinely certless fresh deploy with Vault down,
+  should NATS wait indefinitely (self-heal whenever Vault returns) or fail after a bounded
+  timeout so the orchestrator surfaces it? **Proposed:** bounded ~120s, then exit non-zero so
+  `restart: unless-stopped` retries — visibility without a hard deadlock. Confirm preference
+  before Step 1 lands.

--- a/docs/plans/archived/PLAN-0029-nats-boot-resilience.md
+++ b/docs/plans/archived/PLAN-0029-nats-boot-resilience.md
@@ -1,6 +1,6 @@
 # PLAN-0029 - NATS Boot Resilience
 
-* **Status:** Draft
+* **Status:** Complete
 * **Date:** 2026-06-26
 * **Project:** ruby-core
 * **Roadmap Item:** none (operational reliability fix arising from the 2026-06-23 outage)
@@ -95,6 +95,13 @@ back up.
 timestamp, healthy), the dependent services connect without crash-looping, and no manual
 intervention is required. This mirrors the original failure and is the acceptance criterion.
 
+**Result (2026-06-26):** PASS. After a real host reboot, all three NATS came up **7s after
+boot** — `running`, `healthy`, `restarts=0`, no manual `docker start`. The `wait-for-certs`
+entrypoint ran and JetStream recovered (`Server is ready`). ruby-core app services landed at
+`restarts=0–1` (vs 14–18 on the pre-fix reboot, where they crash-looped for ~5 min until NATS
+was hand-started). The prod gateway reconnected to NATS and re-subscribed to `ada_event` at
+boot. Vault (foundation static-IP fix) also came up unsealed on all 7 networks.
+
 ---
 
 ## Rollback
@@ -107,8 +114,7 @@ rollback is `git revert` + `docker compose up -d`. No data migration, no statefu
 
 ## Open Questions
 
-* **Entrypoint wait-timeout behavior.** On a genuinely certless fresh deploy with Vault down,
-  should NATS wait indefinitely (self-heal whenever Vault returns) or fail after a bounded
-  timeout so the orchestrator surfaces it? **Proposed:** bounded ~120s, then exit non-zero so
-  `restart: unless-stopped` retries — visibility without a hard deadlock. Confirm preference
-  before Step 1 lands.
+* **Entrypoint wait-timeout behavior.** *Resolved:* bounded ~120s, then exit non-zero so
+  `restart: unless-stopped` retries — visibility without a hard deadlock. Implemented in
+  `wait-for-certs.sh` (`CERT_WAIT_TIMEOUT`, default 120s); unit-tested both the timeout and
+  cert-present paths.


### PR DESCRIPTION
## Summary

After the 2026-06-23 power outage (and a confirming controlled reboot), the ruby-core NATS servers (dev/staging/prod) **failed to restart automatically**, leaving every dependent service (gateway/engine/notifier/presence/audit-sink) crash-looping until NATS was started by hand. This PR makes NATS self-recover from a cold boot with zero intervention.

## Root cause

The `nats` service gated startup on `nats-init` via `depends_on: { condition: service_completed_successfully }`. `nats-init` is a `restart: "no"` one-shot that bootstraps the TLS material into the **persistent** `nats-certs` volume on first deploy. On reboot it does not re-run, so its "completed successfully" state is never re-established — and the Docker daemon will not start a container whose `service_completed_successfully` dependency is unsatisfied. The cert was sitting right there in the volume; only the stale gate held NATS down.

Confirmed by comparative inspection: at boot the daemon started everything *except* the containers gated on the completed one-shot. A manual `docker start` (which bypasses `depends_on`) brought NATS up instantly.

Compounding it, the cert-renewer's `post-render.sh` could only `SIGHUP` a **running** NATS and `exit 1`'d when it was stopped — so the one sidecar that survives reboot could never recover NATS; it just retry-looped. No self-healing path existed.

See **ADR-0039** for the full decision record and alternatives considered.

## What changed

- **`deploy/base/nats/wait-for-certs.sh`** (new) — NATS entrypoint that waits (bounded ~120s) for its TLS material in the volume, then `exec`s `nats-server`. Decouples startup from the one-shot's completion state.
- **`deploy/{dev,staging,prod}/compose.*.yaml`** — wire the entrypoint into `nats`, mount the script, and **remove** the `service_completed_successfully` gate.
- **`deploy/{dev,staging,prod}/vault-agent/post-render.sh`** — start NATS if stopped, SIGHUP if running; only a genuine Docker API error is fatal. The renewer is now self-healing.

`nats-init` is unchanged (first-deploy bootstrap only).

## Validation

- **Unit** — `wait-for-certs.sh` tested both paths: loops + times out when certs absent; `exec`s `nats-server` when present.
- **dev + staging** — recreated on the new config (healthy, new entrypoint, gate gone); self-heal proven by stopping NATS and watching the renewer bring it back with no manual `docker start`.
- **prod** — recreated with JetStream fully intact (AUDIT_EVENTS 147,032 / HA_EVENTS 147,032 / KV_idempotency 74,719 msgs restored, all consumers recovered); no collateral service restarts.
- **Real reboot acceptance (PLAN-0029 Step 6)** — **PASS.** All three NATS came up **7s after boot**, `running`, `healthy`, `restarts=0`, unattended. ruby-core app services landed at `restarts=0–1` (vs **14–18** on the pre-fix reboot, where they crash-looped ~5 min). Prod gateway reconnected to NATS and re-subscribed to `ada_event` at boot.

## Pre-PR Checklist

- [x] README — no NATS/boot internals referenced; no update needed.
- [x] Runbook — no NATS/boot runbook exists; ADR-0039 captures the operational knowledge.
- [x] ADR — ADR-0039 added.
- [x] Plan — PLAN-0029 set to Complete with the reboot result, open question resolved, archived to `docs/plans/archived/` (final commit on the branch).
- [x] Pre-commit hooks pass (shellcheck, yamllint, gitleaks, markdownlint).
- [x] Branch name single-concern.

## Drift Observations

- **`navi-prod-digest` comes up with no networks attached after a reboot** (can't reach Vault → crash-loops). Separate root cause, explicitly out of scope here; persists across reboots. Will be filed as a `drift` issue and linked.

## Rollback

Config + scripts only — `nats-certs` and JetStream volumes untouched. `git revert` + `docker compose up -d`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)