### PR TITLE
fix(calendar): quote etag in If-Match header so modify stops 412'ing (#140)

### DIFF
--- a/services/engine/processors/calendar/gcal/client.go
+++ b/services/engine/processors/calendar/gcal/client.go
@@ -120,10 +120,24 @@ func (a *apiService) Insert(ctx context.Context, calendarID string, ev *calendar
 	return out, nil
 }
 
+// quoteEtag wraps a bare etag in the double-quotes an HTTP If-Match entity-tag requires.
+// The mirror stores etags trimmed of Google's surrounding quotes (see trimEtag in the
+// calendar package), but If-Match comparison needs the quoted form — a bare value always
+// yields 412. Idempotent: an already-quoted value is returned unchanged.
+func quoteEtag(etag string) string {
+	if len(etag) >= 2 && etag[0] == '"' && etag[len(etag)-1] == '"' {
+		return etag
+	}
+	return `"` + etag + `"`
+}
+
 func (a *apiService) Update(ctx context.Context, calendarID, eventID, etag string, ev *calendarv3.Event) (*calendarv3.Event, error) {
 	call := a.svc.Events.Update(calendarID, eventID, ev)
 	if etag != "" {
-		call.Header().Set("If-Match", etag)
+		// If-Match requires the quoted entity-tag form. The mirror stores etags
+		// trimmed (trimEtag), so a bare value never matches → Google 412. Re-add the
+		// quotes here.
+		call.Header().Set("If-Match", quoteEtag(etag))
 	}
 	out, err := call.Context(ctx).Do()
 	if err != nil {

--- a/services/engine/processors/calendar/gcal/client_test.go
+++ b/services/engine/processors/calendar/gcal/client_test.go
@@ -1,0 +1,24 @@
+//go:build fast
+
+package gcal
+
+import "testing"
+
+// quoteEtag must produce the quoted entity-tag form an HTTP If-Match requires. The
+// mirror stores etags trimmed of Google's quotes, so a bare value would 412 (issue #140).
+func TestQuoteEtag(t *testing.T) {
+	cases := []struct {
+		name, in, want string
+	}{
+		{"bare numeric", "3565350163851326", `"3565350163851326"`},
+		{"already quoted", `"3565350163851326"`, `"3565350163851326"`},
+		{"bare alnum", "p32o", `"p32o"`},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := quoteEtag(c.in); got != c.want {
+				t.Errorf("quoteEtag(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes #140. Etag-based calendar updates (`calendar.event.upsert` carrying an `etag`) always failed with Google **412** — including the resync-and-retry — and NAK'd to the DLQ. Pre-existing bug, surfaced during live e2e verification of v0.26.1.

## Root cause

`trimEtag` stores etags without the quotes Google wraps them in (mirror column `3565350163851326` vs Google's `"3565350163851326"`), and `gcal.Update` sent that **bare** value as the `If-Match` header. HTTP `If-Match` requires the quoted entity-tag form, so the bare value never matched → 412 on every attempt. The `update()` resync path re-fetched a fresh etag but trimmed it again → same 412 on retry → DLQ.

## Fix

`quoteEtag` re-adds the quotes when setting the `If-Match` header (idempotent for an already-quoted value). Storage and the poller's echo-reconciliation comparison stay trimmed — only the outbound header is quoted. Regression test (`gcal/client_test.go`) covers bare, already-quoted, and alphanumeric etags.

Verified the rest of the update path is sound: an unconditional (no-etag) modify already worked live; this makes the etag path work too.

## Scope / follow-up

This PR makes the `If-Match` path correct when an etag is supplied. The read API does **not** currently expose `etag`, so clients can't yet obtain one to send — exposing it in the `/v1/calendar/events` response (ogen/codegen change) is the enablement follow-up tracked in #140.

## Test plan

- [x] `go test -tags=fast ./services/engine/processors/calendar/...`
- [x] `golangci-lint run` (0 issues)
- [ ] Live: etag-bearing modify applies without 412 (after a deploy)

Closes #140.

🤖 Generated with [Claude Code](https://claude.com/claude-code)