### PR TITLE
feat(gateway): domain-neutral ruby_home_event write path (Slice B, ROADMAP-0012.2)

### DIFF
--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -3,7 +3,6 @@
 | # | Title | Status | Roadmap Item |
 |---|---|---|---|
 | [0009](PLAN-0009-full-stack-observability.md) | Full-Stack Observability | Approved | [ROADMAP-0009](../roadmap/ROADMAP-0009-full-stack-observability.md) |
-| [0031](PLAN-0031-event-bus-generalization.md) | Event-Bus Generalization | Draft | [ROADMAP-0012](../roadmap/ROADMAP-0012-home-calendar.md) |
 | [0032](PLAN-0032-calendar-core.md) | Calendar Core | Draft | [ROADMAP-0012](../roadmap/ROADMAP-0012-home-calendar.md) |
 | [0033](PLAN-0033-household-overlay.md) | Household Overlay | Draft | [ROADMAP-0012](../roadmap/ROADMAP-0012-home-calendar.md) |
 

--- a/docs/plans/archived/PLAN-0031-event-bus-generalization.md
+++ b/docs/plans/archived/PLAN-0031-event-bus-generalization.md
@@ -1,6 +1,6 @@
 # PLAN-0031 - Event-Bus Generalization (gateway `ruby_home_event`)
 
-* **Status:** Draft
+* **Status:** Complete
 * **Date:** 2026-06-27
 * **Project:** ruby-core
 * **Roadmap Item:** docs/roadmap/ROADMAP-0012-home-calendar.md (effort 0012.2)
@@ -109,3 +109,22 @@ subscription simply stops. No stateful change, no schema, no impact on the exist
   Confirm this is the desired on-bus subject, versus collapsing childcare under a flatter
   `ha.events.ruby_home.*`. (Recommendation: keep the `ruby_home.childcare.provider_upsert` structure
   for clarity; the engine processor subscribes with a `.>` pattern regardless.)
+
+---
+
+## Completion Notes
+
+Delivered on branch `feat/event-bus-generalization`. Built as planned; notes:
+
+* **Open question resolved as recommended** — kept the structured subject
+  `ha.events.ruby_home.childcare.provider_upsert` (`provider.upsert` → `provider_upsert` per
+  ADR-0027). A unit test asserts every routed subject is composed of valid ADR-0027 tokens.
+* **Shared subject constants live in `pkg/schemas/homecal.go`** (not inline in the gateway), so the
+  Slice C/D engine consumers import the same contract (ADR-0014). `HomeEventCalendar{Upsert,Delete}`
+  and `HomeEventChildcareProvider{Upsert,Delete}`.
+* **HA producer convention:** `ruby_home_event` wraps the caller payload under a `payload` key, same
+  as `ada_event`'s `script.fire_ada_event` intermediary — documented in the gateway README.
+* **`ada_event` untouched** — dual-subscribe only; the HA-side producer migration and eventual
+  `ada_event` retirement are cross-repo follow-ups in the `homeassistant` repo, out of scope here.
+* Integration test (`-tags=integration`, testcontainers NATS) proves both new subjects land in
+  `HA_EVENTS` and that `ada_event` still routes unchanged.

--- a/pkg/schemas/homecal.go
+++ b/pkg/schemas/homecal.go
@@ -1,0 +1,16 @@
+package schemas
+
+// Home-calendar + household-overlay event subject constants — NATS subjects for the
+// domain-neutral ruby_home_event write path (ROADMAP-0012). Producer: the gateway
+// (Slice B). Consumers: the engine calendar processor (Slices C/D). Subjects follow
+// ADR-0027 (lowercase tokens, underscores only; no dots within a token) and land in
+// the HA_EVENTS stream (ha.events.>).
+const (
+	// Calendar write events (Slice C consumer).
+	HomeEventCalendarUpsert = "ha.events.calendar.event_upsert"
+	HomeEventCalendarDelete = "ha.events.calendar.event_delete"
+
+	// Household-overlay childcare provider events (Slice D consumer).
+	HomeEventChildcareProviderUpsert = "ha.events.ruby_home.childcare.provider_upsert"
+	HomeEventChildcareProviderDelete = "ha.events.ruby_home.childcare.provider_delete"
+)

--- a/services/gateway/README.md
+++ b/services/gateway/README.md
@@ -9,6 +9,25 @@ Also handles Ada baby tracking events via two paths:
 
 Both paths produce identical CloudEvents on `ha.events.ada.>`. See `services/gateway/ada/publish.go` for the event type → subject mapping.
 
+## `ruby_home_event` — domain-neutral write path (ROADMAP-0012)
+
+Alongside `ada_event`, the gateway subscribes to a domain-neutral `ruby_home_event` on the HA event bus. New home-automation write contracts (calendar, childcare, …) ride this single event type instead of getting a bespoke HA event type per domain. The NATS subject is derived from the payload `event` string; see `services/gateway/rubyhome/publish.go` and the shared subject constants in `pkg/schemas/homecal.go`.
+
+### Home Assistant producer contract
+
+Fire `ruby_home_event` with the caller's payload wrapped under a `payload` key (same convention as `ada_event`'s `script.fire_ada_event` intermediary), and an `event` field set to one of the route keys:
+
+| `event` | NATS subject | Consumer |
+|---|---|---|
+| `calendar.event.upsert` | `ha.events.calendar.event_upsert` | calendar processor (Slice C) |
+| `calendar.event.delete` | `ha.events.calendar.event_delete` | calendar processor (Slice C) |
+| `ruby_home.childcare.provider.upsert` | `ha.events.ruby_home.childcare.provider_upsert` | overlay (Slice D) |
+| `ruby_home.childcare.provider.delete` | `ha.events.ruby_home.childcare.provider_delete` | overlay (Slice D) |
+
+Example HA event data: `{"payload": {"event": "calendar.event.upsert", "summary": "Dentist", "start": {...}, "idempotency_key": "…"}}`. Full payload field contracts are in ROADMAP-0012.
+
+> The HA-side producer migration (firing `ruby_home_event`, and the eventual retirement of `ada_event` once all producers move over) is cross-repo work in the `homeassistant` repo and is **not** part of this repo. The gateway dual-subscribes so the cutover is non-breaking.
+
 External access is routed through Traefik; the HTTP port is never published directly to the host (ADR-0020).
 
 ## Configuration

--- a/services/gateway/ha/client.go
+++ b/services/gateway/ha/client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/primaryrutabaga/ruby-core/pkg/schemas"
 	"github.com/primaryrutabaga/ruby-core/services/gateway/ada"
 	gatewayNats "github.com/primaryrutabaga/ruby-core/services/gateway/nats"
+	"github.com/primaryrutabaga/ruby-core/services/gateway/rubyhome"
 )
 
 // haWSMessage is a generic HA WebSocket protocol message envelope.
@@ -181,11 +182,12 @@ func (c *Client) runOnce(ctx context.Context) error {
 	}
 
 	// ── subscribe to events ────────────────────────────────────────────────
-	// IDs must be unique per connection; 1 and 2 are used by the two subscriptions.
+	// IDs must be unique per connection; 1–3 are used by the three subscriptions.
 	// msgID is incremented for any subsequent command (e.g. config/auth/list).
-	const subID = 1    // state_changed
-	const adaSubID = 2 // ada_event (Phase 3b dashboard write path)
-	msgID := 3         // next available ID for on-demand commands
+	const subID = 1          // state_changed
+	const adaSubID = 2       // ada_event (Phase 3b dashboard write path)
+	const homeEventSubID = 3 // ruby_home_event (ROADMAP-0012 domain-neutral write path)
+	msgID := 4               // next available ID for on-demand commands
 
 	if err := conn.WriteJSON(haWSMessage{
 		ID:        subID,
@@ -219,7 +221,23 @@ func (c *Client) runOnce(ctx context.Context) error {
 	}
 	c.log.Info("ha websocket: subscribed to ada_event")
 
-	// Mark connected only after both subscriptions are confirmed — the health
+	if err := conn.WriteJSON(haWSMessage{
+		ID:        homeEventSubID,
+		Type:      "subscribe_events",
+		EventType: "ruby_home_event",
+	}); err != nil {
+		return fmt.Errorf("write subscribe_events ruby_home_event: %w", err)
+	}
+	var homeSubResp haWSMessage
+	if err := conn.ReadJSON(&homeSubResp); err != nil {
+		return fmt.Errorf("read subscribe ruby_home_event result: %w", err)
+	}
+	if !homeSubResp.Success {
+		return fmt.Errorf("ha websocket: subscribe ruby_home_event rejected")
+	}
+	c.log.Info("ha websocket: subscribed to ruby_home_event")
+
+	// Mark connected only after all subscriptions are confirmed — the health
 	// heartbeat reads this flag to publish ha_connected, which the engine watches
 	// to trigger restoreSensors on the false→true transition.
 	c.haConnected.Store(true)
@@ -255,9 +273,28 @@ func (c *Client) handleEvent(ctx context.Context, conn *websocket.Conn, nextID *
 	switch ev.EventType {
 	case "ada_event":
 		return c.handleAdaEvent(ctx, conn, nextID, ev)
+	case "ruby_home_event":
+		return c.handleRubyHomeEvent(ev)
 	default:
 		return c.handleStateChanged(ev)
 	}
+}
+
+// handleRubyHomeEvent processes a ruby_home_event fired from Home Assistant via the
+// domain-neutral write path (ROADMAP-0012). Like ada_event, the HA script wraps the
+// caller's payload under a "payload" key; the NATS subject is derived from the
+// payload "event" string.
+func (c *Client) handleRubyHomeEvent(ev *haEvent) error {
+	var wrapper struct {
+		Payload map[string]any `json:"payload"`
+	}
+	if err := json.Unmarshal(ev.Data, &wrapper); err != nil {
+		return fmt.Errorf("ha: unmarshal ruby_home_event wrapper: %w", err)
+	}
+	if wrapper.Payload == nil {
+		return fmt.Errorf("ha: ruby_home_event missing payload field")
+	}
+	return rubyhome.Publish(c.nc, wrapper.Payload, c.log)
 }
 
 // handleStateChanged processes a state_changed event from HA.

--- a/services/gateway/rubyhome/publish.go
+++ b/services/gateway/rubyhome/publish.go
@@ -1,0 +1,75 @@
+// Package rubyhome routes domain-neutral ruby_home_event write events from Home
+// Assistant onto NATS (ROADMAP-0012, Slice B). It is the domain-neutral successor
+// to the ada package's write path: new home-automation write contracts (calendar,
+// childcare, …) register their event string here instead of getting a bespoke HA
+// event type. The NATS subject is derived from the payload "event" string.
+package rubyhome
+
+import (
+	"crypto/rand"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"time"
+
+	goNats "github.com/nats-io/nats.go"
+
+	"github.com/primaryrutabaga/ruby-core/pkg/schemas"
+)
+
+// eventRoutes maps the frontend event type string (the "event" field in the
+// ruby_home_event payload) to the NATS subject for that event. Subjects are the
+// shared contract constants in pkg/schemas (ADR-0014).
+var eventRoutes = map[string]string{
+	"calendar.event.upsert":               schemas.HomeEventCalendarUpsert,
+	"calendar.event.delete":               schemas.HomeEventCalendarDelete,
+	"ruby_home.childcare.provider.upsert": schemas.HomeEventChildcareProviderUpsert,
+	"ruby_home.childcare.provider.delete": schemas.HomeEventChildcareProviderDelete,
+}
+
+// Publish wraps payload in a CloudEvent and publishes it to the ha.events.* subject
+// derived from the payload "event" string. An unknown event is logged and returns
+// an error without publishing.
+func Publish(nc *goNats.Conn, payload map[string]any, log *slog.Logger) error {
+	eventType, _ := payload["event"].(string)
+	subject, ok := eventRoutes[eventType]
+	if !ok {
+		log.Warn("ruby_home: unknown event type", slog.String("event", eventType))
+		return fmt.Errorf("ruby_home: unknown event type %q", eventType)
+	}
+
+	id := newID()
+	evt := schemas.CloudEvent{
+		SpecVersion:   schemas.CloudEventsSpecVersion,
+		ID:            id,
+		Source:        "ruby_gateway",
+		Type:          subject,
+		Time:          time.Now().UTC().Format(time.RFC3339),
+		DataSchema:    schemas.CloudEventDataSchemaVersionV1,
+		CorrelationID: id,
+		CausationID:   id,
+		Data:          payload,
+	}
+
+	b, err := json.Marshal(evt)
+	if err != nil {
+		return fmt.Errorf("ruby_home: marshal CloudEvent: %w", err)
+	}
+
+	if err := nc.Publish(subject, b); err != nil {
+		return fmt.Errorf("ruby_home: publish %s: %w", subject, err)
+	}
+
+	log.Info("ruby_home: event published",
+		slog.String("event", eventType),
+		slog.String("subject", subject),
+		slog.String("id", id),
+	)
+	return nil
+}
+
+func newID() string {
+	var b [8]byte
+	_, _ = rand.Read(b[:])
+	return fmt.Sprintf("%x", b)
+}

--- a/services/gateway/rubyhome/publish_integration_test.go
+++ b/services/gateway/rubyhome/publish_integration_test.go
@@ -1,0 +1,131 @@
+//go:build integration
+
+package rubyhome_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"testing"
+	"time"
+
+	natsgo "github.com/nats-io/nats.go"
+	tcnats "github.com/testcontainers/testcontainers-go/modules/nats"
+
+	"github.com/primaryrutabaga/ruby-core/pkg/natsx"
+	"github.com/primaryrutabaga/ruby-core/pkg/schemas"
+	"github.com/primaryrutabaga/ruby-core/services/gateway/ada"
+	"github.com/primaryrutabaga/ruby-core/services/gateway/rubyhome"
+)
+
+// startNATS spins up a JetStream-enabled NATS testcontainer and returns a connected
+// conn (cleaned up via t.Cleanup). Mirrors pkg/natsx/consumer_integration_test.go.
+func startNATS(t *testing.T) *natsgo.Conn {
+	t.Helper()
+	ctx := context.Background()
+
+	container, err := tcnats.Run(ctx, "nats:2.10-alpine")
+	if err != nil {
+		t.Fatalf("startNATS: run container: %v", err)
+	}
+	t.Cleanup(func() {
+		if err := container.Terminate(ctx); err != nil {
+			t.Logf("startNATS: terminate container: %v", err)
+		}
+	})
+
+	connStr, err := container.ConnectionString(ctx)
+	if err != nil {
+		t.Fatalf("startNATS: connection string: %v", err)
+	}
+
+	var nc *natsgo.Conn
+	for range 10 {
+		nc, err = natsgo.Connect(connStr, natsgo.MaxReconnects(0))
+		if err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("startNATS: connect: %v", err)
+	}
+	t.Cleanup(nc.Close)
+	return nc
+}
+
+// TestRubyHomeAndAdaLandInHAEvents proves the new ruby_home write path publishes
+// CloudEvents to the correct ha.events.* subjects in the HA_EVENTS stream, and that
+// the existing ada path still routes unchanged (no regression from the dual path).
+func TestRubyHomeAndAdaLandInHAEvents(t *testing.T) {
+	nc := startNATS(t)
+	js, err := nc.JetStream()
+	if err != nil {
+		t.Fatalf("JetStream: %v", err)
+	}
+	if err := natsx.EnsureHAEventsStream(js); err != nil {
+		t.Fatalf("EnsureHAEventsStream: %v", err)
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+
+	// New domain-neutral path: a calendar write event.
+	if err := rubyhome.Publish(nc, map[string]any{
+		"event":           "calendar.event.upsert",
+		"summary":         "Dentist",
+		"idempotency_key": "test-key-1",
+	}, log); err != nil {
+		t.Fatalf("rubyhome.Publish: %v", err)
+	}
+	assertCloudEventStored(t, js, schemas.HomeEventCalendarUpsert)
+
+	// New domain-neutral path: a childcare overlay write event.
+	if err := rubyhome.Publish(nc, map[string]any{
+		"event":        "ruby_home.childcare.provider.upsert",
+		"display_name": "Maya",
+	}, log); err != nil {
+		t.Fatalf("rubyhome.Publish (childcare): %v", err)
+	}
+	assertCloudEventStored(t, js, schemas.HomeEventChildcareProviderUpsert)
+
+	// Regression: the existing ada path still routes onto HA_EVENTS unchanged.
+	if err := ada.Publish(nc, map[string]any{
+		"event": "ada.diaper.log",
+		"type":  "wet",
+	}, log); err != nil {
+		t.Fatalf("ada.Publish: %v", err)
+	}
+	assertCloudEventStored(t, js, schemas.AdaEventDiaperLogged)
+}
+
+// assertCloudEventStored verifies a CloudEvent was stored in HA_EVENTS on subject,
+// with Type == subject and Source == ruby_gateway.
+func assertCloudEventStored(t *testing.T, js natsgo.JetStreamContext, subject string) {
+	t.Helper()
+
+	var (
+		msg *natsgo.RawStreamMsg
+		err error
+	)
+	for range 20 {
+		msg, err = js.GetLastMsg("HA_EVENTS", subject)
+		if err == nil {
+			break
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	if err != nil {
+		t.Fatalf("no message stored on %q: %v", subject, err)
+	}
+
+	var evt schemas.CloudEvent
+	if err := json.Unmarshal(msg.Data, &evt); err != nil {
+		t.Fatalf("unmarshal CloudEvent on %q: %v", subject, err)
+	}
+	if evt.Type != subject {
+		t.Errorf("CloudEvent.Type = %q, want %q", evt.Type, subject)
+	}
+	if evt.Source != "ruby_gateway" {
+		t.Errorf("CloudEvent.Source = %q, want ruby_gateway", evt.Source)
+	}
+}

--- a/services/gateway/rubyhome/publish_test.go
+++ b/services/gateway/rubyhome/publish_test.go
@@ -1,0 +1,70 @@
+//go:build fast
+
+package rubyhome
+
+import (
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/primaryrutabaga/ruby-core/pkg/natsx"
+	"github.com/primaryrutabaga/ruby-core/pkg/schemas"
+)
+
+// TestEventRoutes verifies every ruby_home write event maps to its shared-contract
+// subject and that no unexpected routes exist.
+func TestEventRoutes(t *testing.T) {
+	want := map[string]string{
+		"calendar.event.upsert":               schemas.HomeEventCalendarUpsert,
+		"calendar.event.delete":               schemas.HomeEventCalendarDelete,
+		"ruby_home.childcare.provider.upsert": schemas.HomeEventChildcareProviderUpsert,
+		"ruby_home.childcare.provider.delete": schemas.HomeEventChildcareProviderDelete,
+	}
+	if len(eventRoutes) != len(want) {
+		t.Fatalf("eventRoutes has %d entries, want %d", len(eventRoutes), len(want))
+	}
+	for ev, subj := range want {
+		got, ok := eventRoutes[ev]
+		if !ok {
+			t.Errorf("eventRoutes missing %q", ev)
+			continue
+		}
+		if got != subj {
+			t.Errorf("%q routes to %q, want %q", ev, got, subj)
+		}
+	}
+}
+
+// TestSubjectsValidPerADR0027 asserts every routed subject lands under the HA_EVENTS
+// prefix and is composed of valid ADR-0027 tokens (lowercase, underscores; no dots
+// within a token).
+func TestSubjectsValidPerADR0027(t *testing.T) {
+	for ev, subj := range eventRoutes {
+		if !strings.HasPrefix(subj, "ha.events.") {
+			t.Errorf("%q subject %q is not under the ha.events. prefix", ev, subj)
+		}
+		for _, tok := range strings.Split(subj, ".") {
+			if !natsx.IsValidToken(tok) {
+				t.Errorf("%q subject %q contains invalid token %q", ev, subj, tok)
+			}
+		}
+	}
+}
+
+// TestPublishUnknownEvent verifies an unknown event returns an error before touching
+// NATS (nil conn proves no publish is attempted).
+func TestPublishUnknownEvent(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	if err := Publish(nil, map[string]any{"event": "calendar.nope"}, log); err == nil {
+		t.Fatal("expected error for unknown event, got nil")
+	}
+}
+
+// TestPublishMissingEventField verifies a payload with no event field is rejected.
+func TestPublishMissingEventField(t *testing.T) {
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	if err := Publish(nil, map[string]any{}, log); err == nil {
+		t.Fatal("expected error for missing event field, got nil")
+	}
+}


### PR DESCRIPTION
## Summary

Slice B of the home-calendar effort (ROADMAP-0012.2 / PLAN-0031): makes the gateway's HA→NATS write pipe **domain-neutral**. The gateway now dual-subscribes a new `ruby_home_event` HA event type alongside `ada_event`, deriving the NATS subject from the payload `event` string. This carries the home-calendar + childcare write contracts onto `HA_EVENTS` so Slices C/D have a consumer-ready ingress — without disturbing Ada.

Independent of Slice A (#119); both are foundation slices.

## What's here

- **`pkg/schemas/homecal.go`** — shared subject constants (ADR-0014) for the four write events: `calendar.event.{upsert,delete}` → `ha.events.calendar.event_{upsert,delete}`, and `ruby_home.childcare.provider.{upsert,delete}` → `ha.events.ruby_home.childcare.provider_{upsert,delete}`. ADR-0027-valid tokens; land in `HA_EVENTS`.
- **`services/gateway/rubyhome/publish.go`** — domain-neutral `eventRoutes` map + CloudEvent publish, mirroring the ada path. Unknown event → logged + error, no publish.
- **`services/gateway/ha/client.go`** — subscribe `ruby_home_event` (sub ID 3) alongside `state_changed`/`ada_event`, dispatch case, and `handleRubyHomeEvent` (payload wrapped under a `payload` key, same convention as `ada_event`).
- **gateway README** — documents the HA producer contract (route table + payload shape) and notes the cross-repo migration.

## Sequencing / cross-repo

Dual-subscribe → (HA producers migrate to `ruby_home_event`) → drop `ada_event`. The middle and last steps are **cross-repo work in the `homeassistant` repo and are not part of this PR** — the gateway dual-subscribes so the cutover is non-breaking. `ada_event` routing is untouched here.

## Verification

- `go build ./...`, fast unit tests: route-map correctness, **every routed subject is composed of valid ADR-0027 tokens**, and unknown/missing-`event` error paths.
- **Integration test** (`-tags=integration`, testcontainers NATS): publishing `ruby_home_event` calendar + childcare events lands CloudEvents on the correct `ha.events.*` subjects in `HA_EVENTS`; `ada.Publish` still routes unchanged (no regression). Passes in ~3s.
- `golangci-lint-from-main` clean; all pre-commit hooks green.

## Notable decision

Resolved the plan's open question: kept the structured subject `ha.events.ruby_home.childcare.provider_upsert` (`provider.upsert` → `provider_upsert` per ADR-0027) rather than a flatter `ha.events.ruby_home.*`. The engine processor subscribes with a `.>` pattern regardless.

## Pre-PR Checklist

- [x] gateway README reflects current state (ruby_home_event producer contract)
- [x] No operational runbook affected (no deployed behavior change)
- [x] No new/updated ADR needed (implements existing ADR-0027/0009/0003)
- [x] PLAN-0031 archived to `docs/plans/archived/` (Complete, with completion notes) as the final commit
- [x] Pre-commit + pre-push hooks pass
- [x] Branch single-concern (`feat/event-bus-generalization`)
- [x] Drift observations — none new from this slice

## Drift Observations

None new from this slice. (The two open drift items — Traefik→api mTLS deferral and the api host-side provisioning blocker — belong to #119 and are tracked as separate issues.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)