### PR TITLE
fix(deploy): build api image in release and gate it behind a compose profile

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -39,6 +39,7 @@ jobs:
           - audit-sink
           - notifier
           - presence
+          - api
 
     steps:
       - name: Checkout code

--- a/deploy/prod/compose.prod.yaml
+++ b/deploy/prod/compose.prod.yaml
@@ -188,6 +188,12 @@ services:
   #   - API bearer token at secret/ruby-core/api (field: token)
   #   - the ruby-api-auth Traefik middleware in Traefik's dynamic config
   api:
+    # Opt-in until host-side prerequisites exist (read-only Postgres role at
+    # secret/ruby-core/postgres_readonly, the api bearer at secret/ruby-core/api,
+    # and the ruby-api-auth Traefik middleware). Without this profile the deploy
+    # skips api (no pull, no start); enable with COMPOSE_PROFILES=api once
+    # provisioned (drift #123).
+    profiles: [api]
     image: ghcr.io/${GITHUB_REPOSITORY_OWNER}/ruby-core-api:${VERSION:?VERSION env var required}
     container_name: ruby-core-prod-api
     restart: unless-stopped

--- a/deploy/staging/compose.staging.yaml
+++ b/deploy/staging/compose.staging.yaml
@@ -216,6 +216,11 @@ services:
   # publicly routed). Pre-conditions: secret/ruby-core/staging/postgres_readonly
   # and secret/ruby-core/staging/api (field: token).
   api:
+    # Opt-in until host-side prerequisites exist (read-only Postgres role at
+    # secret/ruby-core/staging/postgres_readonly + the staging api bearer). Without
+    # this profile the deploy skips api (no pull, no start) so releases stay green;
+    # enable with COMPOSE_PROFILES=api once provisioned (drift #123).
+    profiles: [api]
     image: ghcr.io/${GITHUB_REPOSITORY_OWNER}/ruby-core-api:${VERSION}
     container_name: ruby-core-staging-api
     restart: unless-stopped


### PR DESCRIPTION
## Summary

The **v0.25.0 staging deploy failed** pulling `ghcr.io/.../ruby-core-api:v0.25.0` with **`manifest unknown`** — the `api` image was never built.

**Root cause:** Slice A (#119) added `api` to the **CI** docker-build matrix and to the staging/prod **compose** files, but not to **`release.yml`**'s build-and-push matrix. So the release built every image except `api`, and staging then failed trying to pull it.

Behind that was a second issue: even with the image, `api` would **crash-loop** in staging/prod because its host-side prerequisites don't exist yet (read-only Postgres role, api bearer, `ruby-api-auth` Traefik middleware — see #123). That's why we don't want deploys starting `api` until it's provisioned.

## Fix (two parts)

1. **`release.yml`** — add `api` to the build-and-push matrix, so the image is published.
2. **staging + prod compose** — put `api` behind `profiles: [api]`. The deploy scripts run plain `docker compose pull`/`up -d` with no profile, so `api` is now **skipped** (no pull, no start). Releases stay green and an unprovisioned `api` can't crash-loop. `dev` already gated `api` behind its `services` profile.

## Verification

- `docker compose config --services` (staging & prod): `api` **excluded** by default; **included** only with `--profile api`.
- `actionlint` + `yamllint` pass on the changed files.

## How `api` comes online later

Once the #123 prerequisites are provisioned, enable it with `COMPOSE_PROFILES=api` (commented inline in both compose files; tracked on #123). The household-overlay slice — which adds the api's overlay read endpoints — will flip this profile on so `api` deploys with that release in a single cycle.

## Recovery

This is a `fix:` commit, so release-please will propose **v0.25.1**; merging it tags the release, builds **all** images (incl. `api`), and the staging deploy passes (`api` skipped). The failed v0.25.0 can't be retried — its `api` image never existed — so the path forward is the next patch release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)