### PR TITLE
docs(calendar): decompose home-calendar + API foundation effort (ROADMAP-0012)

### DIFF
--- a/docs/adr/0040-read-api-service-and-auth.md
+++ b/docs/adr/0040-read-api-service-and-auth.md
@@ -1,0 +1,68 @@
+# ADR-0040 - Synchronous Read API Service (`services/api`) with Defense-in-Depth Auth
+
+* **Status:** Proposed
+* **Date:** 2026-06-27
+* **Supersedes:** *(none)*
+* **Superseded by:** *(none)*
+
+---
+
+## Context
+
+Until now every ruby-core service is event-driven: services consume and publish NATS subjects, and the only HTTP surfaces are operational (`/health`) or a single write-translation endpoint on the gateway (`POST /ada/events`). There has been no synchronous read plane — nothing a client can query to ask "what is the current state of X."
+
+The home-calendar effort (ROADMAP-0012) needs exactly that: a client (Home Assistant, dashboards, future domains) must be able to `GET` calendar instances over an arbitrary date range, the people directory, and the childcare roster. That is a request/response read API, not an event stream. It is also explicitly intended to be **the first instance of a reusable read plane** that future domains (Ada, finance) will extend — so its shape, auth, and placement set precedent.
+
+This forces two decisions: **where** the read API lives, and **how** it authenticates.
+
+On placement: the gateway (ADR-0009) is a protocol translator for Home Assistant — a WebSocket ingest and a thin REST actuation surface. A typed, spec-first read API that must hold a Postgres connection and serve many domains has a different shape, a different blast radius, and a different dependency set (it must join the `postgres` network; the gateway must not). Folding it into the gateway would overload a service whose responsibilities are deliberately narrow.
+
+On auth: ADR-0020 established "edge authentication" for the gateway — authentication MUST be handled by Traefik (JWT in prod), the application MUST NOT contain primary auth logic, and the service is protected by network isolation (no published host port) plus Traefik↔service mTLS. That posture is correct and should extend to the new service. But ROADMAP-0012's brief also calls for the API to model a bearer security scheme **in the OpenAPI spec** — the spec is the source of truth, and a self-documenting API must declare how it is authenticated. A spec that declares `bearerAuth` while the app enforces nothing is dishonest documentation; an app that enforces a bearer in addition to the edge gate is strictly more secure. The tension is only apparent: ADR-0020 forbids the app from being the *primary* auth layer, not from adding a *second* one.
+
+## Alternatives Considered
+
+**Extend the gateway with the read endpoints** — Overloads a service whose ADR-0009 scope is HA protocol translation, forces the gateway onto the `postgres` network (widening its blast radius and credential scope), and couples the read plane's release cadence to the gateway's. Rejected: the read API is a distinct concern that future domains share.
+
+**A read API per domain (e.g. a calendar service that serves its own HTTP)** — Each new domain would re-solve OpenAPI bundling, codegen, auth middleware, Problem Details, and docs. Rejected: the explicit goal is one reusable read plane; per-domain HTTP servers defeat it and fragment the spec.
+
+**Edge-only auth, no in-app enforcement (strict ADR-0020 as written)** — Honors ADR-0020 literally but leaves the spec's declared `bearerAuth` unenforced and the service trusting any caller that reaches it on the Docker network. Rejected: a second, cheap enforcement layer meaningfully reduces blast radius if the edge is ever misconfigured or bypassed, and makes the spec truthful.
+
+**In-app auth only, drop the edge gate (supersede ADR-0020)** — Moves primary auth into the application, exactly what ADR-0020 rejected for sound reasons (mixed concerns, duplicated logic, no centralized policy). Rejected: the edge gate stays primary; we are adding depth, not relocating it.
+
+**OAuth2/JWT validation inside the app** — Full JWT validation (JWKS fetch, claim checks) in-app duplicates what Traefik already does at the edge and adds operational weight for a LAN-only, service-to-service API. Rejected as over-engineered for the second layer; a Vault-issued static bearer compared in constant time is sufficient depth behind the edge.
+
+## Decision
+
+We will introduce a dedicated read-API service and authenticate it in two layers.
+
+1. **New service.** Ruby-core's synchronous read plane **MUST** live in a new service at `services/api`, separate from the gateway. It **MUST** be the shared home for read endpoints across domains (calendar first; Ada/finance later), not a per-domain HTTP server.
+
+2. **Read-only.** `services/api` **MUST NOT** perform any database writes and **MUST** connect to Postgres using a role granted only `SELECT` (and `USAGE`/`CONNECT`), via a dedicated Vault path (`secret/data/ruby-core/postgres_readonly`). It **MUST NOT** run schema migrations — migrations remain owned by the engine.
+
+3. **Edge auth stays primary (ADR-0020 extended).** Authentication and network posture from ADR-0020 **MUST** apply to `services/api`: the container port **MUST NOT** be published to the host; the connection from Traefik to `services/api` **MUST** be secured with mTLS using an internal-CA client certificate; Traefik edge authentication (JWT in production) remains the primary gate. ADR-0020 remains in force for the gateway and is hereby generalized to cover `services/api`.
+
+4. **In-app bearer as defense-in-depth.** `services/api` **MUST** additionally enforce a bearer token, modeled in the OpenAPI spec as an `http`/`bearer` security scheme and implemented as the ogen `SecurityHandler`. The expected token is a Vault-issued service token read at startup (`secret/data/ruby-core/api/token`) and compared in **constant time**. This layer is secondary to the edge gate; a request that fails it **MUST** receive an RFC 9457 `application/problem+json` 401. The OpenAPI spec **MUST NOT** declare a security scheme the service does not enforce.
+
+5. **Operational endpoints stay unauthenticated and ungenerated.** `GET /health` **MUST** be served outside the authed, ogen-generated mux so Traefik and Uptime Kuma can probe it. The Scalar docs (`/docs`) and raw spec (`/openapi.yaml`) **SHOULD** sit behind the bearer (operator tooling, not public).
+
+## Consequences
+
+### Positive
+
+* A single, reusable read plane: future domains add fragments + handlers instead of re-solving HTTP, auth, and docs.
+* Three independent layers must all fail for unauthorized data access: network isolation, Traefik↔api mTLS, and the in-app bearer — strictly stronger than ADR-0020 alone.
+* The OpenAPI spec is honest: the declared security scheme is actually enforced, so generated clients and docs reflect reality.
+* A `SELECT`-only role makes a read endpoint physically incapable of mutating state even under a handler bug — the read/write split is enforced by Postgres, not convention.
+* The gateway keeps its narrow ADR-0009 scope and stays off the `postgres` network.
+
+### Negative
+
+* A new service to build, deploy, monitor, and back the auth material for — more compose wiring, another PKI role, another Uptime Kuma monitor, another image in the CI matrix.
+* The in-app bearer is one more secret to issue, store in Vault, inject, and rotate; a stale token is a new failure mode (mitigated: it surfaces as a clean 401, not data exposure).
+* A read-only Postgres role and the `postgres_readonly` Vault path must be provisioned on the shared foundation Postgres before `services/api` can deploy — a sequencing dependency outside this repo.
+
+### Neutral
+
+* Formalizes `services/api` as a long-lived architectural component and a critical read-path dependency for Home Assistant and dashboards.
+* Establishes that in-app auth in ruby-core is *additive* defense-in-depth, never a replacement for the edge gate — a precedent future services inherit.
+* The bearer is a single shared service token, not per-caller identity; finer-grained authorization is deferred until a second distinct consumer needs different access.

--- a/docs/adr/0041-openapi-lifecycle-and-codegen-governance.md
+++ b/docs/adr/0041-openapi-lifecycle-and-codegen-governance.md
@@ -1,0 +1,73 @@
+# ADR-0041 - OpenAPI Lifecycle & Codegen Governance for the HTTP API
+
+* **Status:** Proposed
+* **Date:** 2026-06-27
+* **Supersedes:** *(none)*
+* **Superseded by:** *(none)*
+
+---
+
+## Context
+
+ROADMAP-0012 introduces ruby-core's first synchronous HTTP API (`services/api`, ADR-0040). An HTTP API is a long-lived external contract: Home Assistant, dashboards, and future domains will couple to its shapes. The global engineering standards require APIs to be "structured and self-documenting" with an OpenAPI spec maintained alongside the code, and require code generation to be enforced in CI ("regenerate, fail on diff" — the same discipline already applied to sqlc/migrate for the database).
+
+This raises a governance question distinct from the one ADR-0014 already answered. ADR-0014 governs **shared data schemas carried over NATS** (YAML rules, CloudEvents) with a *schema-in-code* strategy: Go structs are the source of truth. That decision is correct for the event bus and remains in force — including for the calendar write-event contracts, which are NATS payloads. But the HTTP read surface is a different artifact with different consumers (including a non-Go Home Assistant client), and "Go structs are the truth" produces a spec that is reverse-engineered from handlers and drifts from documentation. For a self-documenting API the contract must come first and the code must be provably derived from it.
+
+We also need machine enforcement, not discipline. The system has no human reviewer besides the solo developer; a documentation standard that depends on remembering to update a spec, add examples, and avoid breaking changes will erode. The standards already call for generation enforced in CI; the API surface additionally needs lint enforcement (every operation documented) and breaking-change detection (the contract can't silently break consumers).
+
+Today none of this tooling exists in the repo: no OpenAPI spec, no ogen/oapi-codegen, no Spectral, no oasdiff, and no codegen fail-on-diff gate (not even for sqlc, despite the discipline being followed manually).
+
+## Alternatives Considered
+
+**Schema-in-code for HTTP too (extend ADR-0014, generate the spec from Go)** — Keeps one mental model, but makes the spec a derived artifact that lags the code, produces awkward/under-documented OpenAPI, and offers no natural place to require descriptions/examples or to diff for breaking changes. Rejected: defeats the "self-documenting, spec-is-the-contract" standard for the API surface.
+
+**oapi-codegen instead of ogen** — A capable generator, but ogen produces a stricter typed server interface with built-in request/response validation and a first-class error handler, which fits "validation generated from the spec" with less hand-written glue. Rejected as the lesser fit; either would work, ogen is chosen for the stronger generated contract.
+
+**A single hand-authored monolithic `openapi.yaml`** — Simpler tooling (no bundler), but one file becomes unmanageable as domains accumulate (calendar, then Ada, finance) and makes per-domain ownership unclear. Rejected: per-domain fragments bundled into one served spec scale better and match the multi-domain intent.
+
+**Lint/breaking-change checks as advisory (warn, don't block)** — Lower friction, but advisory gates are ignored gates for a solo developer; drift and accidental breaking changes would still ship. Rejected: the whole point is to make drift structurally impossible, which requires blocking.
+
+**A runtime schema registry / contract-testing service** — Overkill for a single-node V0, the same conclusion ADR-0014 reached for event schemas. Rejected: static spec + CI gates deliver the guarantees without new infrastructure.
+
+## Decision
+
+We adopt a spec-first lifecycle for the HTTP API, enforced in CI.
+
+1. **Spec is the source of truth.** For the HTTP API surface, the hand-authored OpenAPI document **MUST** be the source of truth; the Go server interface, Go client, request/response validation, and the Python client **MUST** be generated from it — never hand-edited. This applies to the HTTP surface only; **ADR-0014 (schema-in-code) remains the governance for NATS/CloudEvents contracts**, including the calendar write-event payloads.
+
+2. **Fragmented spec, bundled.** The spec **MUST** be authored as per-domain fragments under `api/openapi/` (`calendar.yaml`, later `ada.yaml`, `finance.yaml`, plus shared `components/`) and bundled into a single served document (`api/openapi.gen.yaml`) with **Redocly CLI** (`@redocly/cli bundle`). The bundled file **MUST** be checked in and is the input to code generation and the served `/openapi.yaml`.
+
+3. **Generator.** Code generation **MUST** use **ogen** (go-installable, pinned), driven by a `//go:generate` directive, emitting into `services/api/oas` (package `oas`). The Python client for the Home Assistant read-proxy **MUST** be generated with `openapi-python-client` (pinned) into `clients/python/` and checked in.
+
+4. **Versioning & errors.** The API **MUST** be versioned by URL path (`/v1/`). All error responses **MUST** use RFC 9457 Problem Details (`application/problem+json`), defined once as a shared component and referenced by every operation's error responses.
+
+5. **CI gates (all blocking on merge).** A CI stage **MUST** enforce:
+   * **Codegen fail-on-diff** — re-bundle, re-generate (ogen + python client), and re-run `sqlc generate`, then fail if `git diff` is non-empty. (This gate also closes the existing manual sqlc discipline gap.)
+   * **Spectral lint** — a ruleset requiring a `description` **and** an `example` on every operation, parameter, and response; missing documentation fails the build.
+   * **oasdiff breaking-change detection** — the PR spec is compared against the base branch; an unapproved breaking change fails the build.
+
+6. **Pagination convention.** A cursor-pagination convention **MUST** be documented in the API style guide (`docs/api/style-guide.md`) for future endpoints. Only the date-range filter that the calendar read endpoint needs is implemented now; cursor pagination is not built until an endpoint requires it.
+
+7. **Deferred, with room left.** Schemathesis fuzzing and mock servers are **out of scope** now. AsyncAPI is the intended future machine-readable home for the NATS write-event contracts; the payload schemas **SHOULD** be authored so they port cleanly, but AsyncAPI is not adopted here.
+
+## Consequences
+
+### Positive
+
+* Drift between the API, its documentation, its Go server/client, and its Python client becomes structurally impossible — CI rejects any mismatch.
+* Every endpoint is documented (description + example) by construction, satisfying the self-documenting-API standard automatically.
+* Breaking changes are caught mechanically before merge, protecting Home Assistant and dashboard consumers.
+* Adding a domain is "add a fragment + handlers + regenerate," a repeatable path future domains inherit.
+* The fail-on-diff gate retroactively hardens the previously-manual sqlc generation discipline.
+
+### Negative
+
+* New tooling spanning three ecosystems: ogen/oasdiff/sqlc (Go), Redocly/Spectral (Node), openapi-python-client (pip) — all must be pinned and available to CI (and ideally pre-commit), adding setup and maintenance surface.
+* Spec-first adds an authoring step before code: a change starts in YAML, then regenerates — slower than editing a handler directly, and a different workflow from the schema-in-code model used elsewhere in the repo.
+* Two governance models now coexist (spec-first for HTTP, schema-in-code for NATS); the boundary must be understood to avoid applying the wrong one.
+
+### Neutral
+
+* Establishes ogen + Redocly + Spectral + oasdiff as the standard API toolchain future domains build on.
+* Checked-in generated code (Go `oas/`, `clients/python/`, sqlc output) grows the diff surface of routine changes, in exchange for reviewable, buildable-offline artifacts.
+* Formalizes a clear split: ADR-0041 owns the synchronous HTTP contract; ADR-0014 owns the asynchronous event contract.

--- a/docs/adr/0042-calendar-sync-architecture.md
+++ b/docs/adr/0042-calendar-sync-architecture.md
@@ -1,0 +1,88 @@
+# ADR-0042 - Calendar Sync Architecture: Google as Source of Record, Local Durable Mirror
+
+* **Status:** Proposed
+* **Date:** 2026-06-27
+* **Supersedes:** *(none)*
+* **Superseded by:** *(none)*
+
+---
+
+## Context
+
+ROADMAP-0012 makes ruby-core the durable authority and read source for the family calendar while keeping the Google **Family** calendar as the human-facing system of record. The household will keep adding and editing events in the Google app on their phones; ruby-core must reflect those changes, serve all reads, layer on local-only data Google cannot hold (event subjects, childcare assignments), own reminder policy, and drive automations — and it must also write back the events ruby-core itself originates.
+
+Several forces shape the design:
+
+* **The account is a consumer Gmail account.** It cannot be impersonated by a Google Workspace service account, so domain-wide delegation is unavailable. Access must be via OAuth user consent with an offline refresh token.
+* **Google's OAuth "Testing" publishing status expires refresh tokens after ~7 days.** A long-lived integration requires the OAuth app in **production** publishing status.
+* **NATS is at-least-once** (the existing engine consumer already dedupes on event id, ADR-0025). A create that is redelivered must not double-insert into Google.
+* **Two writers can race.** ruby-core writes through to Google and also polls Google for changes; without care, ruby-core re-observes its own writes and reacts to them (echo ping-pong), and a concurrent human edit can be clobbered.
+* **Google's data model is specific.** Dates are a date XOR datetime+timezone trio; all-day `end` is exclusive; recurrence is a set of RRULE/EXDATE/RDATE lines; a modified or cancelled single occurrence is a separate event carrying `recurringEventId` and an original-start anchor. A faithful mirror must reproduce this rather than flatten it, or downstream consumers get subtly wrong times (especially across DST).
+* **The repo already has the building blocks.** Postgres persistence with sqlc + golang-migrate (Ada, ADR-0029/0037), a single-writer principle (ADR-0023), self-contained engine processors (ADR-0007), idempotency tracking (ADR-0025), and the HA→NATS write path through the gateway (ADR-0009) with subject naming per ADR-0027.
+
+The decision records how sync, write-through, persistence shape, recurrence, and reminders fit together — and the conscious boundaries (single calendar, series-level edits) we are accepting for the MVP.
+
+## Alternatives Considered
+
+**Google service account with domain-wide delegation** — The clean impersonation path, but impossible on a consumer Gmail account (delegation requires a Workspace domain). Rejected: not available for this account.
+
+**Treat Google as a cache; make ruby-core the write-side system of record** — ruby-core would own events and push to Google one-directionally. Rejected: the family lives in the Google app; it must stay the human-facing source of record, and edits made there must win. ruby-core is the durable *mirror* and read authority, not the primary author.
+
+**Google push notifications (`watch` channels) instead of polling** — Lower latency, no timer. Rejected *for now*: push requires a public HTTPS webhook endpoint and channel lifecycle management; ~60s polling is operationally trivial on a single node. The design keeps push as a drop-in future replacement — a push only needs to trigger the same incremental sync the timer triggers.
+
+**Flatten dates to a single UTC timestamp pair in the mirror** — Simpler schema, but loses the all-day distinction, the original timezone, and the exclusive-end convention, and makes DST-correct recurrence expansion impossible. Rejected: the mirror must reproduce Google's native shape; derived UTC columns exist only for range queries.
+
+**Pre-expand recurring events into stored instance rows** — Makes range reads a trivial SELECT, but stores a combinatorial explosion, drifts whenever a rule changes, and still needs tz logic to generate. Rejected: expansion is computed on demand, timezone-aware, with a max-window guard.
+
+**Honor Google's per-event reminder overrides** — Would mirror a `reminders` column and fire what users set in the Google app. Rejected: reminder policy is a ruby-core concern (it drives HA automations with no card open); honoring Google's overrides splits ownership and creates two competing reminder sources. ruby-core owns reminders outright.
+
+**Per-instance recurrence editing in the MVP** — Matches Google's full capability, but the write path, idempotency, and overlay cascade get materially more complex. Rejected for MVP: delete/edit are series-level; the `original_start_*` columns are laid down now as the groundwork for per-instance later.
+
+**Multi-calendar from the start** — More general, but `google_event_id` is unique only within a calendar, so the mirror PK and every overlay foreign key would need a calendar dimension. Rejected: single-calendar is a conscious boundary; going multi later is a known, scoped migration.
+
+## Decision
+
+1. **Authority split.** Google **MUST** remain the human-facing system of record for standard calendar fields (summary, start/end, recurrence, location, description, calendarId, attendees). ruby-core **MUST** own, locally and **never** written to Google, the event subjects, childcare assignments, people/provider registries, reminder policy, and all derived state.
+
+2. **Auth.** Access **MUST** use OAuth user-consent with an offline refresh token (scope `https://www.googleapis.com/auth/calendar.events`), stored in Vault at `secret/ruby-core/google` (`client_id`, `client_secret`, `refresh_token`, `calendar_id`). The OAuth app **MUST** be in **production** publishing status. The Family calendar **MUST** be addressed by `calendarId`.
+
+3. **Single writer, single poller.** Exactly one component — the calendar processor in the engine — **MUST** write to Google and poll Google (ADR-0023). The poller **MUST** run only where enabled (`CALENDAR_SYNC_ENABLED`, off by default outside production) so the single shared calendar is never double-synced across environments.
+
+4. **Incremental sync.** The poller **MUST** use Google's sync-token incremental polling (~60s), persisting `nextSyncToken` in a `SYNC_STATE` row keyed by `calendar_id`. A **410** on sync **MUST** trigger a full resync with a fresh token (clear the stored token, page through, record the new token) and **MUST** be logged — never a silent stop. The poller **MUST** be structured so a future Google `watch`/push can replace the timer by triggering the same incremental sync.
+
+5. **Write-through + echo reconciliation.** A local write **MUST** call Google, take the returned id/etag, and upsert the mirror in the same operation. Creates **MUST** dedupe on an `idempotency_key` carried in the payload so a redelivered create cannot double-insert into Google. Updates **MUST** send the stored `etag` as `If-Match`; a Google **412** **MUST** be handled by resyncing and retrying, not by clobbering. The poller **MUST** reconcile re-observed self-writes by `etag` so a write does not trigger reprocessing (no ping-pong).
+
+6. **Mirror shape.** The `CALENDAR_EVENT` table **MUST** reproduce Google's native shape: `google_event_id` as primary key (single-calendar boundary); start/end/original-start each a **date XOR datetime+timezone** trio with `all_day` distinguishing; all-day `end` stored and surfaced as **exclusive**; `recurrence` as a `text[]` of RRULE/EXDATE/RDATE lines; `recurring_event_id` and the `original_start_*` trio on override/cancelled children; `status` as `text` + CHECK (`confirmed|tentative|cancelled`); `etag`, `sequence`, full `raw` jsonb. Derived `start_utc`/`end_utc` columns **MUST** exist for range queries and sorting only — internal, one-directional, never an output transform. Enum-like columns **MUST** be `text` + CHECK constraints, not Postgres native enums.
+
+7. **Recurrence.** A modified or cancelled single occurrence **MUST** be stored as a separate event carrying `recurring_event_id` + the `original_start_*` trio. Cancelled children **MUST** be retained (`status = cancelled`) and subtracted during expansion like implicit EXDATEs. Expansion **MUST** be on-demand and **timezone-aware** (a weekly 9am slot stays 9am local across DST), with a **max-window guard** so a single request cannot expand an unbounded range.
+
+8. **Delete & cascade.** MVP delete **MUST** be series-level (per-instance delete deferred). A true event delete/cancel **MUST** cascade the overlay rows; cancelled events **MUST** otherwise be retained and filtered from reads and from suggestion counting (no destructive cascade on cancel).
+
+9. **Reminders.** ruby-core **MUST** own reminder policy outright and **MUST NOT** read or honor Google's per-event reminder overrides (no `reminders` mirror column). The engine **MUST** compute reminders from event start times over the mirror and surface them via `sensor.ruby_home_calendar_status` (next event + active-reminder flag, always-on) and a NATS `calendar.reminder.due`.
+
+10. **Persistence reuse.** The calendar store **MUST** follow the established Postgres pattern (sqlc + golang-migrate, shared foundation Postgres, a dedicated `schema_migrations_calendar` tracking table; ADR-0029/0037). Migrations **MUST** be owned and run by the engine; `services/api` reads only (ADR-0040).
+
+## Consequences
+
+### Positive
+
+* Google stays the system the family already uses; ruby-core adds durability, local overlay, reminders, and automation without changing their workflow.
+* The mirror is forward-compatible: native-shape columns plus full `raw` jsonb mean unmodeled Google fields are retained and queryable later.
+* At-least-once delivery and concurrent human edits are both handled explicitly (idempotency key; etag `If-Match`/412; etag echo reconciliation) rather than hoped away.
+* DST-correct, on-demand expansion avoids a stored-instance explosion and avoids the drift that pre-expansion suffers when a rule changes.
+* Reusing the Ada persistence and engine-processor patterns keeps the new code idiomatic and the operational surface familiar.
+* The polling design is a clean seam: swapping in Google push later changes the trigger, not the sync logic.
+
+### Negative
+
+* The OAuth-in-production requirement is a real operational footgun: a token that lapses (app demoted to testing, consent revoked) silently stops sync until re-consented — it MUST be alerted on, and re-consent is a manual runbook step.
+* Bidirectional sync with etag reconciliation is genuinely subtle; an incorrect echo/etag comparison can loop or clobber, so it demands strong unit coverage and is the highest-risk part of the build.
+* New durable state (`CALENDAR_EVENT`, `SYNC_STATE`, overlay) is a production-readiness obligation: backup, restore, and a force-resync runbook are required before it is considered production-ready.
+* Single-calendar and series-level-only edits are real functional limits the household will feel (no per-instance "just this Tuesday" edit yet).
+* ruby-core owning reminders means a reminder set in the Google app will not fire — a deliberate behavior change that must be communicated to the family.
+
+### Neutral
+
+* Establishes the engine as the single calendar writer/poller and `services/api` as the read surface — a fixed division of responsibility.
+* `google_event_id` as PK and overlay FKs bake in the single-calendar assumption; going multi-calendar later is a known, scoped migration (add the calendar dimension to the PK and every overlay FK).
+* The full `raw` jsonb column trades storage for forward compatibility.

--- a/docs/api/style-guide.md
+++ b/docs/api/style-guide.md
@@ -1,0 +1,100 @@
+# ruby-core HTTP API — Style Guide
+
+Conventions for ruby-core's synchronous HTTP read API (`services/api`, ADR-0040), governed
+spec-first per ADR-0041. This guide is the human-readable companion to the OpenAPI spec: the spec
+is the contract, this explains the conventions every fragment is expected to follow.
+
+It applies to the HTTP read surface only. NATS write-event contracts are governed separately
+(ADR-0014 schema-in-code; the calendar write payloads are documented with the calendar plan).
+
+---
+
+## Source of truth & generation
+
+- The spec is hand-authored as per-domain fragments under `api/openapi/` and bundled into
+  `api/openapi.gen.yaml` (Redocly). The bundle is the input to ogen (Go server/client) and
+  `openapi-python-client` (HA read-proxy client). **Generated code is never hand-edited.**
+- CI blocks merge on: codegen fail-on-diff, Spectral lint, and oasdiff breaking-change detection
+  (ADR-0041). Treat a red gate as a contract violation, not a CI annoyance.
+
+## Versioning
+
+- The API is versioned by **URL path**: every operation lives under `/v1/`.
+- A breaking change (removing/renaming a field, changing a type, tightening validation) requires a
+  new path version, not an in-place edit. oasdiff enforces this mechanically.
+- Additive changes (new optional fields, new endpoints) stay within the current version.
+
+## Documentation (enforced)
+
+Spectral fails the build if any of these is missing, so author them up front:
+
+- Every **operation** has a `summary` and a `description`.
+- Every **parameter** has a `description` and an `example`.
+- Every **response** has a `description`, and every response body schema carries an `example`.
+
+Write descriptions for a future reader with no context. Examples must be realistic (a plausible
+event, person, provider) — not `"string"`.
+
+## Errors — RFC 9457 Problem Details
+
+- All error responses use `application/problem+json` and the shared `Problem` component (defined
+  once, referenced everywhere). Never invent a per-endpoint error shape.
+- Fields: `type` (a stable URI/slug identifying the error class), `title` (short, stable),
+  `status` (matches the HTTP status), `detail` (human-readable, specific to this occurrence),
+  `instance` (optional, the offending request path). Domain-specific context goes in extension
+  members, not in `detail` string-munging.
+- Conventions:
+  - `400` — malformed/invalid request (failed validation, range exceeds the max window).
+  - `401` — missing/invalid bearer (defense-in-depth layer; the edge gate is primary, ADR-0040).
+  - `404` — addressed resource does not exist.
+  - `422` — well-formed but semantically rejected (reserve for cases distinct from 400).
+  - `500` — unexpected; `detail` must not leak internals.
+
+## Naming & shapes
+
+- JSON property names are `snake_case`, matching the underlying mirror columns and the NATS payloads
+  (avoids a translation layer and keeps the spec legible against the schema).
+- Timestamps are RFC 3339. The calendar surface mirrors Google's native shape deliberately: a date
+  XOR a datetime+timezone, with `all_day` distinguishing, and **all-day `end` is exclusive** (a
+  one-day event on the 26th ends on the 27th). This convention is surfaced to consumers, documented
+  on the schema, not hidden — see ADR-0042.
+- Enpoints return flat, sorted collections where a range is requested (calendar instances are
+  expanded and sorted server-side).
+
+## Filtering & ranges
+
+- The calendar read endpoint takes explicit `start` and `end` query parameters (RFC 3339) and
+  returns the expanded, sorted instances in that window.
+- **Max-window guard:** range requests that would expand an excessive span MUST be rejected with a
+  `400` Problem (`type` identifying the window-exceeded class). On-demand recurrence expansion is
+  unbounded otherwise; the guard is mandatory, not advisory (ADR-0042).
+
+## Pagination (convention now, implementation later)
+
+No endpoint paginates today (calendar uses the date-range filter; the overlay collections are
+small). When an endpoint needs pagination, it MUST follow this **opaque-cursor** convention rather
+than offset/limit:
+
+- Request: `?cursor=<opaque>&limit=<n>` — `cursor` omitted on the first page; `limit` bounded by a
+  documented server maximum.
+- Response: the page plus a `next_cursor` (string, omitted/null on the last page). Cursors are
+  opaque tokens the client echoes back verbatim — never construct or parse them client-side.
+- Rationale: opaque cursors are stable under concurrent inserts/deletes (offset pagination skips or
+  repeats rows when the underlying set shifts) and let the server change the underlying ordering key
+  without a contract break.
+
+Offset/limit pagination is **not** to be added. Implement the cursor convention only when a real
+endpoint requires it.
+
+## Authentication
+
+- Two layers (ADR-0040): Traefik edge auth + mTLS is primary; an in-app Vault-issued **bearer**
+  (`http`/`bearer` security scheme) is defense-in-depth. The spec declares `bearerAuth` and the
+  service enforces it — the spec never declares a scheme that isn't enforced.
+- `GET /health` is unauthenticated and lives outside the generated mux (for Traefik/Uptime Kuma).
+
+## Deferred (leave room, don't build)
+
+- Schemathesis fuzzing and mock servers — out of scope (ADR-0041).
+- AsyncAPI for the NATS write-event contracts — the eventual machine-readable home; author write
+  payload schemas so they port cleanly, but do not adopt AsyncAPI yet.

--- a/docs/plans/PLAN-0030-api-foundation.md
+++ b/docs/plans/PLAN-0030-api-foundation.md
@@ -1,0 +1,174 @@
+# PLAN-0030 - API Foundation (`services/api`)
+
+* **Status:** Draft
+* **Date:** 2026-06-27
+* **Project:** ruby-core
+* **Roadmap Item:** docs/roadmap/ROADMAP-0012-home-calendar.md (effort 0012.1)
+* **Branch:** feat/api-foundation
+* **Related ADRs:** ADR-0040 (read-API service + defense-in-depth auth), ADR-0041 (OpenAPI lifecycle & codegen governance)
+
+---
+
+## Scope
+
+Stand up `services/api` — ruby-core's first synchronous HTTP read plane — as a spec-first platform
+with **no real domain data yet**. This plan delivers: the OpenAPI tooling chain (Redocly bundle →
+ogen → Spectral → oasdiff → openapi-python-client), a minimal served spec (`/v1/ping` placeholder
+endpoint plus the shared `Problem` component and `bearerAuth` scheme), the service skeleton
+(Vault + read-only Postgres boot, ogen server mounted on `http.Server`, RFC 9457 error handler,
+constant-time bearer middleware, Scalar docs, `/health`), the Makefile codegen targets, the new CI
+gate stage, and deploy wiring. **Out of scope:** calendar/directory/childcare endpoints and any
+query against real tables (PLAN-0032/0033); cursor-pagination implementation; mTLS server config on
+`services/api` (tracked here as a follow-up but the bearer + network isolation land now).
+
+---
+
+## Pre-conditions
+
+* [ ] On branch `feat/api-foundation` cut from latest `main`.
+* [ ] A read-only Postgres role exists on foundation Postgres and its DSN is stored at Vault
+      `secret/ruby-core/postgres_readonly` (host-side provisioning; see Open Questions if not yet
+      done — the skeleton can be built and unit-tested without it, but integration tests and deploy
+      need it).
+* [ ] A bearer token for the API is generated and stored at Vault `secret/ruby-core/api` field
+      `token` (via `ruby-core-writer`).
+* [ ] Node (for `@redocly/cli`, `@stoplight/spectral-cli`) and Go toolchain available locally and on
+      the self-hosted runner; `oasdiff`, `ogen` go-installable.
+
+---
+
+## Steps
+
+### Step 1 — Scaffold the spec tree and Redocly bundle
+
+**Action:** Create `api/openapi/openapi.root.yaml` (info, `servers: [{url: /v1}]`, the `bearerAuth`
+security scheme, a `$ref` to a placeholder `paths/ping.yaml` with `GET /ping`), `api/openapi/components/problem.yaml`
+(RFC 9457 `Problem` schema with description + example), and `api/openapi/paths/ping.yaml` (fully
+documented: summary, description, 200 response with example, default → `Problem`). Add a pinned
+`package.json` with `@redocly/cli` and `@stoplight/spectral-cli`, and `api/.spectral.yaml` requiring
+description + example on every operation/parameter/response.
+
+**Verification:** `npx @redocly/cli bundle api/openapi/openapi.root.yaml -o api/openapi.gen.yaml`
+produces a single valid file; `npx spectral lint api/openapi.gen.yaml` exits 0.
+
+### Step 2 — Generate the ogen server + Go client
+
+**Action:** Add `services/api/oas/generate.go` with
+`//go:generate go run github.com/ogen-go/ogen/cmd/ogen -target . -package oas -clean ../../../api/openapi.gen.yaml`.
+Add ogen to `go.mod` tooling (a `tools.go` build-tagged import, or the Go 1.25 `go tool` directive).
+Run generation.
+
+**Verification:** `go generate ./services/api/oas/...` produces `services/api/oas/*.go`;
+`go build ./services/api/oas/...` compiles; the generated `Handler` interface contains a `Ping`
+method and a `SecurityHandler` with `HandleBearerAuth`.
+
+### Step 3 — Generate the Python client
+
+**Action:** Add a pinned `openapi-python-client` invocation (documented in the Makefile target,
+Step 7) generating into `clients/python/`. Run it. Check the output in.
+
+**Verification:** `openapi-python-client generate --path api/openapi.gen.yaml --output-path clients/python --overwrite`
+produces a package; `git status` shows the generated tree; a trivial import of the generated package
+under Python succeeds (documented manual check; CI re-generates and diffs).
+
+### Step 4 — Service skeleton: boot + read-only pgxpool
+
+**Action:** Create `services/api/main.go` mirroring `services/gateway/main.go`'s boot order:
+`logging.NewLogger("api")` + `slog.SetDefault`, `boot.LoadConfig("api")`, fetch the read-only DSN via
+`boot.FetchPostgresConfig(addr, token, "secret/data/ruby-core/postgres_readonly")`, `pgxpool.New`,
+signal handling, graceful shutdown. **No `MigrateUp`.** NATS is not wired (read API does not publish
+in this slice).
+
+**Verification:** `go build ./services/api/...` compiles; running locally against the read-only DSN
+opens the pool and logs "api: ready" without attempting any write.
+
+### Step 5 — App wiring: ogen mux, error handler, auth, health, docs
+
+**Action:** Create `services/api/app/{app.go,auth.go,problem.go,docs.go}`:
+
+* `problem.go`: implement the ogen `ErrorHandler` rendering `application/problem+json` from the shared
+  `Problem` shape; centralize status→Problem mapping.
+* `auth.go`: implement `HandleBearerAuth` doing a `crypto/subtle.ConstantTimeCompare` against the
+  Vault-issued token (read at startup from `secret/data/ruby-core/api/token`); failure → 401 Problem.
+* `docs.go`: `GET /openapi.yaml` serves the `go:embed`-ed `api/openapi.gen.yaml`; `GET /docs` serves a
+  small HTML page loading the pinned Scalar standalone JS against `/openapi.yaml` (behind bearer).
+* `app.go`: build the ogen `Server` (handlers + security + error handler), chain it behind the bearer,
+  add a plain `GET /health` **outside** the generated mux, mount on `http.Server` `:8080` with the
+  gateway's timeouts (`services/gateway/app/app.go` pattern).
+* `services/api/handlers/ping.go`: implement the placeholder `Ping`.
+
+**Verification:** `go build ./...`; `go test -tags=fast ./services/api/...` (Step 6) green; locally
+`curl -sf localhost:8080/health` → 200, `curl localhost:8080/v1/ping` without bearer → 401
+`application/problem+json`, with the correct bearer → 200.
+
+### Step 6 — Unit tests (`-tags=fast`)
+
+**Action:** Add `//go:build fast` tests: bearer 401 vs 200 (constant-time path), Problem rendering for
+each mapped status, `Ping` handler, and `/openapi.yaml` serving bytes identical to the embedded
+bundle.
+
+**Verification:** `go test -tags=fast -race ./services/api/...` passes.
+
+### Step 7 — Makefile codegen targets
+
+**Action:** Add commented targets: `openapi-bundle` (redocly), `openapi-gen` (bundle → `go generate`
+→ python client), `openapi-lint` (spectral), `openapi-diff` (oasdiff vs `origin/main`). Keep them
+grouped under an "API / OpenAPI" header.
+
+**Verification:** `make openapi-gen` runs end-to-end on a clean tree and leaves `git diff` empty;
+`make openapi-lint` exits 0; `make openapi-diff` runs (no breaking change vs main → exit 0).
+
+### Step 8 — CI gate stage
+
+**Action:** In `.github/workflows/ci.yml` add a path-filtered stage (filter on `api/**`,
+`services/api/**`, `clients/**`, and `**/*.sql.go`) with three jobs: **codegen-diff** (re-bundle,
+`go generate`, python client, `sqlc generate` across existing configs, then `git diff --exit-code`),
+**spectral**, **oasdiff** (vs the PR base). Add `api` to the existing docker-build matrix.
+
+**Verification:** Push the branch; the new jobs appear and pass. Deliberately edit `api/openapi.gen.yaml`
+by hand in a scratch commit → codegen-diff fails (then revert). Remove an example from a fragment →
+spectral fails (then revert).
+
+### Step 9 — Dockerfile + deploy wiring
+
+**Action:** Add `services/api/Dockerfile` (copy `services/gateway/Dockerfile`, build `./services/api`,
+distroless nonroot). Add an `api` service to `deploy/{base,dev,staging,prod}` compose: networks
+`postgres` + `traefik_proxy`; Vault role-id/secret-id mounts like the engine; env incl.
+`VAULT_PG_PATH=secret/data/ruby-core/postgres_readonly`; Traefik labels mirroring the gateway
+(`compose.prod.yaml`) for `Host(...) && PathPrefix(/v1,/docs,/openapi.yaml)`, `tls=true`,
+auth middleware, `loadbalancer.server.port=8080`; **no host port published**. Register an Uptime Kuma
+monitor on `/health` (manual).
+
+**Verification:** `docker compose -f deploy/dev/... config` validates; `make dev-up` (or the dev
+target that includes api) starts the container; `docker logs` shows "api: ready"; from a container on
+`traefik_proxy`, `/health` returns 200.
+
+### Step 10 — README + Pre-PR checklist
+
+**Action:** Add `services/api/README.md` (purpose, endpoints, auth posture, how to regenerate). Update
+`docs/plans/README.md` to list PLAN-0030. Run the Pre-PR Checklist; archive this plan to
+`docs/plans/archived/` (status → Complete) as the final commit.
+
+**Verification:** Pre-commit hooks pass (`golangci-lint`, gitleaks, formatting); README reflects actual
+endpoints.
+
+---
+
+## Rollback
+
+The service is additive and read-only. Rollback = remove the `api` service from the compose files and
+redeploy; no schema or stateful change is introduced by this slice (the read-only role and Vault
+paths are provisioned out-of-band and harmless if unused). CI gate changes are revertable by reverting
+the workflow commit. No data migration → clean rollback.
+
+---
+
+## Open Questions
+
+* **Read-only Postgres role provisioning** is a host/foundation step outside this repo. If it is not
+  yet done, Steps 1–8 (skeleton, codegen, gates, unit tests) proceed without it; Steps 9 integration
+  startup and deploy require it. Confirm the role + `secret/ruby-core/postgres_readonly` path before
+  Step 9.
+* **mTLS on `services/api`** (Traefik→api) per ADR-0040: should it land in this slice or as a
+  fast-follow? This plan implements network isolation + in-app bearer now and recommends mTLS as a
+  scoped follow-up using the gateway's PKI-role pattern — confirm acceptable, or fold it into Step 9.

--- a/docs/plans/PLAN-0031-event-bus-generalization.md
+++ b/docs/plans/PLAN-0031-event-bus-generalization.md
@@ -1,0 +1,111 @@
+# PLAN-0031 - Event-Bus Generalization (gateway `ruby_home_event`)
+
+* **Status:** Draft
+* **Date:** 2026-06-27
+* **Project:** ruby-core
+* **Roadmap Item:** docs/roadmap/ROADMAP-0012-home-calendar.md (effort 0012.2)
+* **Branch:** feat/event-bus-generalization
+* **Related ADRs:** ADR-0009 (gateway responsibilities), ADR-0027 (subject naming), ADR-0003 (CloudEvents)
+
+---
+
+## Scope
+
+Make the gateway's HA→NATS write pipe domain-neutral by adding a new `ruby_home_event` Home Assistant
+event type alongside the existing `ada_event`, deriving NATS subjects from the payload `event` string.
+This carries the home-calendar write contracts (`calendar.event.upsert`, `calendar.event.delete`,
+`ruby_home.childcare.provider.upsert`, `ruby_home.childcare.provider.delete`) onto the bus so Slice C
+has a consumer-ready ingress. **Out of scope:** any consumer of the new subjects (engine processor is
+PLAN-0032); dropping the `ada_event` subscription (deferred until HA producers migrate — cross-repo
+follow-up, the `homeassistant` repo is not modified here); the HA-side producer change itself
+(described, not committed).
+
+---
+
+## Pre-conditions
+
+* [ ] On branch `feat/event-bus-generalization` cut from latest `main`.
+* [ ] Familiarity confirmed with the existing dual-subscribe in `services/gateway/ha/client.go`
+      (state_changed subID=1, ada_event adaSubID=2, `handleEvent()` switch) and the route-map publish
+      pattern in `services/gateway/ada/publish.go` (`eventRoutes` map + CloudEvent wrap).
+
+---
+
+## Steps
+
+### Step 1 — Define the `ruby_home` route table
+
+**Action:** Create `services/gateway/rubyhome/publish.go` mirroring `services/gateway/ada/publish.go`:
+a `eventRoutes` map from the payload `event` string to the precomputed NATS subject, covering
+`calendar.event.upsert` → `ha.events.calendar.event_upsert`, `calendar.event.delete` →
+`ha.events.calendar.event_delete`, `ruby_home.childcare.provider.upsert` →
+`ha.events.ruby_home.childcare.provider_upsert`, `ruby_home.childcare.provider.delete` →
+`ha.events.ruby_home.childcare.provider_delete`. (Confirm the exact subject tokens against ADR-0027
+`BuildSubject` validity — lowercase, underscores; no dots inside a token.) Wrap each in a CloudEvent
+like the ada path and publish. Unknown `event` → warn + return error (ada parity).
+
+**Verification:** `go build ./services/gateway/...` compiles; the subject for each known event matches
+the ROADMAP-0012 write-contract names.
+
+### Step 2 — Subscribe to `ruby_home_event` in the HA client
+
+**Action:** In `services/gateway/ha/client.go`, add `const homeEventSubID = 3` and a third
+`subscribe_events` write for `EventType: "ruby_home_event"` next to the existing two; add
+`case "ruby_home_event":` to the `handleEvent()` switch routing to a new `handleRubyHomeEvent()` that
+extracts the payload and calls `rubyhome.Publish(...)` (mirroring `handleAdaEvent`).
+
+**Verification:** `go build ./services/gateway/...`; unit test (Step 3) green. Gateway logs show three
+subscriptions established at startup.
+
+### Step 3 — Unit tests (`-tags=fast`)
+
+**Action:** Add table-driven tests mirroring the ada publish tests: each known `event` string maps to
+the expected subject; unknown event returns an error and publishes nothing; the published payload is a
+well-formed CloudEvent (id, source, type) per ADR-0003.
+
+**Verification:** `go test -tags=fast -race ./services/gateway/...` passes.
+
+### Step 4 — Integration test (`-tags=integration`)
+
+**Action:** Add a testcontainers-NATS integration test (existing pattern in `pkg/natsx`): publish a
+synthetic `ruby_home_event` payload through the gateway publish path and assert the CloudEvent lands on
+the correct `ha.events.*` subject in the `HA_EVENTS` stream; assert an `ada_event` still routes
+unchanged (no regression).
+
+**Verification:** `go test -tags=integration -race ./services/gateway/...` passes.
+
+### Step 5 — Document the HA-side producer change (no commit to that repo)
+
+**Action:** Add a short section to `services/gateway/README.md` (and reference it from the calendar
+runbook) describing what the Home Assistant side must emit: fire a `ruby_home_event` with an `event`
+field set to one of the route keys and the documented payload. Note that the eventual `ada_event` drop
+happens only after HA producers migrate.
+
+**Verification:** README documents each `ruby_home_event` route key and payload shape; matches the
+`eventRoutes` map exactly (no drift).
+
+### Step 6 — Pre-PR checklist
+
+**Action:** Run the Pre-PR Checklist; update `docs/plans/README.md`; archive this plan to
+`docs/plans/archived/` (status → Complete) as the final commit on the branch.
+
+**Verification:** Pre-commit hooks pass; the route keys in the README, the `eventRoutes` map, and the
+ROADMAP-0012 write contracts agree.
+
+---
+
+## Rollback
+
+Additive and isolated to the gateway. Rollback = revert the commit and redeploy the gateway; the new
+subscription simply stops. No stateful change, no schema, no impact on the existing `state_changed` /
+`ada_event` paths (they are untouched). Clean rollback.
+
+---
+
+## Open Questions
+
+* **Subject token for childcare provider events:** ADR-0027 forbids dots inside a token, so
+  `provider.upsert` becomes `provider_upsert` in the subject (`ha.events.ruby_home.childcare.provider_upsert`).
+  Confirm this is the desired on-bus subject, versus collapsing childcare under a flatter
+  `ha.events.ruby_home.*`. (Recommendation: keep the `ruby_home.childcare.provider_upsert` structure
+  for clarity; the engine processor subscribes with a `.>` pattern regardless.)

--- a/docs/plans/PLAN-0032-calendar-core.md
+++ b/docs/plans/PLAN-0032-calendar-core.md
@@ -1,0 +1,186 @@
+# PLAN-0032 - Calendar Core (mirror, sync, write consumer, read endpoint)
+
+* **Status:** Draft
+* **Date:** 2026-06-27
+* **Project:** ruby-core
+* **Roadmap Item:** docs/roadmap/ROADMAP-0012-home-calendar.md (effort 0012.3)
+* **Branch:** feat/calendar-core
+* **Related ADRs:** ADR-0042 (calendar sync architecture), ADR-0040 (read API), ADR-0023 (single writer), ADR-0025 (idempotency), ADR-0029/0037 (Postgres persistence pattern), ADR-0027 (subjects)
+
+---
+
+## Scope
+
+Build the calendar mirror, bidirectional Google sync, the single engine-side write consumer, reminder
+policy, and the `GET /v1/calendar/events` read endpoint. Depends on PLAN-0030 (read API platform) and
+PLAN-0031 (the `ha.events.calendar.*` ingress). **Out of scope:** the household overlay tables and
+their resolution in responses (PLAN-0033 — this slice returns native calendar fields and leaves
+`subjects[]`/`childcare` empty/absent); per-instance recurrence edit and single-instance delete
+(deferred; the `original_start_*` columns are laid down now); multi-calendar.
+
+---
+
+## Pre-conditions
+
+* [ ] On branch `feat/calendar-core` cut from latest `main`, with 0012.1 and 0012.2 merged.
+* [ ] Google OAuth complete per `docs/runbooks/google-calendar-oauth.md`: `secret/ruby-core/google`
+      holds `client_id`, `client_secret`, `refresh_token`, `calendar_id`; OAuth app in **production**
+      publishing status. (`client_id`/`client_secret`/`calendar_id` suffice to start; the
+      `refresh_token` is minted with the Step 1 helper.)
+* [ ] Engine Vault read policy will be extended to `secret/data/ruby-core/google` (Step 7).
+
+---
+
+## Steps
+
+### Step 1 — `cmd/google-auth` refresh-token helper
+
+**Action:** Build `cmd/google-auth/main.go`: a loopback OAuth flow (`golang.org/x/oauth2` +
+`/google`) taking `--client-id`/`--client-secret`, scope `calendar.events`, `AccessType=offline`,
+`prompt=consent`; prints the `refresh_token`.
+
+**Verification:** Operator runs it once, signs in as the household account, and it prints a
+`refresh_token`; that token is stored in Vault per the runbook.
+
+### Step 2 — Shared calendar store package `pkg/calendar/store`
+
+**Action:** Create `pkg/calendar/store/` mirroring `services/engine/processors/ada/store/`:
+`sqlc.yaml` (copy ada's verbatim — postgresql, pgx/v5, emit_*_struct_pointers), `migrate.go`
+(`//go:embed migrations/*.sql` → `pkgstore.MigrateUp(ctx, fs, "migrations", dsn, "schema_migrations_calendar")`),
+`migrations/000001_calendar_core.up.sql`/`.down.sql`, and `queries/{calendar,sync_state}.sql`.
+The `000001` schema per ADR-0042: `calendar_event` (`google_event_id` PK; start/end/original_start
+date-XOR-datetime+tz trios with CHECKs; `all_day`; derived `start_utc`/`end_utc` indexed;
+`recurrence text[]`; `recurring_event_id`; `status text` + CHECK; `etag`; `sequence`; `raw jsonb`;
+`synced_at`) and `sync_state` (`calendar_id` PK, `sync_token`, `last_synced_at`,
+`last_full_resync_at`). Generate code.
+
+**Verification:** `sqlc generate` (from `pkg/calendar/store`) produces `*.sql.go` with no diff on
+re-run; `go build ./pkg/calendar/...` compiles; a testcontainers Postgres applies `000001` cleanly and
+the date-XOR CHECK rejects a row with both `start_date` and `start_datetime` set.
+
+### Step 3 — Timezone-aware expansion `pkg/calendar/expand`
+
+**Action:** Create `pkg/calendar/expand/` using `github.com/teambition/rrule-go`: given a master event
+(start in its IANA tz + `recurrence` lines) and a window, build an `rrule.Set` (RRULE+EXDATE+RDATE),
+generate occurrences in-zone (DST-correct), subtract EXDATEs and `status=cancelled` children (matched
+by `recurring_event_id` + `original_start_*`), and apply modified-occurrence overrides. Single
+(non-recurring) events pass through directly. Enforce a max-window guard (return a typed error beyond
+N days).
+
+**Verification:** `go test -tags=fast ./pkg/calendar/expand/...` covers: weekly 9am stays 9am local
+across a spring-forward boundary; EXDATE removes an instance; a cancelled child is subtracted; an
+override replaces the base instance; a window beyond the guard returns the window-exceeded error.
+
+### Step 4 — Google client wrapper behind an interface
+
+**Action:** Create `services/engine/processors/calendar/google/` with a `CalendarService` interface
+(List with sync token + ShowDeleted, Insert, Update with If-Match, Delete) and a real implementation
+over `google.golang.org/api/calendar/v3`; `token.go` builds an auto-refreshing
+`oauth2.ReuseTokenSource` from the Vault refresh token. Add `boot.FetchGoogleConfig` to `pkg/boot`
+mirroring `FetchPostgresConfig`, reading `secret/data/ruby-core/google`.
+
+**Verification:** `go build ./...`; a fake `CalendarService` is usable in tests; `FetchGoogleConfig`
+unit test parses the four fields.
+
+### Step 5 — Sync poller
+
+**Action:** In `services/engine/processors/calendar/poller.go`, implement the ~60s incremental loop:
+`List(calendarId).SyncToken(tok).ShowDeleted(true)`, upsert each event into the mirror (mapping
+Google's native date shape into the trios + derived UTC), persist `nextSyncToken` to `sync_state`.
+**410** → clear token, full page-through resync, set `last_full_resync_at`, log it. Reconcile
+re-observed self-writes by `etag` (no reprocess). Launch the goroutine from the processor's
+`Initialize`, cancel in `Shutdown`. Gate the whole poller on `CALENDAR_SYNC_ENABLED` (default false).
+
+**Verification:** `go test -tags=fast` against the fake `CalendarService`: a returned event upserts a
+mirror row; a 410 transitions to a full resync and records `last_full_resync_at`; an event whose etag
+matches the mirror is a no-op. Integration (`-tags=integration`, testcontainers Postgres) confirms the
+upsert path against real SQL.
+
+### Step 6 — Write consumer (engine processor)
+
+**Action:** Create `services/engine/processors/calendar/processor.go` implementing `StatefulProcessor`
+(`RequiresStorage()=true`), `Subscriptions()` → `ha.events.calendar.event_upsert`,
+`ha.events.calendar.event_delete`. In `writethrough.go`: on upsert, dedupe create on the payload
+`idempotency_key` (reuse `pkg/idempotency` HybridStore on a `calendar` KV bucket), call Google
+Insert/Update (Update sends stored `etag` as `If-Match`; **412** → resync + retry once), then upsert
+the mirror with Google's returned id/etag in the same operation. On delete: a series-level Google
+delete plus the mirror status update (cancel); cascade is wired in PLAN-0033 (overlay tables don't
+exist yet).
+Register `host.Register(calendar.New(logger))` in `services/engine/main.go` and add
+`calendarstore.MigrateUp(ctx, pgCfg.DSN())` right after the existing `adastore.MigrateUp(...)` in the
+`host.RequiresStorage()` block.
+
+**Verification:** `go test -tags=fast ./services/engine/...`: an upsert with no `google_event_id`
+calls Insert once and writes one mirror row; the same `idempotency_key` redelivered does not call
+Insert again; an update with a stale etag triggers the 412→resync→retry path. Integration: publish
+`event_upsert` to testcontainers NATS → mirror row appears (Google faked).
+
+### Step 7 — Vault policy + engine config
+
+**Action:** Extend the engine's Vault read grant to `secret/data/ruby-core/google` (policy file in
+`/opt/foundation/vault/`, applied host-side). Add `CALENDAR_SYNC_ENABLED` to the engine config and to
+`deploy/{dev,staging,prod}` env (`true` only in prod `.env`). Update `.env.example` files and the host
+`deploy/prod/.env` / `deploy/staging/.env` per the version-bump feedback.
+
+**Verification:** Prod engine starts with the policy applied and reads `secret/ruby-core/google`
+without permission error; non-prod engines start with the poller disabled (log line confirms).
+
+### Step 8 — Reminders
+
+**Action:** In `services/engine/processors/calendar/reminders.go`, a ticker expands a near-future
+window over the mirror, computes due reminders from start times (ruby-core policy; **ignore** Google
+reminder overrides), pushes `sensor.ruby_home_calendar_status` (next event + active-reminder flag) via
+the engine HA client, and publishes a CloudEvent on NATS `calendar.reminder.due` (subject
+`ha.events.calendar.reminder_due`, lands in HA_EVENTS). HA push gated to prod (ADR-0033 analog).
+
+**Verification:** `go test -tags=fast`: an event crossing the reminder lead time produces exactly one
+due reminder and one published `reminder_due`; no Google reminder override changes the result.
+
+### Step 9 — Read endpoint `GET /v1/calendar/events?start=&end=`
+
+**Action:** Add `api/openapi/paths/calendar.yaml` (the endpoint with `start`/`end` params, the
+instance response schema mirroring native fields + placeholders for `subjects[]`/`childcare`/attendees
+filled in PLAN-0033, all documented with examples), regenerate. Implement `services/api/handlers/calendar.go`:
+read from `pkg/calendar/store`, expand via `pkg/calendar/expand`, sort, apply the max-window guard
+(→ RFC 9457 400). Reference `calendar.yaml` from the root spec.
+
+**Verification:** `make openapi-gen` clean diff; `make openapi-lint`/`openapi-diff` pass; integration
+(`-tags=integration`, testcontainers Postgres seeded with a recurring event) — the generated Go client
+gets back expanded, sorted instances for the window; an over-wide range returns a 400 Problem.
+
+### Step 10 — Backup, runbook, README, Pre-PR checklist
+
+**Action:** Add the new tables to the foundation Postgres backup set and document restore + the
+force-resync procedure (extend `docs/runbooks/google-calendar-oauth.md`, already drafted). Add
+`services/engine/processors/calendar/README.md`. Update `docs/plans/README.md`. Run the Pre-PR
+Checklist; archive this plan to `docs/plans/archived/` as the final commit.
+
+**Verification:** Backup job includes `calendar_event`/`sync_state`; pre-commit hooks pass; READMEs
+reflect reality.
+
+---
+
+## Rollback
+
+This slice introduces durable state and external writes — rollback is **not** fully clean:
+
+* **Schema:** `000001` is additive (new tables); a down-migration drops them. Rolling back the engine
+  image leaves the tables in place (harmless; they are only read/written by this processor). Do not
+  down-migrate if any real events have synced — snapshot first.
+* **Google writes:** events ruby-core created in Google persist after rollback (Google is the source of
+  record); this is correct, not a leak.
+* **Sync:** disabling `CALENDAR_SYNC_ENABLED` and redeploying the engine stops all polling/writing
+  immediately — the primary kill switch.
+Document the snapshot-before-down-migration step explicitly; treat full rollback as engine-image
+revert + `CALENDAR_SYNC_ENABLED=false`, leaving tables intact.
+
+---
+
+## Open Questions
+
+* **Reminder lead-time policy:** what lead time(s) drive `calendar.reminder.due` and the active flag
+  (single fixed lead, or per-event)? Defaulting to a single configurable lead in Step 8 unless
+  specified.
+* **`logged_by` attribution:** the write contracts inject `logged_by` for per-edit attribution on the
+  shared calendar — confirm whether it is persisted on `calendar_event` (audit column) or only emitted
+  to the audit stream. (Recommendation: audit stream only this slice; add a column if needed later.)

--- a/docs/plans/PLAN-0033-household-overlay.md
+++ b/docs/plans/PLAN-0033-household-overlay.md
@@ -1,0 +1,124 @@
+# PLAN-0033 - Household Overlay (people, childcare, subjects, suggestions)
+
+* **Status:** Draft
+* **Date:** 2026-06-27
+* **Project:** ruby-core
+* **Roadmap Item:** docs/roadmap/ROADMAP-0012-home-calendar.md (effort 0012.4)
+* **Branch:** feat/household-overlay
+* **Related ADRs:** ADR-0042 (calendar sync architecture), ADR-0040 (read API), ADR-0041 (OpenAPI governance)
+
+---
+
+## Scope
+
+Add the local-only household overlay — people directory, childcare providers, and event associations
+(subjects + childcare) — never written to Google; enrich calendar responses with resolved
+`subjects[]`, resolved `childcare`, and attendees reconciled to `person_id`; and add the directory,
+provider, and ranked-suggestions read endpoints. Depends on PLAN-0032 (calendar mirror + read endpoint
+exist). **Out of scope:** per-instance childcare override (series-level only for MVP); group
+membership for `kind=group`; any interaction with the Ada caretaker notification toggle (unrelated
+concept that merely also references HA `person` entities).
+
+---
+
+## Pre-conditions
+
+* [ ] On branch `feat/household-overlay` cut from latest `main`, with 0012.3 merged.
+* [ ] `citext` extension availability on the shared Postgres confirmed (see Open Questions for the
+      `text` + `lower()` fallback if `CREATE EXTENSION` privilege is unavailable).
+
+---
+
+## Steps
+
+### Step 1 — Migration `000002_household_overlay`
+
+**Action:** Add `pkg/calendar/store/migrations/000002_household_overlay.up.sql`/`.down.sql` per
+ADR-0042/ROADMAP-0012: `directory_person` (uuid PK, display_name, `kind text` + CHECK
+(`person|group`), ha_person_entity_id null, `email citext` null, family null, color null, active),
+`childcare_provider` (uuid PK, display_name, `person_id uuid` null FK → directory_person,
+`relationship text` + CHECK null, archived bool, created_at), `event_subject` (uuid PK,
+`google_event_id` FK → calendar_event, `person_id` FK → directory_person, UNIQUE(google_event_id,
+person_id)), `event_childcare` (uuid PK, `google_event_id` FK, `provider_id` FK → childcare_provider,
+created_at, UNIQUE(google_event_id, provider_id)). Enum-like columns are `text` + CHECK, not PG enums.
+Add `queries/overlay.sql`. Regenerate sqlc.
+
+**Verification:** testcontainers Postgres applies `000001`+`000002` cleanly; `sqlc generate` diff-clean;
+inserting two `event_subject` rows with the same (event, person) violates the unique constraint; the
+`kind` CHECK rejects an invalid value.
+
+### Step 2 — Overlay write handlers in the calendar processor
+
+**Action:** Extend `services/engine/processors/calendar/` to handle the overlay write contracts routed
+in via PLAN-0031: `ruby_home.childcare.provider.upsert` (insert/update; person link optional) and
+`ruby_home.childcare.provider.delete` (= set `archived=true`, retain row). Subject associations ride
+inside `calendar.event.upsert.subjects[]` — after the Google id is known, reconcile `event_subject`
+rows for that event (add/remove to match the payload). Wire the **cascade**: a true `event_delete`
+removes the event's `event_subject`/`event_childcare` rows (the deferred cascade from PLAN-0032 Step 6).
+
+**Verification:** `go test -tags=fast ./services/engine/...`: `provider.upsert` creates/updates a row;
+`provider.delete` sets `archived=true` without deleting; `event.upsert` with `subjects[]` converges the
+association rows; a true `event.delete` cascades the overlay rows. Integration confirms against SQL.
+
+### Step 3 — Enrich the calendar read endpoint
+
+**Action:** Fill in the `subjects[]`, `childcare`, and attendee resolution placeholders left by
+PLAN-0032 Step 9 in `services/api/handlers/calendar.go` and `api/openapi/paths/calendar.yaml`: resolve
+`event_subject` → `directory_person`, `event_childcare` → `childcare_provider`, and reconcile Google
+attendees by email (citext) to `person_id` where matched, carrying Google RSVP status. Regenerate.
+
+**Verification:** `make openapi-gen` clean; integration — an event carrying subjects, a childcare
+provider, and an attendee whose email matches a directory person returns all three resolved with RSVP;
+an unmatched attendee returns with `person_id` null.
+
+### Step 4 — Overlay read endpoints
+
+**Action:** Add `api/openapi/paths/directory.yaml` and `paths/childcare.yaml` (documented + examples)
+and handlers: `GET /v1/directory/people`, `GET /v1/childcare/providers` (non-archived roster), and
+`GET /v1/childcare/providers/suggestions`. Implement suggestions in `pkg/calendar` (shared logic):
+for each non-archived provider, expand its associated series' **past** occurrences over a recency
+window via `pkg/calendar/expand`, count per-occurrence, recency-weight, and rank — **no stored
+counter**. Reference the new fragments from the root spec.
+
+**Verification:** `make openapi-gen`/`openapi-lint`/`openapi-diff` pass; `go test -tags=fast` proves a
+provider on a weekly series ranks above one on a single past event, and that an archived provider is
+excluded; integration drives all three endpoints via the generated client.
+
+### Step 5 — Seed/test-data coverage (optional, if dashboards need it)
+
+**Action:** If the household UI needs sample data, extend the seed tooling pattern (analogous to the
+Ada seed) to populate `directory_person`/`childcare_provider` with `test`-flagged rows. (Calendar
+events come from Google, not seeds.)
+
+**Verification:** seed populates the overlay tables; clear removes `test=true` rows. (Skip if not
+needed for the MVP UI.)
+
+### Step 6 — Backup, README, Pre-PR checklist
+
+**Action:** Add the overlay tables to the foundation Postgres backup set. Update the calendar processor
+README and `docs/plans/README.md`. Run the Pre-PR Checklist; archive this plan to
+`docs/plans/archived/` as the final commit.
+
+**Verification:** backup includes the four overlay tables; pre-commit hooks pass; READMEs reflect the
+final endpoint set.
+
+---
+
+## Rollback
+
+`000002` is additive (new tables); the overlay is local-only and never touches Google. Rollback =
+revert the engine + api images; the new endpoints disappear and the write handlers stop. A
+down-migration drops the overlay tables — snapshot first if any real associations exist, since the
+data is authored only in ruby-core and not recoverable from Google. Calendar core (PLAN-0032) is
+unaffected by rolling back this slice.
+
+---
+
+## Open Questions
+
+* **`citext` privilege:** if `CREATE EXTENSION citext` is not permitted on the shared Postgres, fall
+  back to `email text` + a `UNIQUE` index on `lower(email)` and case-fold in queries. Confirm which
+  before Step 1.
+* **Recency window + weighting for suggestions:** what lookback window and decay shape rank providers
+  (e.g. 90 days, linear vs exponential recency weight)? Default to a documented fixed window +
+  simple recency weight in Step 4 unless specified.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -3,5 +3,9 @@
 | # | Title | Status | Roadmap Item |
 |---|---|---|---|
 | [0009](PLAN-0009-full-stack-observability.md) | Full-Stack Observability | Approved | [ROADMAP-0009](../roadmap/ROADMAP-0009-full-stack-observability.md) |
+| [0030](PLAN-0030-api-foundation.md) | API Foundation (`services/api`) | Draft | [ROADMAP-0012](../roadmap/ROADMAP-0012-home-calendar.md) |
+| [0031](PLAN-0031-event-bus-generalization.md) | Event-Bus Generalization | Draft | [ROADMAP-0012](../roadmap/ROADMAP-0012-home-calendar.md) |
+| [0032](PLAN-0032-calendar-core.md) | Calendar Core | Draft | [ROADMAP-0012](../roadmap/ROADMAP-0012-home-calendar.md) |
+| [0033](PLAN-0033-household-overlay.md) | Household Overlay | Draft | [ROADMAP-0012](../roadmap/ROADMAP-0012-home-calendar.md) |
 
 See `archived/` for completed plans.

--- a/docs/roadmap/README.md
+++ b/docs/roadmap/README.md
@@ -12,3 +12,6 @@
 | [0007](archived/ROADMAP-0007-devex-ci-polish.md) | Developer Experience & CI Polish | Complete |
 | [0008](archived/ROADMAP-0008-staging-deploy-validation.md) | Staging Environment & Deploy Validation | Complete |
 | [0009](ROADMAP-0009-full-stack-observability.md) | Full-Stack Observability | Planned — blocked on Foundation Phase 6 |
+| [0010](ROADMAP-0010-ada-hardening-test-data-lifecycle.md) | Ada Hardening & Test-Data Lifecycle | Complete |
+| [0011](ROADMAP-0011-ada-medications-emergency.md) | Ada Medications & Emergency (server-side) | Complete |
+| [0012](ROADMAP-0012-home-calendar.md) | Home Calendar + API Foundation | Planned |

--- a/docs/roadmap/ROADMAP-0012-home-calendar.md
+++ b/docs/roadmap/ROADMAP-0012-home-calendar.md
@@ -1,0 +1,73 @@
+# Make ruby-core the authority for the family calendar, on a reusable HTTP read plane
+
+* **Status:** Planned
+* **Date:** 2026-06-27
+* **Project:** ruby-core
+* **Related ADRs:** ADR-0040 (read-API service + defense-in-depth auth), ADR-0041 (OpenAPI lifecycle & codegen governance), ADR-0042 (calendar sync architecture) — all to be drafted in the docs decomposition
+* **Linked Plan:** docs/plans/PLAN-0030-api-foundation.md, PLAN-0031-event-bus-generalization.md, PLAN-0032-calendar-core.md, PLAN-0033-household-overlay.md
+
+---
+
+**Goal:** Make ruby-core the durable system of record and read authority for the family calendar — bidirectionally synced with the human-facing Google **Family** calendar, holding the local household overlay (subjects, childcare) and reminder policy Google cannot — served over ruby-core's first synchronous, spec-first HTTP read API that every future domain inherits.
+
+---
+
+## Authority split (the invariant this roadmap establishes)
+
+* **Google owns:** standard calendar data — summary, start/end, recurrence, location, description, calendarId, attendees. Google stays the human-facing system of record.
+* **ruby-core owns (local, never written to Google):** event *subjects* (the "FOR" lane), *childcare* assignments, the people/provider registries, reminder policy, and all derived/automation state.
+* **Read path is REST; write path is the existing HA event bus → NATS → a single engine-side consumer.** The REST surface is deliberately read-only. The NATS write-event payloads are first-class, documented contracts equal to the OpenAPI surface.
+
+---
+
+## Efforts
+
+Each effort is one branch/PR (single-concern). **0012.1 and 0012.2 are independent and land in parallel.** 0012.3 depends on both. 0012.4 depends on 0012.3. The cross-repo Home Assistant producer migration (the eventual `ada_event` drop in 0012.2) is HA-side work and is **described, not executed** here — the `homeassistant` repo is out of scope for commits.
+
+### 0012.1 — API foundation (`feat/api-foundation`)
+
+Stand up `services/api`: ruby-core's first synchronous HTTP read plane, spec-first with **ogen** generating the typed server, client, and validation from a hand-authored OpenAPI spec (per-domain fragments bundled into one served spec). RFC 9457 Problem Details error model defined once. URL-path versioning (`/v1/`). Defense-in-depth auth: Vault-issued bearer modeled as an OpenAPI security scheme, layered under Traefik edge auth + mTLS (ADR-0040). Scalar docs at `/docs`, raw spec at `/openapi.yaml`. CI gates: codegen fail-on-diff, Spectral lint (description + example required on every operation/parameter/response), oasdiff breaking-change block. Generated Python client for the HA read-proxy. **Out of scope:** any calendar/overlay endpoints with real data (they arrive in 0012.3/0012.4 against this platform); Schemathesis fuzzing and mock servers (deferred); cursor pagination *implementation* (convention documented in the style guide, only the date-range filter is built).
+
+### 0012.2 — Event-bus generalization (`feat/event-bus-generalization`)
+
+Make the gateway write pipe domain-neutral. The gateway **dual-subscribes** `ada_event` + a new `ruby_home_event` HA event type during cutover, deriving NATS subjects from the payload `event` string (mirroring the existing `services/gateway/ada/publish.go` route-map pattern). This carries the new `calendar.*` and `ruby_home.childcare.*` write contracts onto the bus without disturbing Ada. **Out of scope:** dropping `ada_event` (deferred until HA producers migrate — cross-repo follow-up); any consumer of the new subjects (that is 0012.3).
+
+### 0012.3 — Calendar core (`feat/calendar-core`)
+
+The mirror, sync, and write consumer. OAuth user-consent offline refresh token (not a service account) addressing the Family calendar by `calendarId`; refresh token in Vault; OAuth app in **production** publishing status. Incremental sync-token polling (~60s) with a `SYNC_STATE` token; 410 → full resync. A `CALENDAR_EVENT` mirror that reproduces Google's native date shape (date XOR datetime+tz trios; exclusive all-day end surfaced to consumers; derived UTC columns for range queries; recurrence as RRULE/EXDATE/RDATE lines; cancelled/override children retained). A single engine-side write consumer on `ha.events.calendar.event_upsert` / `event_delete` with idempotency-key dedupe on create, etag `If-Match` on update (412 → resync+retry), series-level delete, write-through to Google + mirror in one operation, and etag echo reconciliation. Timezone-aware on-demand recurrence expansion. Reminder policy owned by ruby-core (Google reminder overrides not honored), surfaced via `sensor.ruby_home_calendar_status` and NATS `calendar.reminder.due`. Read endpoint `GET /v1/calendar/events?start=&end=` with a max-window guard. **Out of scope:** per-instance recurrence edit and single-instance delete (deferred — the `original_start_*` columns are the groundwork); multi-calendar (single-calendar is a conscious boundary); the household overlay resolution in responses (lands in 0012.4).
+
+### 0012.4 — Household overlay (`feat/household-overlay`)
+
+Local-only registries and event associations, never written to Google: `DIRECTORY_PERSON`, `CHILDCARE_PROVIDER`, `EVENT_SUBJECT`, `EVENT_CHILDCARE`. Write events `ruby_home.childcare.provider.upsert` / `.delete` (delete = archive, preserving frequency history) and subject associations riding inside `calendar.event.upsert.subjects[]`. Calendar responses gain resolved `subjects[]`, resolved `childcare`, and attendees reconciled by email to `person_id`. Read endpoints `GET /v1/directory/people`, `GET /v1/childcare/providers`, and `GET /v1/childcare/providers/suggestions` (providers ranked by per-occurrence recency-weighted usage computed from associations + expansion — no stored counter). **Out of scope:** per-instance childcare override (this Tuesday it's Grandma — series-level only for MVP); group membership for `kind = group`; any read/modification of the unrelated Ada caretaker notification toggle.
+
+---
+
+## Done When
+
+* `services/api` is deployed behind Traefik, green in Uptime Kuma on `/health`, serving `/v1/` with the bundled OpenAPI spec at `/openapi.yaml` and Scalar docs at `/docs`; CI blocks any merge where the spec, generated Go server/client, generated Python client, or sqlc output is out of sync with source, where Spectral finds an operation/parameter/response missing a description or example, or where oasdiff detects an unapproved breaking change.
+* Creating or editing an event in the Google **Family** calendar appears in `GET /v1/calendar/events?start=&end=` within ~60s, with recurring series expanded timezone-correctly across DST, EXDATEs and cancelled occurrences subtracted, and overrides applied — and a `calendar.event.upsert` published to NATS creates/updates the event in Google *and* the local mirror in one operation, without a redelivery double-inserting or a concurrent edit clobbering via etag.
+* Calendar instances returned by the API carry resolved `subjects[]`, resolved `childcare`, and attendees reconciled to `person_id` with Google RSVP status; `GET /v1/childcare/providers/suggestions` returns providers ranked by recent per-occurrence usage.
+* The engine computes and fires reminders from event start times over the mirror — surfaced on `sensor.ruby_home_calendar_status` and NATS `calendar.reminder.due` — with no Google reminder override honored and no calendar card open.
+* The new durable tables (`CALENDAR_EVENT`, `SYNC_STATE`, overlay) are covered by a documented backup + restore procedure and a force-resync runbook.
+
+---
+
+## Acceptance Criteria
+
+* [ ] **API platform:** `make openapi-gen` followed by `git diff --exit-code` passes on a clean tree; introducing an undocumented operation fails Spectral in CI; a removed/renamed field fails oasdiff in CI; `curl -sf https://<api-host>/health` returns 200 and `/v1/...` without a valid bearer returns an RFC 9457 `application/problem+json` 401.
+* [ ] **Read-only enforcement:** the `api` service connects with a `SELECT`-only Postgres role; an attempted write through its pool fails at the database, not just in code.
+* [ ] **Bus generalization:** publishing an HA `ruby_home_event` with `event: "calendar.event.upsert"` lands a CloudEvent on `ha.events.calendar.event_upsert` in `HA_EVENTS`, while `ada_event` continues to route unchanged (verified by an integration test against testcontainers NATS).
+* [ ] **Sync + write-through:** with `CALENDAR_SYNC_ENABLED=true` against a scratch calendar, an event created in Google appears in `CALENDAR_EVENT` within two poll cycles; publishing `calendar.event.upsert` with no `google_event_id` twice (same `idempotency_key`) creates exactly one Google event and one mirror row; an update with a stale `etag` returns/handles Google 412 by resyncing and retrying rather than clobbering; a sync-token 410 triggers a logged full resync (not a silent stop).
+* [ ] **Recurrence correctness:** `go test -tags=fast ./pkg/calendar/...` proves a weekly 9am event expands to 9am local on each occurrence across a spring-forward DST boundary, that EXDATE and `status=cancelled` children are subtracted, and that a modified-occurrence override replaces the base instance; a range request exceeding the max window returns an RFC 9457 400.
+* [ ] **Overlay + suggestions:** an event with `subjects[]` and a `childcare` provider returns both resolved in `GET /v1/calendar/events`; `provider.delete` sets `archived = true` (row retained); `GET /v1/childcare/providers/suggestions` ranks a provider attached to a weekly series above one attached to a single past event, computed from associations + expansion with no stored usage column.
+* [ ] **Reminders:** with no app/card open, an event whose start crosses the configured reminder lead time sets the active-reminder flag on `sensor.ruby_home_calendar_status` and publishes `calendar.reminder.due` on NATS; no Google per-event reminder override changes ruby-core behavior.
+* [ ] **Operability:** the OAuth bootstrap runbook (`docs/runbooks/google-calendar-oauth.md`) and a force-resync procedure exist; the new Postgres tables are included in the foundation Postgres backup set with a documented restore.
+
+---
+
+## Related Work & Standards Notes
+
+* **ADRs to write (in the docs decomposition):** ADR-0040 generalizes the ADR-0020 edge-auth posture to `services/api` and adds the in-app bearer as defense-in-depth (ADR-0020 stays in force for the gateway). ADR-0041 establishes OpenAPI/codegen governance, relating to ADR-0014 (schema governance). ADR-0042 records the calendar sync architecture (single writer per ADR-0023; self-contained processor per ADR-0007; idempotency per ADR-0025; subject naming per ADR-0027).
+* **Depends on / builds from:** the Ada persistence pattern (sqlc + golang-migrate, shared external Postgres, per-processor migration table — ADR-0029/0037), the engine processor framework (ADR-0007), the gateway responsibilities split (ADR-0009), and the HA_EVENTS stream retention bounds (ADR-0034).
+* **Standards this advances:** establishes the spec-first, self-documenting HTTP API the global standards require (OpenAPI source of truth, generation enforced in CI) — the read plane future domains (Ada, finance) inherit.
+* **Production-readiness blockers to track:** backup + restore coverage for the new stateful tables; a read-only Postgres role and a `secret/ruby-core/postgres_readonly` Vault path provisioned before `api` deploys; OAuth app set to **production** publishing status (testing-mode refresh tokens expire ~7 days) with alerting on Google auth failure; OTEL tracing for the new `api` service (today only structured logging exists).

--- a/docs/runbooks/google-calendar-oauth.md
+++ b/docs/runbooks/google-calendar-oauth.md
@@ -1,0 +1,149 @@
+# Runbook — Google Calendar OAuth bootstrap & token rotation
+
+Operational guide for granting ruby-core access to the Google **Family** calendar (ROADMAP-0012,
+ADR-0042). ruby-core syncs Google bidirectionally using an **OAuth user-consent offline refresh
+token** — not a service account, because the household account is a consumer Gmail account and
+cannot be impersonated via Workspace domain-wide delegation.
+
+> ⚠️ **The OAuth app MUST be in `production` publishing status.** A refresh token issued while the
+> app is in `Testing` status is revoked by Google after ~7 days, and sync will silently stop until
+> re-consented. This is the single most important step.
+
+All Vault writes run on the host (`ruby-z04-node-01`) using the `ruby-core-writer` token (see
+project memory). The engine reads these secrets at `secret/data/ruby-core/google`.
+
+---
+
+## What lands in Vault (the goal)
+
+A single KV path `secret/ruby-core/google` with four fields:
+
+| Field | Source | Notes |
+|---|---|---|
+| `client_id` | GCP OAuth client | from the Desktop-app OAuth client |
+| `client_secret` | GCP OAuth client | from the same client |
+| `refresh_token` | one-time consent (`cmd/google-auth`) | long-lived; the thing that expires if app is in Testing |
+| `calendar_id` | Google Calendar settings | the Family calendar's ID (often an `…@group.calendar.google.com` address) |
+
+---
+
+## Part 1 — Google Cloud setup (do once; yours to perform)
+
+1. **Project.** In the [Google Cloud Console](https://console.cloud.google.com/), create or select a
+   project for ruby-core (e.g. `ruby-core-home`).
+2. **Enable the API.** APIs & Services → Library → enable **Google Calendar API** for that project.
+3. **OAuth consent screen.** APIs & Services → OAuth consent screen:
+   - User type **External**.
+   - Add the shared household Google account as a user.
+   - Add the scope `https://www.googleapis.com/auth/calendar.events`.
+   - **Set publishing status to `In production`** (Publish app → confirm). Do **not** leave it in
+     Testing.
+4. **OAuth client.** APIs & Services → Credentials → Create credentials → OAuth client ID:
+   - Application type **Desktop app** (this enables the `http://127.0.0.1:<port>` loopback redirect
+     that `cmd/google-auth` uses — far simpler than hosting a web redirect).
+   - Save the generated **client_id** and **client_secret**.
+5. **Calendar ID.** In Google Calendar (web) → the Family calendar's **Settings and sharing** →
+   **Integrate calendar** → copy the **Calendar ID**.
+
+---
+
+## Part 2 — Mint the refresh token (`cmd/google-auth`)
+
+`cmd/google-auth` is a small loopback OAuth helper delivered in Slice C (ROADMAP-0012.3). It runs
+the consent flow with `AccessType=offline` and forces a consent prompt so Google returns a
+`refresh_token` (Google only returns one on first consent unless re-prompted).
+
+```bash
+# On the host, repo root. Provide the client credentials from Part 1.
+go run ./cmd/google-auth \
+  --client-id "<client_id>" \
+  --client-secret "<client_secret>"
+```
+
+The helper prints a URL (or opens a browser), you sign in **as the household account** and grant
+access, and it prints the `refresh_token` to stdout. Copy it.
+
+> If it prints no `refresh_token` (only an access token), you have consented before without a forced
+> prompt — re-run; the helper passes `prompt=consent` to force re-issuance.
+
+---
+
+## Part 3 — Store in Vault
+
+```bash
+# On the host. VAULT_TOKEN_RUBY_CORE_WRITER is in deploy/prod/.env (see project memory).
+VAULT_ADDR=https://127.0.0.1:8200 \
+VAULT_CACERT=/opt/foundation/vault/tls/vault-ca.crt \
+VAULT_TOKEN="$VAULT_TOKEN_RUBY_CORE_WRITER" \
+vault kv put secret/ruby-core/google \
+  client_id="<client_id>" \
+  client_secret="<client_secret>" \
+  refresh_token="<refresh_token>" \
+  calendar_id="<calendar_id>"
+```
+
+Confirm (metadata only — do not print secrets into logs):
+
+```bash
+VAULT_ADDR=https://127.0.0.1:8200 VAULT_CACERT=/opt/foundation/vault/tls/vault-ca.crt \
+VAULT_TOKEN="$VAULT_TOKEN_RUBY_CORE_WRITER" \
+vault kv get -field=calendar_id secret/ruby-core/google
+```
+
+The engine's Vault read policy must grant read on `secret/data/ruby-core/google` — added alongside
+the existing `secret/ruby-core/*` grants in Slice C.
+
+---
+
+## Part 4 — Enable sync
+
+Sync is gated by `CALENDAR_SYNC_ENABLED` (off by default outside production, so the single shared
+calendar is never double-synced across dev/staging/prod — same pattern as Ada's `HA_INGEST_ENABLED`,
+ADR-0033). Set `CALENDAR_SYNC_ENABLED=true` only in `deploy/prod/.env`, then restart the prod engine.
+
+Verify the poller is healthy: the engine logs an incremental sync line roughly every ~60s and a
+`SYNC_STATE` row exists for the calendar (`last_synced_at` advancing).
+
+---
+
+## Token rotation / recovery
+
+Symptom: engine logs Google auth failures (`invalid_grant` / 401) and the `SYNC_STATE`
+`last_synced_at` stops advancing.
+
+Likely causes and fixes:
+
+- **App reverted to Testing / token aged out** → set publishing status back to `In production`
+  (Part 1.3), then re-mint (Part 2) and re-store (Part 3).
+- **Consent revoked** (household removed the app at <https://myaccount.google.com/permissions>) →
+  re-mint (Part 2) and re-store (Part 3).
+- **Client secret rotated in GCP** → update `client_id`/`client_secret` in Vault (Part 3) and
+  re-mint.
+
+After re-storing, restart the prod engine. No code change is needed — the engine reads the new
+secret at startup.
+
+---
+
+## Force a full resync
+
+If the local mirror is suspected stale or diverged (and to recover from a stuck sync token), clear
+the stored sync token so the next poll does a full page-through. A 410 from Google triggers this
+automatically; to do it manually:
+
+```sql
+-- against ruby_core (prod), on the postgres network
+UPDATE sync_state SET sync_token = NULL WHERE calendar_id = '<calendar_id>';
+```
+
+Then restart the prod engine. The next poll resyncs from scratch and records a fresh token. This is
+non-destructive to `CALENDAR_EVENT` rows (they are re-upserted), but the overlay tables are local
+and unaffected.
+
+---
+
+## Related
+
+- ADR-0042 — calendar sync architecture (authority split, single writer, 410/412 handling).
+- `docs/runbooks/` — add the new `CALENDAR_EVENT` / `SYNC_STATE` / overlay tables to the foundation
+  Postgres backup set (tracked as a production-readiness blocker in ROADMAP-0012).


### PR DESCRIPTION
## Summary

Docs-first decomposition of the home-calendar effort — the planning artifacts that gate execution of the four implementation slices to follow. **No feature code**; this PR establishes the contracts.

ruby-core becomes the durable system of record and read authority for the family calendar (bidirectionally synced with the human-facing Google **Family** calendar), and this effort stands up ruby-core's first synchronous, spec-first HTTP read API — the read plane future domains inherit.

## What's in this PR (12 files)

- **`ROADMAP-0012-home-calendar`** — outcome goal, four efforts mapped to single-concern branches (A API foundation, B event-bus generalization, C calendar core, D household overlay), Done When, verifiable acceptance criteria.
- **ADR-0040** — new `services/api` read plane with defense-in-depth auth (Traefik + mTLS primary, in-app Vault-issued bearer secondary); generalizes ADR-0020 to the new service.
- **ADR-0041** — spec-first OpenAPI lifecycle + codegen governance (ogen, Redocly bundle, Spectral, oasdiff, fail-on-diff CI gates); HTTP-surface counterpart to ADR-0014's schema-in-code (which still governs NATS contracts).
- **ADR-0042** — calendar sync architecture: Google as source of record, local durable mirror, single poller/writer, OAuth offline refresh token, single-calendar boundary, ruby-core reminder ownership.
- **`google-calendar-oauth` runbook** — OAuth bootstrap (consent screen in **production** status — testing tokens die ~7d), token rotation, force-resync.
- **`api/style-guide`** — RFC 9457 errors, URL-path versioning, opaque-cursor pagination convention.
- **PLAN-0030..0033** — per-slice implementation plans with ordered, verifiable steps.
- **README index updates** — `docs/roadmap/README.md`, `docs/plans/README.md`.

## Sequencing

A + B are independent (parallel); C depends on A + B; D depends on C. The cross-repo Home Assistant producer migration (the eventual `ada_event` drop in slice B) is **described, not executed** — the `homeassistant` repo is out of scope for commits.

## Decisions confirmed before drafting

- **Docs-first** execution (this PR) before any feature code.
- **Defense-in-depth auth** for the read API (edge gate stays primary per ADR-0020; in-app bearer added as a second layer).
- Google refresh token minted via a small Go helper (`cmd/google-auth`, delivered in slice C).

## Notes for review

- ADR-0040 **extends** rather than supersedes ADR-0020, so 0020 keeps its `Accepted` status (a forward link will be added once 0040 is Accepted).
- The PLAN-0030..0033 files are *deliverables* of this branch (drafts for future slices), not plans executed by it — so they are intentionally **not** archived here; each archives when its own slice completes.
- ADRs are status **Proposed** pending review.

## Pre-PR Checklist

- [x] READMEs reflect current state (roadmap/plans indexes updated; service READMEs land with their slices)
- [x] Runbook reviewed — new OAuth runbook added; no existing runbook affected (docs-only, no deployed change)
- [x] ADRs written (0040, 0041, 0042 — Proposed)
- [x] Linked-plan archival — N/A by design (see notes above)
- [x] Pre-commit hooks pass cleanly (markdownlint + gitleaks)
- [x] Branch name single-concern (`docs/roadmap-home-calendar`)
- [x] Drift observations listed below

## Drift Observations

1. `docs/ARCHITECTURE_DECISIONS.md` is a stale ADR index — frozen at ADR-0028, missing 0029–0042. Either maintain it or retire it in favor of the `docs/adr/` listing.
2. `docs/plans/README.md` does not index the archived plans 0010–0029 (pre-existing gap; only 0009 + the new drafts are listed).
3. No codegen CI gate exists today, not even for sqlc — the regenerate-and-diff discipline is manual/unenforced. ADR-0041 closes this as part of slice A.
4. Global `CLAUDE.md` documents the plan archive path as `docs/plans/archive/`, but the repo convention is `docs/plans/archived/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)