### PR TITLE
docs(runbook): fix idempotency-KV purge to avoid DLQ flood

### DIFF
--- a/docs/runbooks/idempotency-kv.md
+++ b/docs/runbooks/idempotency-kv.md
@@ -6,13 +6,16 @@ The engine dedups processed events in a NATS KV bucket named `idempotency` (shar
 A KV bucket's **TTL is fixed at creation**. `idempotency.CreateOrBindKVBucket` binds an
 existing bucket as-is, so lowering `DefaultIdempotencyTTL` in code has **no effect** on a
 live bucket — the engine logs a WARN at startup when the live TTL differs from the
-configured value. To actually apply a new TTL (or to purge a bloated bucket), delete the
-bucket and let the engine recreate it.
+configured value. To actually apply a new TTL (or to drain a bloated bucket), either edit
+the backing stream's max-age in place (Option A, preferred) or recreate the bucket with the
+engine stopped (Option B).
 
-> ⚠️ This is a destructive op on a live bucket (`del`). It is safe here because dedup only
-> needs to outlive the ~165s redelivery window and the calendar write-through is now
-> idempotent at Google (ADR-0042) — so reprocessing during the brief empty-history window
-> is harmless. Still, do it **off-peak**.
+> ⚠️ **Do not `kv del` while the engine is consuming.** A running consumer whose bound
+> bucket disappears gets `idempotency check: nats: no responders available` on every
+> `Seen()` → the event NAKs → and events that exhaust `MaxDeliver` (5, within ~15s of
+> backoff) during the gap land in the **DLQ**. A live purge of the 24h bucket once DLQ'd
+> ~52 `state_changed` telemetry events this way (benign — superseded — but noisy). Use one
+> of the two safe procedures below instead, and do it **off-peak**.
 
 ## Inspect
 
@@ -24,33 +27,51 @@ ENV=prod scripts/nats-admin.sh kv status idempotency   # shows TTL + entry count
 A healthy bucket at the 30m TTL holds low-thousands of entries. Tens of thousands means the
 old 24h TTL is still in effect (or marking volume has grown) — recreate it.
 
-## Purge + recreate (apply a new TTL)
+## Option A — edit the backing stream's max-age in place (preferred, zero disruption)
 
-1. **Deploy the engine build** that sets the new `DefaultIdempotencyTTL`. On startup it
-   binds the *existing* bucket and logs the TTL-mismatch WARN — expected at this step.
-2. **Delete the bucket** (off-peak):
+A KV bucket is backed by a stream named `KV_<bucket>`. Editing that stream's `max-age`
+changes the effective TTL **without** deleting the bucket, so the engine keeps running and
+nothing DLQs. Existing entries older than the new age are evicted on the next enforcement
+pass. Verify the command on a non-prod bucket first if you haven't used it before.
 
-   ```bash
-   ENV=prod scripts/nats-admin.sh kv del idempotency
-   ```
+```bash
+ENV=prod scripts/nats-admin.sh stream edit KV_idempotency --max-age=30m --force
+ENV=prod scripts/nats-admin.sh kv status idempotency   # Maximum Age = 30m0s; count falls as entries age out
+```
 
-3. **Restart the engine** so startup recreates the bucket at the new TTL:
+The engine still logs the startup TTL-mismatch WARN until its next restart re-binds and
+sees the matching age — cosmetic once the stream is edited.
 
-   ```bash
-   docker restart ruby-core-engine-prod    # adjust to the actual prod engine container name
-   ```
+## Option B — recreate the bucket (stop the engine FIRST)
 
-4. **Verify**: the startup log shows no TTL-mismatch WARN, and:
+Use this for a clean empty bucket. The engine **must not** be running while the bucket is
+absent (see the warning above); its startup recreates the bucket at the configured TTL
+*before* the consumer loop starts, so stop → delete → start is the safe order.
 
-   ```bash
-   ENV=prod scripts/nats-admin.sh kv status idempotency   # TTL = 30m, low entry count
-   ```
+```bash
+ENV=prod scripts/nats-admin.sh kv status idempotency      # note current TTL/count
+docker stop ruby-core-prod-engine                         # stop consuming FIRST
+ENV=prod scripts/nats-admin.sh kv del idempotency --force # now safe to delete
+docker start ruby-core-prod-engine                        # startup recreates it at 30m before consuming
+```
+
+> The earlier "delete the live bucket, then `docker restart`" procedure is **unsafe** — the
+> old container keeps consuming against the missing bucket during the restart and DLQs
+> events (see the warning at the top). Always stop first.
+
+**Verify** (either option):
+
+```bash
+ENV=prod scripts/nats-admin.sh kv status idempotency   # Maximum Age = 30m0s, low/again-growing count
+docker logs ruby-core-prod-engine --since 1m 2>&1 | grep -iE "idempotency|no responders"  # no errors
+ENV=prod scripts/nats-admin.sh stream info DLQ 2>&1 | grep Messages   # no purge-window DLQ growth
+```
 
 Note: the calendar processor's separate `calendar_idempotency` bucket (reminder-firing
-dedup) is low-volume and unaffected — do not delete it.
+dedup) is low-volume and unaffected — do not touch it.
 
 ## Rollback
 
-Recreate at the prior TTL by deploying the previous engine image (its
-`DefaultIdempotencyTTL`) and repeating the delete + restart, or `kv del` + let the running
-binary recreate it. No data rollback — the bucket holds only transient dedup markers.
+Set the prior TTL back with Option A (`stream edit … --max-age=24h`), or deploy the previous
+engine image and recreate via Option B. No data rollback — the bucket holds only transient
+dedup markers.


### PR DESCRIPTION
## Summary

Corrects the `docs/runbooks/idempotency-kv.md` purge procedure (added in #136). The original "`kv del idempotency` then `docker restart`" sequence deletes the bucket **while the engine is still consuming**, so every `Seen()` returns `nats: no responders available` → events NAK → and any that exhaust `MaxDeliver` (5, ~15s of backoff) during the gap land in the DLQ.

This was hit live applying the PLAN-0034 30m TTL: **~52 `state_changed` telemetry events DLQ'd** (benign — superseded — but noisy) during the ~11s window between the delete and the recreated bucket.

## What changed

- **Option A (preferred, zero disruption):** `nats stream edit KV_idempotency --max-age=30m` — changes the TTL on the KV backing stream **in place**, no delete, no consumer disruption, no DLQ. Existing entries age out at the new TTL.
- **Option B (recreate):** stop the engine **first**, then `kv del`, then start — startup recreates the bucket at the configured TTL before the consumer loop runs.
- Added a warning explaining the failure mode, a verify block (no `no responders` errors, no purge-window DLQ growth), and fixed the prod engine container name (`ruby-core-prod-engine`).

## Context

Found while applying PLAN-0034's Step 5 in prod (v0.26.1). The 52 DLQ'd events were all stale telemetry and recommended for purge; the engine recovered cleanly once the bucket was recreated. No code change — runbook only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)