### PR TITLE
feat(observability): distributed traces — W3C propagation + per-service spans (PLAN-0009 PR 2/2)

### DIFF
--- a/docs/ops/phase9-verification.md
+++ b/docs/ops/phase9-verification.md
@@ -1,23 +1,26 @@
 # Phase 9 Verification — Full-Stack Observability (PLAN-0009)
 
-PLAN-0009 ships in two PRs on `phase-9-observability`:
+PLAN-0009 shipped in two PRs:
 
-* **PR 1 — metrics + log correlation** (this PR): the OTel SDK foundation, OTLP metric
-  export from all 5 services, log-trace ID injection, and compose wiring. Closes **#31**
+* **PR 1 — metrics + log correlation** (#150, merged): the OTel SDK foundation, OTLP metric
+  export from all 5 services, log-trace ID injection, and compose wiring. Closed **#31**
   (superseded by OTLP — no `/metrics` endpoint) and **#137** (idempotency metrics).
-* **PR 2 — distributed traces** (follow-up): per-service spans, W3C context propagation
-  across NATS, and `ctx` threading through the engine `process` path to connect a
+* **PR 2 — distributed traces** (this PR): per-service spans, W3C context propagation across
+  NATS, and `ctx` threading through the engine `process` path to connect a
   gateway→engine→notifier trace.
 
 ## Acceptance Criteria (ROADMAP-0009)
 
 | # | Criterion | Status | Notes |
 |---|---|---|---|
-| AC-1 | A distributed trace for a complete automation flow is viewable | `[ ]` | PR 2 (spans + W3C propagation) |
-| AC-2 | Key service metrics visible in a dashboard | `[~]` | Emission code-complete (PR 1); dashboard visibility needs the live staging/prod export below |
-| AC-3 | Log entries contain trace IDs that correlate with traces | `[~]` | Injection mechanism shipped (PR 1); IDs are non-empty only once spans exist (PR 2) |
+| AC-1 | A distributed trace for a complete automation flow is viewable | `[~]` | Mechanism complete + unit-verified (inject→extract shares one trace ID); the live Tempo view is the deploy step below |
+| AC-2 | Key service metrics visible in a dashboard | `[~]` | Emission code-complete (PR 1); dashboard visibility needs the live export below |
+| AC-3 | Log entries contain trace IDs that correlate with traces | `[~]` | Injection shipped (PR 1) + spans now populate the IDs (PR 2); live Loki↔Tempo correlation is the deploy step |
 
-`[~]` = code-complete in PR 1, full sign-off pending PR 2 + a live deploy.
+`[~]` = code-complete and unit-verified; final sign-off is the one-time live confirmation in
+Grafana after a deploy (this node has no telemetry backend access from CI, so it can't be
+ticked from the repo). The connected-trace mechanism itself is proven by
+`TestPublishWithContext_PropagatesTraceToObserve` in `pkg/natsx`.
 
 ---
 
@@ -98,10 +101,38 @@ ruby_core_idempotency_kv_entries
 Expect a series per running service, filterable by `deployment_environment`
 (`production` vs `staging`).
 
-### Deferred to PR 2
+## What PR 2 delivers — distributed traces
 
-* AC-1 (connected gateway→engine→notifier trace in Tempo).
-* AC-3 full sign-off (Loki entries carrying non-empty `trace_id` matching a Tempo trace).
-* Spans: `nats.consume`, `ha.ingest`, `engine.process`, `notify.send`, `presence.wifi_check`.
-* W3C `traceparent` injection on the 3 gateway publish paths + `ctx` threading through the
-  engine `process`/`ProcessEvent` path.
+**Spans** (all OTLP-exported, parented via W3C trace context carried in NATS headers):
+
+| Span | Service | Where |
+|---|---|---|
+| `ha.ingest` | gateway | `handleEvent` — root span per HA WebSocket event |
+| `nats.consume` | engine, notifier, presence, audit-sink | `pkg/natsx.MsgInstruments.Observe` (extracts the parent from headers) |
+| `engine.process` | engine | `ProcessorHost.Process` |
+| `notify.send` | notifier | `sendNotification` (HA push REST call) |
+| `presence.wifi_check` | presence | `queryWifiState` (WiFi corroboration REST call) |
+
+**Propagation.** `natsx.PublishWithContext` injects the active span's `traceparent` into the
+NATS message headers; the consumer's `Observe` extracts it and opens `nats.consume` as a child.
+The gateway injects on all three publish paths (`state_changed`, `ada_event`, `ruby_home_event`);
+the engine threads `ctx` through `handle → decide → process → ProcessorHost.Process →
+Processor.ProcessEvent`, and `presence_notify` publishes the notify command with context — so the
+full flow connects:
+
+```text
+ha.ingest → nats.consume(engine) → engine.process → nats.consume(notifier) → notify.send
+```
+
+**Unit-verified:** `TestPublishWithContext_PropagatesTraceToObserve` asserts the consumer span
+shares the producer's trace ID (inject→extract round-trip).
+
+### Live verification (run once after a deploy — completes AC sign-off)
+
+1. **Trace (AC-1):** trigger a presence transition (or publish a notify command); in Grafana →
+   Tempo, search for service `gateway` and open the trace. Expect the connected span chain above
+   with the engine and notifier spans as descendants of `ha.ingest`.
+2. **Log correlation (AC-3):** in Loki, find an `engine`/`notifier` log line emitted during that
+   flow; it carries `trace_id`/`span_id`. Paste the `trace_id` into Tempo and confirm it opens the
+   same trace.
+3. **Metrics (AC-2):** the PromQL above returns a series per service.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -7,7 +7,7 @@ Active plans below are hand-maintained. The **Archived** table is generated from
 
 | # | Title | Status | Roadmap Item |
 |---|---|---|---|
-| [0009](PLAN-0009-full-stack-observability.md) | Full-Stack Observability | In Progress | [ROADMAP-0009](../roadmap/ROADMAP-0009-full-stack-observability.md) |
+| _none_ | | | |
 
 ## Archived
 
@@ -15,6 +15,7 @@ Active plans below are hand-maintained. The **Archived** table is generated from
 
 | Plan | Title | Status |
 |---|---|---|
+| [0009](archived/PLAN-0009-full-stack-observability.md) | Full-Stack Observability | Complete |
 | [0010](archived/PLAN-0010-ada-backend-phase2.md) | Ada Backend Phase 2: Event Ingestion and Persistence | Complete |
 | [0011](archived/PLAN-0011-ada-phase3b-event-bus.md) | Ada Phase 3b: Replace HTTP Gateway Calls with HA Event Bus | Complete |
 | [0012](archived/PLAN-0012-ada-sleep-timer-and-sensor-refresh.md) | Ada: Live Sleep Timer and Periodic Sensor Refresh | In Progress |

--- a/docs/plans/archived/PLAN-0009-full-stack-observability.md
+++ b/docs/plans/archived/PLAN-0009-full-stack-observability.md
@@ -1,6 +1,6 @@
 # PLAN-0009 — Full-Stack Observability
 
-* **Status:** In Progress (reconciled 2026-06-29 — see Reconciliation)
+* **Status:** Complete (2026-06-29 — shipped as PR #150 metrics+logs and the traces PR; see Reconciliation)
 * **Date:** 2026-03-20
 * **Project:** ruby-core
 * **Roadmap Item:** [docs/roadmap/ROADMAP-0009-full-stack-observability.md](../roadmap/ROADMAP-0009-full-stack-observability.md)
@@ -364,5 +364,9 @@ Corrections applied during execution:
   paths), which would mislabel its ephemeral smoke-test telemetry as production. Added an
   `OTEL_DEPLOYMENT_ENVIRONMENT` override (preferred over `ENVIRONMENT` in `otel.Init`); staging
   compose sets it to `staging`.
-* **Plan stays In Progress** until PR 2 lands — it is archived as the final commit of PR 2, not
-  PR 1. PR-1 verification: `docs/ops/phase9-verification.md`.
+* **PR split landed:** PR 1 (metrics + log correlation) merged as #150 (release 0.28.0); PR 2
+  (distributed traces) completed the spans + W3C propagation + engine `ctx` threading. The
+  connected `ha.ingest → nats.consume → engine.process → nats.consume → notify.send` trace is
+  unit-proven (`TestPublishWithContext_PropagatesTraceToObserve`); the one-time live Grafana
+  confirmation of the three ACs is documented in `docs/ops/phase9-verification.md` (CI has no
+  telemetry-backend access, so it can't be ticked from the repo). Plan archived with PR 2.

--- a/docs/roadmap/ROADMAP-0009-full-stack-observability.md
+++ b/docs/roadmap/ROADMAP-0009-full-stack-observability.md
@@ -32,9 +32,18 @@ A distributed trace is visible in the trace backend for a complete automation fl
 
 ## Acceptance Criteria
 
-* `[ ]` A distributed trace can be viewed in the trace backend for a complete automation flow.
-* `[ ]` Key service metrics (e.g., processing latency, queue depth) are visible in a dashboard.
-* `[ ]` Log entries contain trace IDs that correlate with traces in the backend.
+Implemented across PR #150 (metrics + log correlation) and the traces PR (PLAN-0009).
+`[~]` = code-complete and unit-verified; the final tick is a one-time live confirmation in
+Grafana after a deploy (CI has no telemetry-backend access). See
+[docs/ops/phase9-verification.md](../ops/phase9-verification.md) for the live steps.
+
+* `[~]` A distributed trace can be viewed in the trace backend for a complete automation flow.
+  Mechanism complete — `ha.ingest → nats.consume → engine.process → nats.consume → notify.send`,
+  connected via W3C trace context in NATS headers; proven by a propagation round-trip unit test.
+* `[~]` Key service metrics (e.g., processing latency, queue depth) are visible in a dashboard.
+  Emitted via OTLP (`ruby_core_*`); dashboard visibility is the live step.
+* `[~]` Log entries contain trace IDs that correlate with traces in the backend.
+  slog stamps `trace_id`/`span_id` from the active span; live Loki↔Tempo correlation is the live step.
 
 ---
 

--- a/pkg/natsx/instrument.go
+++ b/pkg/natsx/instrument.go
@@ -4,13 +4,21 @@ import (
 	"context"
 	"time"
 
+	"github.com/nats-io/nats.go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 )
 
-// meterName is the instrumentation scope for ruby-core consumer metrics.
+// meterName is the instrumentation scope for ruby-core consumer metrics and the
+// nats.consume span.
 const meterName = "github.com/primaryrutabaga/ruby-core/pkg/natsx"
+
+// tracer opens consumer spans. otel.Tracer delegates to the global TracerProvider, so a
+// package-level value picks up the real provider once otel.Init installs it.
+var tracer = otel.Tracer(meterName)
 
 // Outcome labels for ruby_core_messages_processed_total. Each consumer loop maps its
 // terminal branch (ack / nak / dedup) to one of these.
@@ -20,13 +28,44 @@ const (
 	OutcomeDuplicate = "duplicate"
 )
 
+// natsHeaderCarrier adapts nats.Header to the W3C TextMapCarrier interface so trace
+// context can be injected into and extracted from NATS message headers.
+type natsHeaderCarrier nats.Header
+
+func (c natsHeaderCarrier) Get(key string) string { return nats.Header(c).Get(key) }
+func (c natsHeaderCarrier) Set(key, value string) { nats.Header(c).Set(key, value) }
+func (c natsHeaderCarrier) Keys() []string {
+	keys := make([]string, 0, len(c))
+	for k := range c {
+		keys = append(keys, k)
+	}
+	return keys
+}
+
+// MsgPublisher is the subset of *nats.Conn needed to publish a message with headers.
+// Defined as an interface so processors that inject a narrow publish dependency (for
+// testing) can still carry trace context.
+type MsgPublisher interface {
+	PublishMsg(*nats.Msg) error
+}
+
+// PublishWithContext publishes data to subject, injecting the active span's W3C trace
+// context into the message headers so the consumer can continue the same trace. Use this
+// in place of nc.Publish on any cross-service hop that should appear as one connected
+// trace (PLAN-0009).
+func PublishWithContext(ctx context.Context, pub MsgPublisher, subject string, data []byte) error {
+	msg := &nats.Msg{Subject: subject, Data: data, Header: nats.Header{}}
+	otel.GetTextMapPropagator().Inject(ctx, natsHeaderCarrier(msg.Header))
+	return pub.PublishMsg(msg)
+}
+
 // MsgInstruments holds the OTel metric instruments shared by every JetStream consumer
 // loop: a processed counter and a processing-duration histogram, both labeled by
 // service / stream / consumer / outcome. Construct one per service (after otel.Init) and
 // pass it into each loop. The instruments degrade to no-op when no OTLP endpoint is
 // configured (the global MeterProvider is then a no-op), so the dev path needs no special
-// handling. A nil *MsgInstruments is also safe — Observe just runs the work without
-// recording, which keeps direct-constructed consumers in tests instrument-free.
+// handling. A nil *MsgInstruments is also safe — Observe just runs the work without a
+// span or metrics, which keeps direct-constructed consumers in tests instrument-free.
 type MsgInstruments struct {
 	service   string
 	processed metric.Int64Counter
@@ -57,29 +96,47 @@ func NewMsgInstruments(service string) (*MsgInstruments, error) {
 	return &MsgInstruments{service: service, processed: processed, duration: duration}, nil
 }
 
-// Observe runs fn (the per-message work), measures its wall-clock duration, and records
-// the processed counter and duration histogram with the outcome string fn returns. A nil
-// receiver runs fn without recording. The stream/consumer labels identify which durable
-// consumer produced the message.
+// Observe extracts any W3C trace context from msg's headers, opens a child nats.consume
+// span, runs fn (the per-message work) with the span-scoped context, then records the
+// processed counter and duration histogram with the outcome string fn returns. fn MUST use
+// the context it is passed so downstream publishes and logs join the same trace. A nil
+// receiver runs fn with the original context and records nothing.
 //
-// ctx carries cancellation/baggage for the metric record. Distributed-trace spans are
-// added in a later change; the signature already takes ctx so wrapping does not move.
-func (mi *MsgInstruments) Observe(ctx context.Context, stream, consumer string, fn func() string) {
+// The stream/consumer labels identify which durable consumer produced the message.
+func (mi *MsgInstruments) Observe(ctx context.Context, msg *nats.Msg, stream, consumer string, fn func(context.Context) string) {
 	if mi == nil {
-		fn()
+		fn(ctx)
 		return
 	}
+
+	pctx := otel.GetTextMapPropagator().Extract(ctx, natsHeaderCarrier(msg.Header))
+	sctx, span := tracer.Start(pctx, "nats.consume",
+		trace.WithSpanKind(trace.SpanKindConsumer),
+		trace.WithAttributes(
+			attribute.String("messaging.system", "nats"),
+			attribute.String("messaging.destination.name", stream),
+			attribute.String("messaging.consumer.name", consumer),
+		),
+	)
+	defer span.End()
+
 	start := time.Now()
-	outcome := fn()
+	outcome := fn(sctx)
 	elapsed := time.Since(start).Seconds()
+
+	span.SetAttributes(attribute.String("messaging.outcome", outcome))
+	if outcome == OutcomeFailure {
+		span.SetStatus(codes.Error, "processing failed")
+	}
+
 	attrs := metric.WithAttributes(
 		attribute.String("service", mi.service),
 		attribute.String("stream", stream),
 		attribute.String("consumer", consumer),
 		attribute.String("outcome", outcome),
 	)
-	mi.processed.Add(ctx, 1, attrs)
-	mi.duration.Record(ctx, elapsed, attrs)
+	mi.processed.Add(sctx, 1, attrs)
+	mi.duration.Record(sctx, elapsed, attrs)
 }
 
 // NewDedupCounter registers ruby_core_idempotency_dedup_total, incremented each time a

--- a/pkg/natsx/instrument_test.go
+++ b/pkg/natsx/instrument_test.go
@@ -6,11 +6,61 @@ import (
 	"context"
 	"testing"
 
+	"github.com/nats-io/nats.go"
 	"go.opentelemetry.io/otel"
 	noopmetric "go.opentelemetry.io/otel/metric/noop"
+	"go.opentelemetry.io/otel/propagation"
 	sdkmetric "go.opentelemetry.io/otel/sdk/metric"
 	"go.opentelemetry.io/otel/sdk/metric/metricdata"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/trace"
+	nooptrace "go.opentelemetry.io/otel/trace/noop"
 )
+
+// pubFunc adapts a function to the MsgPublisher interface.
+type pubFunc func(*nats.Msg) error
+
+func (f pubFunc) PublishMsg(m *nats.Msg) error { return f(m) }
+
+// PublishWithContext injects the active span's W3C context into the message headers, and a
+// downstream Observe extracts it so the consumer span shares the producer's trace — the
+// mechanism that connects a gateway→engine→notifier trace.
+func TestPublishWithContext_PropagatesTraceToObserve(t *testing.T) {
+	otel.SetTextMapPropagator(propagation.TraceContext{})
+	tp := sdktrace.NewTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() { otel.SetTracerProvider(nooptrace.NewTracerProvider()) })
+
+	// Producer: start a span and publish, capturing the message that would hit NATS.
+	ctx, span := tracer.Start(context.Background(), "producer")
+	parentTraceID := span.SpanContext().TraceID()
+
+	var captured *nats.Msg
+	pub := pubFunc(func(m *nats.Msg) error { captured = m; return nil })
+	if err := PublishWithContext(ctx, pub, "ruby_engine.commands.notify.x", []byte("{}")); err != nil {
+		t.Fatalf("PublishWithContext: %v", err)
+	}
+	span.End()
+
+	if captured.Header.Get("traceparent") == "" {
+		t.Fatal("publish did not inject a traceparent header")
+	}
+
+	// Consumer: Observe extracts the parent and opens a child span in the same trace.
+	mi, err := NewMsgInstruments("notifier")
+	if err != nil {
+		t.Fatalf("NewMsgInstruments: %v", err)
+	}
+	var childTraceID trace.TraceID
+	mi.Observe(context.Background(), captured, "COMMANDS", "notifier_processor", func(sctx context.Context) string {
+		childTraceID = trace.SpanContextFromContext(sctx).TraceID()
+		return OutcomeSuccess
+	})
+
+	if childTraceID != parentTraceID {
+		t.Errorf("consumer span trace ID = %s, want %s (not connected)", childTraceID, parentTraceID)
+	}
+}
 
 // sumValue returns the total of all int64 data points for the named counter in rm, and
 // whether the metric was found at all.
@@ -61,7 +111,7 @@ func TestObserve_RecordsProcessedAndDuration(t *testing.T) {
 
 	runs := 0
 	for i := 0; i < 3; i++ {
-		mi.Observe(context.Background(), "HA_EVENTS", "engine_processor", func() string {
+		mi.Observe(context.Background(), &nats.Msg{Subject: "ha.events.x"}, "HA_EVENTS", "engine_processor", func(context.Context) string {
 			runs++
 			return OutcomeSuccess
 		})
@@ -88,7 +138,7 @@ func TestObserve_RecordsProcessedAndDuration(t *testing.T) {
 func TestObserve_NilReceiverRunsWork(t *testing.T) {
 	var mi *MsgInstruments
 	ran := false
-	mi.Observe(context.Background(), "S", "c", func() string {
+	mi.Observe(context.Background(), &nats.Msg{}, "S", "c", func(context.Context) string {
 		ran = true
 		return OutcomeSuccess
 	})

--- a/services/audit-sink/main.go
+++ b/services/audit-sink/main.go
@@ -198,7 +198,7 @@ func runFetchLoop(ctx context.Context, sub *nats.Subscription, writer *NDJSONWri
 			}
 			go func(m *nats.Msg) {
 				defer func() { <-sem }()
-				instr.Observe(ctx, cfg.Stream, cfg.Durable, func() string {
+				instr.Observe(ctx, m, cfg.Stream, cfg.Durable, func(_ context.Context) string {
 					return handleAuditMsg(m, writer, logger)
 				})
 			}(msg)

--- a/services/engine/consumer.go
+++ b/services/engine/consumer.go
@@ -42,7 +42,7 @@ func (NoopRecorder) Record(_, _, _, _, _ string) {}
 type Consumer struct {
 	sub       *nats.Subscription
 	idStore   idempotency.Store
-	process   func(subject string, data []byte) error
+	process   func(ctx context.Context, subject string, data []byte) error
 	audit     Recorder
 	log       *slog.Logger
 	workerN   int
@@ -73,7 +73,7 @@ func (c *Consumer) logger() *slog.Logger {
 func NewConsumer(
 	sub *nats.Subscription,
 	idStore idempotency.Store,
-	process func(subject string, data []byte) error,
+	process func(ctx context.Context, subject string, data []byte) error,
 	workerN, batchSize int,
 	backOff []time.Duration,
 	log *slog.Logger,
@@ -147,8 +147,8 @@ func (c *Consumer) Run(ctx context.Context) error {
 			}
 			go func(m *nats.Msg) {
 				defer func() { <-sem }()
-				c.instruments.Observe(ctx, c.stream, c.consumerName, func() string {
-					return c.handle(m)
+				c.instruments.Observe(ctx, m, c.stream, c.consumerName, func(sctx context.Context) string {
+					return c.handle(sctx, m)
 				})
 			}(msg)
 		}
@@ -158,7 +158,7 @@ func (c *Consumer) Run(ctx context.Context) error {
 // handle processes a single message: checks idempotency, calls process, then acks/naks.
 // Structured log entries include correlationid and causationid from the CloudEvent payload.
 // It returns the outcome label (natsx.Outcome*) for metric recording by the caller.
-func (c *Consumer) handle(msg *nats.Msg) string {
+func (c *Consumer) handle(ctx context.Context, msg *nats.Msg) string {
 	meta, err := msg.Metadata()
 	if err != nil {
 		c.logger().Error("engine: metadata error", slog.String("error", err.Error()))
@@ -169,7 +169,7 @@ func (c *Consumer) handle(msg *nats.Msg) string {
 	eventID := extractEventID(msg.Header, msg.Data, meta)
 	correlationID, causationID := extractCorrelationFields(msg.Data)
 
-	result, err := c.decide(msg.Subject, eventID, msg.Data)
+	result, err := c.decide(ctx, msg.Subject, eventID, msg.Data)
 	if err != nil {
 		c.logger().Error("engine: decide error",
 			slog.String("eventid", eventID),
@@ -221,7 +221,7 @@ func (c *Consumer) handle(msg *nats.Msg) string {
 
 // decide evaluates idempotency and calls the process function.
 // It is a pure decision function, separated from NATS types to enable unit testing.
-func (c *Consumer) decide(subject, eventID string, data []byte) (handleResult, error) {
+func (c *Consumer) decide(ctx context.Context, subject, eventID string, data []byte) (handleResult, error) {
 	seen, err := c.idStore.Seen(eventID)
 	if err != nil {
 		return resultNak, fmt.Errorf("idempotency check: %w", err)
@@ -232,7 +232,7 @@ func (c *Consumer) decide(subject, eventID string, data []byte) (handleResult, e
 		)
 		return resultSkip, nil
 	}
-	if err := c.process(subject, data); err != nil {
+	if err := c.process(ctx, subject, data); err != nil {
 		c.logger().Warn("engine: process error, will nak",
 			slog.String("eventid", eventID),
 			slog.String("error", err.Error()),

--- a/services/engine/consumer_test.go
+++ b/services/engine/consumer_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"testing"
@@ -47,10 +48,10 @@ func (m *mockStore) Close() error { return nil }
 func TestDecide_Success(t *testing.T) {
 	c := &Consumer{
 		idStore: newMockStore(),
-		process: func(_ string, _ []byte) error { return nil },
+		process: func(_ context.Context, _ string, _ []byte) error { return nil },
 	}
 
-	result, err := c.decide("ha.events.person.wife", "evt-001", []byte("data"))
+	result, err := c.decide(context.Background(), "ha.events.person.wife", "evt-001", []byte("data"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -62,10 +63,10 @@ func TestDecide_Success(t *testing.T) {
 func TestDecide_ProcessFailure(t *testing.T) {
 	c := &Consumer{
 		idStore: newMockStore(),
-		process: func(_ string, _ []byte) error { return errors.New("transient error") },
+		process: func(_ context.Context, _ string, _ []byte) error { return errors.New("transient error") },
 	}
 
-	result, err := c.decide("ha.events.person.wife", "evt-002", []byte("data"))
+	result, err := c.decide(context.Background(), "ha.events.person.wife", "evt-002", []byte("data"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -81,13 +82,13 @@ func TestDecide_Duplicate(t *testing.T) {
 	processed := false
 	c := &Consumer{
 		idStore: store,
-		process: func(_ string, _ []byte) error {
+		process: func(_ context.Context, _ string, _ []byte) error {
 			processed = true
 			return nil
 		},
 	}
 
-	result, err := c.decide("ha.events.person.wife", "evt-003", []byte("data"))
+	result, err := c.decide(context.Background(), "ha.events.person.wife", "evt-003", []byte("data"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
@@ -104,10 +105,10 @@ func TestDecide_IdempotencyCheckError(t *testing.T) {
 	store.seeErr = errors.New("kv unreachable")
 	c := &Consumer{
 		idStore: store,
-		process: func(_ string, _ []byte) error { return nil },
+		process: func(_ context.Context, _ string, _ []byte) error { return nil },
 	}
 
-	result, err := c.decide("ha.events.person.wife", "evt-004", []byte("data"))
+	result, err := c.decide(context.Background(), "ha.events.person.wife", "evt-004", []byte("data"))
 	if err == nil {
 		t.Fatal("expected error from idempotency failure, got nil")
 	}
@@ -177,14 +178,14 @@ func TestExtractEventID_FallbackOnEmptyCloudEventID(t *testing.T) {
 // ---------------------------------------------------------------------------
 
 func TestNewConsumer_FetchBatchExceedsWorkerN(t *testing.T) {
-	_, err := NewConsumer(nil, newMockStore(), func(_ string, _ []byte) error { return nil }, 10, 11, nil, nil, nil)
+	_, err := NewConsumer(nil, newMockStore(), func(_ context.Context, _ string, _ []byte) error { return nil }, 10, 11, nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error when batchSize > workerN, got nil")
 	}
 }
 
 func TestNewConsumer_ValidConfig(t *testing.T) {
-	c, err := NewConsumer(nil, newMockStore(), func(_ string, _ []byte) error { return nil }, 20, 20, nil, nil, nil)
+	c, err := NewConsumer(nil, newMockStore(), func(_ context.Context, _ string, _ []byte) error { return nil }, 20, 20, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}

--- a/services/engine/host.go
+++ b/services/engine/host.go
@@ -1,17 +1,25 @@
 package main
 
 import (
+	"context"
 	"fmt"
 	"log/slog"
 	"strings"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/nats-io/nats.go"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/primaryrutabaga/ruby-core/pkg/boot"
 	"github.com/primaryrutabaga/ruby-core/services/engine/config"
 	"github.com/primaryrutabaga/ruby-core/services/engine/processor"
 )
+
+// tracer opens engine spans; delegates to the global provider installed by otel.Init.
+var tracer = otel.Tracer("github.com/primaryrutabaga/ruby-core/services/engine")
 
 // ProcessorHost manages the lifecycle of all registered Logical Processors
 // (ADR-0007) and routes incoming events to the processors that subscribed
@@ -76,7 +84,11 @@ func (h *ProcessorHost) Initialize(ruleCfg *config.CompiledConfig, nc *nats.Conn
 // Errors from individual processors are logged but do not prevent other processors
 // from running; the error from the first failing processor is returned to the caller
 // so the consumer can NAK the message.
-func (h *ProcessorHost) Process(subject string, data []byte) error {
+func (h *ProcessorHost) Process(ctx context.Context, subject string, data []byte) error {
+	ctx, span := tracer.Start(ctx, "engine.process",
+		trace.WithAttributes(attribute.String("subject", subject)))
+	defer span.End()
+
 	var firstErr error
 	matched := false
 
@@ -84,7 +96,7 @@ func (h *ProcessorHost) Process(subject string, data []byte) error {
 		for _, pattern := range p.Subscriptions() {
 			if matchesSubject(pattern, subject) {
 				matched = true
-				if err := p.ProcessEvent(subject, data); err != nil {
+				if err := p.ProcessEvent(ctx, subject, data); err != nil {
 					h.log.Warn("host: processor error",
 						slog.String("subject", subject),
 						slog.String("error", err.Error()),
@@ -100,6 +112,9 @@ func (h *ProcessorHost) Process(subject string, data []byte) error {
 
 	if !matched {
 		h.log.Debug("host: no processor matched subject", slog.String("subject", subject))
+	}
+	if firstErr != nil {
+		span.SetStatus(codes.Error, firstErr.Error())
 	}
 	return firstErr
 }

--- a/services/engine/host_test.go
+++ b/services/engine/host_test.go
@@ -3,6 +3,7 @@
 package main
 
 import (
+	"context"
 	"errors"
 	"log/slog"
 	"testing"
@@ -21,7 +22,7 @@ type mockProcessor struct {
 
 func (m *mockProcessor) Initialize(_ processor.Config) error { return m.initErr }
 func (m *mockProcessor) Subscriptions() []string             { return m.subs }
-func (m *mockProcessor) ProcessEvent(subject string, _ []byte) error {
+func (m *mockProcessor) ProcessEvent(_ context.Context, subject string, _ []byte) error {
 	m.events = append(m.events, subject)
 	return m.processErr
 }
@@ -47,7 +48,7 @@ func TestHost_RoutesExactMatch(t *testing.T) {
 	p := &mockProcessor{subs: []string{"ha.events.person.wife"}}
 	h := newHost(t, p)
 
-	if err := h.Process("ha.events.person.wife", []byte("{}")); err != nil {
+	if err := h.Process(context.Background(), "ha.events.person.wife", []byte("{}")); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(p.events) != 1 || p.events[0] != "ha.events.person.wife" {
@@ -59,7 +60,7 @@ func TestHost_RoutesWildcard(t *testing.T) {
 	p := &mockProcessor{subs: []string{"ha.events.device_tracker.>"}}
 	h := newHost(t, p)
 
-	if err := h.Process("ha.events.device_tracker.tracker_one", []byte("{}")); err != nil {
+	if err := h.Process(context.Background(), "ha.events.device_tracker.tracker_one", []byte("{}")); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(p.events) != 1 {
@@ -71,7 +72,7 @@ func TestHost_NoMatchIsNotAnError(t *testing.T) {
 	p := &mockProcessor{subs: []string{"ha.events.light.>"}}
 	h := newHost(t, p)
 
-	if err := h.Process("ha.events.person.wife", []byte("{}")); err != nil {
+	if err := h.Process(context.Background(), "ha.events.person.wife", []byte("{}")); err != nil {
 		t.Fatalf("no-match should not return error, got: %v", err)
 	}
 	if len(p.events) != 0 {
@@ -84,7 +85,7 @@ func TestHost_ProcessorNotCalledTwicePerEvent(t *testing.T) {
 	p := &mockProcessor{subs: []string{"ha.events.person.>", "ha.events.person.wife"}}
 	h := newHost(t, p)
 
-	if err := h.Process("ha.events.person.wife", []byte("{}")); err != nil {
+	if err := h.Process(context.Background(), "ha.events.person.wife", []byte("{}")); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(p.events) != 1 {
@@ -97,7 +98,7 @@ func TestHost_MultipleProcessors(t *testing.T) {
 	p2 := &mockProcessor{subs: []string{"ha.events.device_tracker.>"}}
 	h := newHost(t, p1, p2)
 
-	if err := h.Process("ha.events.person.wife", []byte("{}")); err != nil {
+	if err := h.Process(context.Background(), "ha.events.person.wife", []byte("{}")); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(p1.events) != 1 {
@@ -116,7 +117,7 @@ func TestHost_ReturnsFirstProcessorError(t *testing.T) {
 	}
 	h := newHost(t, p)
 
-	err := h.Process("ha.events.person.wife", []byte("{}"))
+	err := h.Process(context.Background(), "ha.events.person.wife", []byte("{}"))
 	if !errors.Is(err, wantErr) {
 		t.Errorf("error = %v, want %v", err, wantErr)
 	}

--- a/services/engine/main.go
+++ b/services/engine/main.go
@@ -397,6 +397,6 @@ var forceFail = os.Getenv("ENGINE_FORCE_FAIL") == "true"
 
 // forceFailProcess wraps a process func so every call returns an error.
 // Used only when ENGINE_FORCE_FAIL=true.
-func forceFailProcess(_ string, _ []byte) error {
+func forceFailProcess(_ context.Context, _ string, _ []byte) error {
 	return errors.New("ENGINE_FORCE_FAIL: forced failure for DLQ verification")
 }

--- a/services/engine/processor/processor.go
+++ b/services/engine/processor/processor.go
@@ -8,6 +8,8 @@
 package processor
 
 import (
+	"context"
+
 	"github.com/jackc/pgx/v5/pgxpool"
 	"github.com/nats-io/nats.go"
 
@@ -48,7 +50,7 @@ type Config struct {
 type Processor interface {
 	Initialize(cfg Config) error
 	Subscriptions() []string
-	ProcessEvent(subject string, data []byte) error
+	ProcessEvent(ctx context.Context, subject string, data []byte) error
 	Shutdown()
 }
 

--- a/services/engine/processors/ada/processor.go
+++ b/services/engine/processors/ada/processor.go
@@ -194,7 +194,7 @@ func (p *Processor) Shutdown() {
 
 // ProcessEvent routes an incoming event by CloudEvent type to the appropriate handler.
 // DB errors are returned to trigger NAK+retry; HA push failures are non-fatal.
-func (p *Processor) ProcessEvent(subject string, data []byte) error {
+func (p *Processor) ProcessEvent(_ context.Context, subject string, data []byte) error {
 	var evt schemas.CloudEvent
 	if err := json.Unmarshal(data, &evt); err != nil {
 		return fmt.Errorf("ada: unmarshal CloudEvent: %w", err)

--- a/services/engine/processors/calendar/processor.go
+++ b/services/engine/processors/calendar/processor.go
@@ -173,7 +173,7 @@ func (p *Processor) Shutdown() {
 }
 
 // ProcessEvent routes a calendar write event to write-through.
-func (p *Processor) ProcessEvent(subject string, data []byte) error {
+func (p *Processor) ProcessEvent(ctx context.Context, subject string, data []byte) error {
 	if !p.syncEnabled {
 		// Non-prod: do not touch the shared calendar. Ack and ignore.
 		return nil
@@ -185,7 +185,6 @@ func (p *Processor) ProcessEvent(subject string, data []byte) error {
 		return nil // ack malformed
 	}
 
-	ctx := context.Background()
 	switch subject {
 	case schemas.HomeEventCalendarUpsert:
 		return p.handleUpsert(ctx, &evt)

--- a/services/engine/processors/presence_notify/processor.go
+++ b/services/engine/processors/presence_notify/processor.go
@@ -13,6 +13,7 @@
 package presence_notify
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
@@ -36,9 +37,11 @@ type kvStore interface {
 }
 
 // natsPub is a narrow interface over *nats.Conn for publishing, allowing
-// test injection without a live NATS connection.
+// test injection without a live NATS connection. PublishMsg carries headers so the
+// notify command can propagate W3C trace context to the notifier (PLAN-0009).
 type natsPub interface {
 	Publish(subject string, data []byte) error
+	PublishMsg(*nats.Msg) error
 }
 
 // kvAdapter adapts nats.KeyValue to the kvStore interface.
@@ -135,7 +138,7 @@ func (p *Processor) Subscriptions() []string {
 // ProcessEvent receives a CloudEvent from the HA gateway, determines whether
 // a presence transition occurred for a watched entity, and publishes a
 // notification command if so.
-func (p *Processor) ProcessEvent(subject string, data []byte) error {
+func (p *Processor) ProcessEvent(ctx context.Context, subject string, data []byte) error {
 	var evt schemas.CloudEvent
 	if err := json.Unmarshal(data, &evt); err != nil {
 		p.log.Warn("presence_notify: unmarshal event",
@@ -179,7 +182,7 @@ func (p *Processor) ProcessEvent(subject string, data []byte) error {
 		return nil // transition to an unmonitored state (e.g. "unavailable")
 	}
 
-	return p.publishNotify(evt, params)
+	return p.publishNotify(ctx, evt, params)
 }
 
 // Shutdown is a no-op; the KV bucket and NATS connection are owned by the engine.
@@ -220,7 +223,7 @@ func (p *Processor) saveState(entityID, state string) error {
 	return p.kv.Put(entityID, data)
 }
 
-func (p *Processor) publishNotify(cause schemas.CloudEvent, params notifyParams) error {
+func (p *Processor) publishNotify(ctx context.Context, cause schemas.CloudEvent, params notifyParams) error {
 	corrID := cause.CorrelationID
 	if corrID == "" {
 		corrID = cause.ID
@@ -248,7 +251,7 @@ func (p *Processor) publishNotify(cause schemas.CloudEvent, params notifyParams)
 	}
 
 	subj := "ruby_engine.commands.notify." + evtID
-	if err := p.nc.Publish(subj, data); err != nil {
+	if err := natsx.PublishWithContext(ctx, p.nc, subj, data); err != nil {
 		return fmt.Errorf("presence_notify: publish notify command: %w", err)
 	}
 

--- a/services/engine/processors/presence_notify/processor_test.go
+++ b/services/engine/processors/presence_notify/processor_test.go
@@ -3,11 +3,14 @@
 package presence_notify_test
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"strings"
 	"testing"
 	"time"
+
+	"github.com/nats-io/nats.go"
 
 	"github.com/primaryrutabaga/ruby-core/pkg/schemas"
 	"github.com/primaryrutabaga/ruby-core/services/engine/config"
@@ -53,6 +56,13 @@ type stubNC struct {
 
 func (s *stubNC) Publish(subj string, data []byte) error {
 	s.msgs = append(s.msgs, published{subj, data})
+	return nil
+}
+
+// PublishMsg records the message; presence_notify now publishes via
+// natsx.PublishWithContext (which calls PublishMsg) to carry trace headers.
+func (s *stubNC) PublishMsg(m *nats.Msg) error {
+	s.msgs = append(s.msgs, published{m.Subject, m.Data})
 	return nil
 }
 
@@ -142,7 +152,7 @@ func TestArrival_PublishesNotification(t *testing.T) {
 	nc := &stubNC{}
 	p := newTestProcessor(t, kv, nc, minimalConfig())
 
-	if err := p.ProcessEvent("ha.events.person.wife", stateEvent("person.wife", "home")); err != nil {
+	if err := p.ProcessEvent(context.Background(), "ha.events.person.wife", stateEvent("person.wife", "home")); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -173,7 +183,7 @@ func TestDeparture_PublishesNotification(t *testing.T) {
 
 	p := newTestProcessor(t, kv, nc, minimalConfig())
 
-	if err := p.ProcessEvent("ha.events.person.wife", stateEvent("person.wife", "not_home")); err != nil {
+	if err := p.ProcessEvent(context.Background(), "ha.events.person.wife", stateEvent("person.wife", "not_home")); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
@@ -202,7 +212,7 @@ func TestSameState_NoNotification(t *testing.T) {
 	p := newTestProcessor(t, kv, nc, minimalConfig())
 
 	// Receive another "home" event — no transition, no notification.
-	if err := p.ProcessEvent("ha.events.person.wife", stateEvent("person.wife", "home")); err != nil {
+	if err := p.ProcessEvent(context.Background(), "ha.events.person.wife", stateEvent("person.wife", "home")); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(nc.msgs) != 0 {
@@ -216,7 +226,7 @@ func TestUnwatchedEntity_NoNotification(t *testing.T) {
 	p := newTestProcessor(t, kv, nc, minimalConfig())
 
 	// "person.stranger" is not in any rule.
-	if err := p.ProcessEvent("ha.events.person.stranger", stateEvent("person.stranger", "home")); err != nil {
+	if err := p.ProcessEvent(context.Background(), "ha.events.person.stranger", stateEvent("person.stranger", "home")); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(nc.msgs) != 0 {
@@ -230,7 +240,7 @@ func TestMalformedEvent_AckedNotErrored(t *testing.T) {
 	p := newTestProcessor(t, kv, nc, minimalConfig())
 
 	// A non-JSON payload should not return an error (ack and move on).
-	if err := p.ProcessEvent("ha.events.person.wife", []byte("not-json")); err != nil {
+	if err := p.ProcessEvent(context.Background(), "ha.events.person.wife", []byte("not-json")); err != nil {
 		t.Errorf("malformed payload should not return error, got: %v", err)
 	}
 }
@@ -253,7 +263,7 @@ func TestNoStateField_NoNotification(t *testing.T) {
 	}
 	data, _ := json.Marshal(evt)
 
-	if err := p.ProcessEvent("ha.events.person.wife", data); err != nil {
+	if err := p.ProcessEvent(context.Background(), "ha.events.person.wife", data); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(nc.msgs) != 0 {
@@ -278,7 +288,7 @@ func TestCorrelationID_PropagatedToCommand(t *testing.T) {
 	}
 	data, _ := json.Marshal(evt)
 
-	if err := p.ProcessEvent("ha.events.person.wife", data); err != nil {
+	if err := p.ProcessEvent(context.Background(), "ha.events.person.wife", data); err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
 	if len(nc.msgs) == 0 {

--- a/services/gateway/ada/handler.go
+++ b/services/gateway/ada/handler.go
@@ -39,7 +39,7 @@ func (h *Handler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := Publish(h.nc, raw, h.log); err != nil {
+	if err := Publish(r.Context(), h.nc, raw, h.log); err != nil {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}

--- a/services/gateway/ada/publish.go
+++ b/services/gateway/ada/publish.go
@@ -1,6 +1,7 @@
 package ada
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/json"
 	"fmt"
@@ -9,6 +10,7 @@ import (
 
 	goNats "github.com/nats-io/nats.go"
 
+	"github.com/primaryrutabaga/ruby-core/pkg/natsx"
 	"github.com/primaryrutabaga/ruby-core/pkg/schemas"
 )
 
@@ -68,7 +70,7 @@ var eventRoutes = map[string]string{
 // Publish wraps payload in a CloudEvent and publishes to the appropriate
 // ha.events.ada.* NATS subject. Used by both the HTTP handler and the
 // gateway WebSocket ada_event handler.
-func Publish(nc *goNats.Conn, payload map[string]any, log *slog.Logger) error {
+func Publish(ctx context.Context, nc *goNats.Conn, payload map[string]any, log *slog.Logger) error {
 	eventType, _ := payload["event"].(string)
 	subject, ok := eventRoutes[eventType]
 	if !ok {
@@ -94,7 +96,7 @@ func Publish(nc *goNats.Conn, payload map[string]any, log *slog.Logger) error {
 		return fmt.Errorf("ada: marshal CloudEvent: %w", err)
 	}
 
-	if err := nc.Publish(subject, b); err != nil {
+	if err := natsx.PublishWithContext(ctx, nc, subject, b); err != nil {
 		return fmt.Errorf("ada: publish %s: %w", subject, err)
 	}
 
@@ -111,7 +113,7 @@ func Publish(nc *goNats.Conn, payload map[string]any, log *slog.Logger) error {
 // after querying HA — not routed through eventRoutes.
 // availableServices is the full list of mobile_app_* notify service names
 // discovered from HA, forwarded so the engine can populate the device picker.
-func PublishUsersSynced(nc *goNats.Conn, users []schemas.AdaHAUser, availableServices []string, log *slog.Logger) error {
+func PublishUsersSynced(ctx context.Context, nc *goNats.Conn, users []schemas.AdaHAUser, availableServices []string, log *slog.Logger) error {
 	subject := schemas.AdaEventUsersSynced
 	id := newID()
 	evt := schemas.CloudEvent{
@@ -132,7 +134,7 @@ func PublishUsersSynced(nc *goNats.Conn, users []schemas.AdaHAUser, availableSer
 	if err != nil {
 		return fmt.Errorf("ada: marshal users_synced: %w", err)
 	}
-	if err := nc.Publish(subject, b); err != nil {
+	if err := natsx.PublishWithContext(ctx, nc, subject, b); err != nil {
 		return fmt.Errorf("ada: publish users_synced: %w", err)
 	}
 	log.Info("ada: users_synced published", slog.Int("count", len(users)))

--- a/services/gateway/ha/client.go
+++ b/services/gateway/ha/client.go
@@ -13,13 +13,18 @@ import (
 	"github.com/gorilla/websocket"
 	goNats "github.com/nats-io/nats.go"
 	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/primaryrutabaga/ruby-core/pkg/schemas"
 	"github.com/primaryrutabaga/ruby-core/services/gateway/ada"
 	gatewayNats "github.com/primaryrutabaga/ruby-core/services/gateway/nats"
 	"github.com/primaryrutabaga/ruby-core/services/gateway/rubyhome"
 )
+
+// tracer opens the ha.ingest span; delegates to the global provider installed by otel.Init.
+var tracer = otel.Tracer("github.com/primaryrutabaga/ruby-core/services/gateway")
 
 // haWSMessage is a generic HA WebSocket protocol message envelope.
 type haWSMessage struct {
@@ -279,15 +284,22 @@ func (c *Client) runOnce(ctx context.Context) error {
 	}
 }
 
-// handleEvent routes an incoming HA WebSocket event by event_type.
+// handleEvent routes an incoming HA WebSocket event by event_type. It opens the root
+// ha.ingest span for the event; the span context flows to the NATS publish so the engine
+// (and notifier) continue the same distributed trace (PLAN-0009).
 func (c *Client) handleEvent(ctx context.Context, conn *websocket.Conn, nextID *int, ev *haEvent) error {
+	ctx, span := tracer.Start(ctx, "ha.ingest",
+		trace.WithSpanKind(trace.SpanKindProducer),
+		trace.WithAttributes(attribute.String("ha.event_type", ev.EventType)))
+	defer span.End()
+
 	switch ev.EventType {
 	case "ada_event":
 		return c.handleAdaEvent(ctx, conn, nextID, ev)
 	case "ruby_home_event":
-		return c.handleRubyHomeEvent(ev)
+		return c.handleRubyHomeEvent(ctx, ev)
 	default:
-		return c.handleStateChanged(ev)
+		return c.handleStateChanged(ctx, ev)
 	}
 }
 
@@ -295,7 +307,7 @@ func (c *Client) handleEvent(ctx context.Context, conn *websocket.Conn, nextID *
 // domain-neutral write path (ROADMAP-0012). Like ada_event, the HA script wraps the
 // caller's payload under a "payload" key; the NATS subject is derived from the
 // payload "event" string.
-func (c *Client) handleRubyHomeEvent(ev *haEvent) error {
+func (c *Client) handleRubyHomeEvent(ctx context.Context, ev *haEvent) error {
 	var wrapper struct {
 		Payload map[string]any `json:"payload"`
 	}
@@ -305,11 +317,11 @@ func (c *Client) handleRubyHomeEvent(ev *haEvent) error {
 	if wrapper.Payload == nil {
 		return fmt.Errorf("ha: ruby_home_event missing payload field")
 	}
-	return rubyhome.Publish(c.nc, wrapper.Payload, c.log)
+	return rubyhome.Publish(ctx, c.nc, wrapper.Payload, c.log)
 }
 
 // handleStateChanged processes a state_changed event from HA.
-func (c *Client) handleStateChanged(ev *haEvent) error {
+func (c *Client) handleStateChanged(ctx context.Context, ev *haEvent) error {
 	var data haEventData
 	if err := json.Unmarshal(ev.Data, &data); err != nil {
 		return fmt.Errorf("ha: unmarshal state_changed data: %w", err)
@@ -329,7 +341,7 @@ func (c *Client) handleStateChanged(ev *haEvent) error {
 	}
 
 	filtered := c.norm.Apply(domain, ns.Attributes)
-	if err := c.publisher.PublishHAEvent(ns.EntityID, ns.State, filtered, ns.LastChanged); err != nil {
+	if err := c.publisher.PublishHAEvent(ctx, ns.EntityID, ns.State, filtered, ns.LastChanged); err != nil {
 		return fmt.Errorf("publish event for %s: %w", ns.EntityID, err)
 	}
 
@@ -369,7 +381,7 @@ func (c *Client) handleAdaEvent(ctx context.Context, conn *websocket.Conn, nextI
 		return c.syncUsers(ctx, conn, id)
 	}
 
-	return ada.Publish(c.nc, wrapper.Payload, c.log)
+	return ada.Publish(ctx, c.nc, wrapper.Payload, c.log)
 }
 
 // syncUsers queries HA for all active users via the config/auth/list WebSocket
@@ -433,7 +445,7 @@ func (c *Client) syncUsers(ctx context.Context, conn *websocket.Conn, id int) er
 		})
 	}
 
-	return ada.PublishUsersSynced(c.nc, users, availableServices, c.log)
+	return ada.PublishUsersSynced(ctx, c.nc, users, availableServices, c.log)
 }
 
 // fetchMobileAppServices queries GET /api/services and returns all mobile_app_*

--- a/services/gateway/ha/reconciler.go
+++ b/services/gateway/ha/reconciler.go
@@ -67,7 +67,7 @@ func (r *Reconciler) Run(ctx context.Context, criticalEntities []string) {
 		if ctx.Err() != nil {
 			return
 		}
-		if err := r.reconcileOne(entityID); err != nil {
+		if err := r.reconcileOne(ctx, entityID); err != nil {
 			r.log.Warn("reconciler: entity reconcile failed",
 				slog.String("entity_id", entityID),
 				slog.String("error", err.Error()),
@@ -78,7 +78,7 @@ func (r *Reconciler) Run(ctx context.Context, criticalEntities []string) {
 }
 
 // reconcileOne reconciles a single entity.
-func (r *Reconciler) reconcileOne(entityID string) error {
+func (r *Reconciler) reconcileOne(ctx context.Context, entityID string) error {
 	haState, err := r.fetchHAState(entityID)
 	if err != nil {
 		return fmt.Errorf("fetch HA state: %w", err)
@@ -112,7 +112,7 @@ func (r *Reconciler) reconcileOne(entityID string) error {
 		return err
 	}
 	filtered := r.norm.Apply(domain, haState.Attributes)
-	return r.publisher.PublishHAEvent(entityID, haState.State, filtered, haState.LastChanged)
+	return r.publisher.PublishHAEvent(ctx, entityID, haState.State, filtered, haState.LastChanged)
 }
 
 // fetchHAState calls the HA REST API to retrieve the current state of an entity.

--- a/services/gateway/nats/publisher.go
+++ b/services/gateway/nats/publisher.go
@@ -13,6 +13,7 @@ import (
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/metric"
 
+	"github.com/primaryrutabaga/ruby-core/pkg/natsx"
 	"github.com/primaryrutabaga/ruby-core/pkg/schemas"
 )
 
@@ -40,7 +41,7 @@ func New(nc *goNats.Conn) *Publisher {
 //   - state:    the new entity state string, e.g. "home"
 //   - attrs:    the filtered attribute map (post lean projection)
 //   - lastChanged: the HA last_changed timestamp (RFC3339 UTC)
-func (p *Publisher) PublishHAEvent(entityID, state string, attrs map[string]any, lastChanged string) error {
+func (p *Publisher) PublishHAEvent(ctx context.Context, entityID, state string, attrs map[string]any, lastChanged string) error {
 	domain, entityName, err := splitEntityID(entityID)
 	if err != nil {
 		return err
@@ -74,11 +75,11 @@ func (p *Publisher) PublishHAEvent(entityID, state string, attrs map[string]any,
 	}
 
 	subject := fmt.Sprintf("ha.events.%s.%s", domain, entityName)
-	if err := p.nc.Publish(subject, payload); err != nil {
+	if err := natsx.PublishWithContext(ctx, p.nc, subject, payload); err != nil {
 		return err
 	}
 	if p.eventsReceived != nil {
-		p.eventsReceived.Add(context.Background(), 1, metric.WithAttributes(attribute.String("entity_domain", domain)))
+		p.eventsReceived.Add(ctx, 1, metric.WithAttributes(attribute.String("entity_domain", domain)))
 	}
 	return nil
 }

--- a/services/gateway/rubyhome/publish.go
+++ b/services/gateway/rubyhome/publish.go
@@ -6,6 +6,7 @@
 package rubyhome
 
 import (
+	"context"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/hex"
@@ -16,6 +17,7 @@ import (
 
 	goNats "github.com/nats-io/nats.go"
 
+	"github.com/primaryrutabaga/ruby-core/pkg/natsx"
 	"github.com/primaryrutabaga/ruby-core/pkg/schemas"
 )
 
@@ -32,7 +34,7 @@ var eventRoutes = map[string]string{
 // Publish wraps payload in a CloudEvent and publishes it to the ha.events.* subject
 // derived from the payload "event" string. An unknown event is logged and returns
 // an error without publishing.
-func Publish(nc *goNats.Conn, payload map[string]any, log *slog.Logger) error {
+func Publish(ctx context.Context, nc *goNats.Conn, payload map[string]any, log *slog.Logger) error {
 	eventType, _ := payload["event"].(string)
 	subject, ok := eventRoutes[eventType]
 	if !ok {
@@ -60,7 +62,7 @@ func Publish(nc *goNats.Conn, payload map[string]any, log *slog.Logger) error {
 		return fmt.Errorf("ruby_home: marshal CloudEvent: %w", err)
 	}
 
-	if err := nc.Publish(subject, b); err != nil {
+	if err := natsx.PublishWithContext(ctx, nc, subject, b); err != nil {
 		return fmt.Errorf("ruby_home: publish %s: %w", subject, err)
 	}
 

--- a/services/gateway/rubyhome/publish_integration_test.go
+++ b/services/gateway/rubyhome/publish_integration_test.go
@@ -70,7 +70,7 @@ func TestRubyHomeAndAdaLandInHAEvents(t *testing.T) {
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 
 	// New domain-neutral path: a calendar write event.
-	if err := rubyhome.Publish(nc, map[string]any{
+	if err := rubyhome.Publish(context.Background(), nc, map[string]any{
 		"event":           "calendar.event.upsert",
 		"summary":         "Dentist",
 		"idempotency_key": "test-key-1",
@@ -80,7 +80,7 @@ func TestRubyHomeAndAdaLandInHAEvents(t *testing.T) {
 	assertCloudEventStored(t, js, schemas.HomeEventCalendarUpsert)
 
 	// New domain-neutral path: a childcare overlay write event.
-	if err := rubyhome.Publish(nc, map[string]any{
+	if err := rubyhome.Publish(context.Background(), nc, map[string]any{
 		"event":        "ruby_home.childcare.provider.upsert",
 		"display_name": "Maya",
 	}, log); err != nil {
@@ -89,7 +89,7 @@ func TestRubyHomeAndAdaLandInHAEvents(t *testing.T) {
 	assertCloudEventStored(t, js, schemas.HomeEventChildcareProviderUpsert)
 
 	// Regression: the existing ada path still routes onto HA_EVENTS unchanged.
-	if err := ada.Publish(nc, map[string]any{
+	if err := ada.Publish(context.Background(), nc, map[string]any{
 		"event": "ada.diaper.log",
 		"type":  "wet",
 	}, log); err != nil {

--- a/services/gateway/rubyhome/publish_test.go
+++ b/services/gateway/rubyhome/publish_test.go
@@ -3,6 +3,7 @@
 package rubyhome
 
 import (
+	"context"
 	"io"
 	"log/slog"
 	"strings"
@@ -56,7 +57,7 @@ func TestSubjectsValidPerADR0027(t *testing.T) {
 // NATS (nil conn proves no publish is attempted).
 func TestPublishUnknownEvent(t *testing.T) {
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
-	if err := Publish(nil, map[string]any{"event": "calendar.nope"}, log); err == nil {
+	if err := Publish(context.Background(), nil, map[string]any{"event": "calendar.nope"}, log); err == nil {
 		t.Fatal("expected error for unknown event, got nil")
 	}
 }
@@ -64,7 +65,7 @@ func TestPublishUnknownEvent(t *testing.T) {
 // TestPublishMissingEventField verifies a payload with no event field is rejected.
 func TestPublishMissingEventField(t *testing.T) {
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
-	if err := Publish(nil, map[string]any{}, log); err == nil {
+	if err := Publish(context.Background(), nil, map[string]any{}, log); err == nil {
 		t.Fatal("expected error for missing event field, got nil")
 	}
 }

--- a/services/notifier/handler.go
+++ b/services/notifier/handler.go
@@ -114,6 +114,7 @@ func (h *handler) sendNotification(ctx context.Context, subject, title, message,
 		return fmt.Errorf("notifier: marshal request: %w", err)
 	}
 
+	//nolint:gosec // G704: apiURL host is the Vault-configured Home Assistant base; the path is a fixed notify route, not user-controlled.
 	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("notifier: build request: %w", err)

--- a/services/notifier/handler.go
+++ b/services/notifier/handler.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -10,9 +11,17 @@ import (
 	"strings"
 	"time"
 
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
+
 	"github.com/primaryrutabaga/ruby-core/pkg/audit"
 	"github.com/primaryrutabaga/ruby-core/pkg/schemas"
 )
+
+// tracer opens the notify.send span; delegates to the global provider installed by otel.Init.
+var tracer = otel.Tracer("github.com/primaryrutabaga/ruby-core/services/notifier")
 
 // notifyRequest is the HA mobile_app REST notification payload.
 type notifyRequest struct {
@@ -42,7 +51,7 @@ func newHandler(haURL, haToken string, rec *audit.Publisher, log *slog.Logger) *
 
 // process is the consumer process func for the notifier pull consumer.
 // subject is the NATS subject (e.g. "ruby_engine.commands.notify.{evtID}").
-func (h *handler) process(subject string, data []byte) error {
+func (h *handler) process(ctx context.Context, subject string, data []byte) error {
 	var evt schemas.CloudEvent
 	if err := json.Unmarshal(data, &evt); err != nil {
 		h.log.Warn("notifier: unmarshal command",
@@ -77,7 +86,7 @@ func (h *handler) process(subject string, data []byte) error {
 		return nil // ack: nothing useful to retry until HA is configured
 	}
 
-	if err := h.sendNotification(subject, title, message, device, evt); err != nil {
+	if err := h.sendNotification(ctx, subject, title, message, device, evt); err != nil {
 		// Non-nil error will trigger NAK + backoff redelivery in the consumer.
 		return err
 	}
@@ -85,7 +94,17 @@ func (h *handler) process(subject string, data []byte) error {
 }
 
 // sendNotification POSTs to HA's mobile_app notify service.
-func (h *handler) sendNotification(subject, title, message, device string, cause schemas.CloudEvent) error {
+func (h *handler) sendNotification(ctx context.Context, subject, title, message, device string, cause schemas.CloudEvent) (err error) {
+	ctx, span := tracer.Start(ctx, "notify.send",
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(attribute.String("device", device)))
+	defer func() {
+		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+	}()
+
 	// HA service name: "mobile_app_{device}" — underscores, lowercase.
 	svcName := "mobile_app_" + strings.ToLower(strings.ReplaceAll(device, "-", "_"))
 	apiURL := strings.TrimRight(h.haURL, "/") + "/api/services/notify/" + svcName
@@ -95,7 +114,7 @@ func (h *handler) sendNotification(subject, title, message, device string, cause
 		return fmt.Errorf("notifier: marshal request: %w", err)
 	}
 
-	req, err := http.NewRequest(http.MethodPost, apiURL, bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, apiURL, bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("notifier: build request: %w", err)
 	}

--- a/services/notifier/main.go
+++ b/services/notifier/main.go
@@ -153,8 +153,8 @@ func runConsumer(ctx context.Context, sub *nats.Subscription, h *handler, batchS
 		}
 		for _, msg := range msgs {
 			m := msg
-			instr.Observe(ctx, m, stream, consumer, func(_ context.Context) string {
-				if err := h.process(m.Subject, m.Data); err != nil {
+			instr.Observe(ctx, m, stream, consumer, func(sctx context.Context) string {
+				if err := h.process(sctx, m.Subject, m.Data); err != nil {
 					log.Warn("notifier: process failed, naking",
 						slog.String("subject", m.Subject),
 						slog.String("error", err.Error()),

--- a/services/notifier/main.go
+++ b/services/notifier/main.go
@@ -153,7 +153,7 @@ func runConsumer(ctx context.Context, sub *nats.Subscription, h *handler, batchS
 		}
 		for _, msg := range msgs {
 			m := msg
-			instr.Observe(ctx, stream, consumer, func() string {
+			instr.Observe(ctx, m, stream, consumer, func(_ context.Context) string {
 				if err := h.process(m.Subject, m.Data); err != nil {
 					log.Warn("notifier: process failed, naking",
 						slog.String("subject", m.Subject),

--- a/services/presence/handler.go
+++ b/services/presence/handler.go
@@ -16,10 +16,15 @@ import (
 	"github.com/nats-io/nats.go"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
 	"go.opentelemetry.io/otel/metric"
+	"go.opentelemetry.io/otel/trace"
 
 	"github.com/primaryrutabaga/ruby-core/pkg/schemas"
 )
+
+// tracer opens the presence.wifi_check span; delegates to the global provider set by otel.Init.
+var tracer = otel.Tracer("github.com/primaryrutabaga/ruby-core/services/presence")
 
 // handler implements multi-source presence fusion with debounce and WiFi
 // corroboration for uncertain states (unknown/unavailable).
@@ -80,7 +85,7 @@ func (h *handler) initState() {
 }
 
 // process handles a NATS message from the HA_EVENTS pull consumer.
-func (h *handler) process(subject string, data []byte) error {
+func (h *handler) process(ctx context.Context, subject string, data []byte) error {
 	var evt schemas.CloudEvent
 	if err := json.Unmarshal(data, &evt); err != nil {
 		h.log.Warn("presence: unmarshal event",
@@ -103,7 +108,7 @@ func (h *handler) process(subject string, data []byte) error {
 	}
 
 	if h.cfg.isUncertain(newState) {
-		h.handleUncertain(newState)
+		h.handleUncertain(ctx, newState)
 	} else {
 		h.handleTrusted(newState)
 	}
@@ -149,7 +154,7 @@ func (h *handler) handleTrusted(newState string) {
 
 // handleUncertain processes an uncertain state (unknown/unavailable).
 // It corroborates via WiFi before starting a debounce timer.
-func (h *handler) handleUncertain(uncertainState string) {
+func (h *handler) handleUncertain(ctx context.Context, uncertainState string) {
 	h.mu.Lock()
 	defer h.mu.Unlock()
 
@@ -175,7 +180,7 @@ func (h *handler) handleUncertain(uncertainState string) {
 
 	// Corroborate via WiFi (lock released during HTTP call to avoid holding it).
 	h.mu.Unlock()
-	wifiState, err := h.queryWifiState()
+	wifiState, err := h.queryWifiState(ctx)
 	h.mu.Lock()
 
 	if err != nil {
@@ -295,13 +300,23 @@ func (h *handler) persistState(state string) error {
 }
 
 // queryWifiState fetches the current state of the WiFi entity from HA REST API.
-func (h *handler) queryWifiState() (string, error) {
+func (h *handler) queryWifiState(ctx context.Context) (state string, err error) {
+	ctx, span := tracer.Start(ctx, "presence.wifi_check",
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(attribute.String("wifi_entity", h.cfg.WifiEntity)))
+	defer func() {
+		if err != nil {
+			span.SetStatus(codes.Error, err.Error())
+		}
+		span.End()
+	}()
+
 	if h.haURL == "" {
 		return "", fmt.Errorf("HA URL not configured")
 	}
 	url := strings.TrimRight(h.haURL, "/") + "/api/states/" + h.cfg.WifiEntity
 
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return "", fmt.Errorf("build request: %w", err)
 	}

--- a/services/presence/handler.go
+++ b/services/presence/handler.go
@@ -316,6 +316,7 @@ func (h *handler) queryWifiState(ctx context.Context) (state string, err error) 
 	}
 	url := strings.TrimRight(h.haURL, "/") + "/api/states/" + h.cfg.WifiEntity
 
+	//nolint:gosec // G704: url host is the Vault-configured Home Assistant base; the path is the configured WiFi entity, not user-controlled.
 	req, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
 	if err != nil {
 		return "", fmt.Errorf("build request: %w", err)

--- a/services/presence/main.go
+++ b/services/presence/main.go
@@ -170,8 +170,8 @@ func runConsumer(ctx context.Context, sub *nats.Subscription, h *handler, batchS
 		}
 		for _, msg := range msgs {
 			m := msg
-			instr.Observe(ctx, m, stream, consumer, func(_ context.Context) string {
-				if err := h.process(m.Subject, m.Data); err != nil {
+			instr.Observe(ctx, m, stream, consumer, func(sctx context.Context) string {
+				if err := h.process(sctx, m.Subject, m.Data); err != nil {
 					log.Warn("presence: process failed, naking",
 						slog.String("subject", m.Subject),
 						slog.String("error", err.Error()),

--- a/services/presence/main.go
+++ b/services/presence/main.go
@@ -170,7 +170,7 @@ func runConsumer(ctx context.Context, sub *nats.Subscription, h *handler, batchS
 		}
 		for _, msg := range msgs {
 			m := msg
-			instr.Observe(ctx, stream, consumer, func() string {
+			instr.Observe(ctx, m, stream, consumer, func(_ context.Context) string {
 				if err := h.process(m.Subject, m.Data); err != nil {
 					log.Warn("presence: process failed, naking",
 						slog.String("subject", m.Subject),


### PR DESCRIPTION
## Summary

**PR 2 of 2** for PLAN-0009 (Full-Stack Observability) — the **distributed traces** half. PR 1 (#150) shipped metrics + log correlation; this PR adds spans and W3C trace-context propagation across NATS so a full automation flow is one connected trace. Completes ROADMAP-0009 and archives PLAN-0009.

## What's in it

Connected trace:

```
ha.ingest → nats.consume(engine) → engine.process → nats.consume(notifier) → notify.send
```

- **Propagation** — `natsx.PublishWithContext` injects the active span's W3C `traceparent` into NATS message headers; `MsgInstruments.Observe` extracts it and opens a child `nats.consume` span. The gateway injects on all three publish paths (`state_changed`, `ada_event`, `ruby_home_event`).
- **Engine `ctx` threading** — `ctx` flows through `handle → decide → process → ProcessorHost.Process → Processor.ProcessEvent` (the interface gained a `ctx` param). `presence_notify` publishes the notify command with context, linking engine → notifier.
- **Spans** — `ha.ingest` (gateway), `nats.consume` (all 4 consumers), `engine.process`, `notify.send`, `presence.wifi_check`. The two HA REST calls use `http.NewRequestWithContext`.

## Verification

- **Unit-proven:** `TestPublishWithContext_PropagatesTraceToObserve` asserts the consumer span shares the producer's trace ID (inject→extract round-trip).
- **Live sign-off (after deploy):** the three ROADMAP-0009 ACs are marked `[~]` (code-complete + unit-verified). The one-time Grafana/Tempo/Loki confirmation can't run from CI (no telemetry-backend access) and is documented step-by-step in `docs/ops/phase9-verification.md`.

## Release-please

3 `feat(otel)` commits → next **minor** bump (`0.28.0 → 0.29.0`); the `docs(obs)` and `fix(lint)` commits add a Documentation/Bug-Fixes entry. No breaking changes.

## Drift Observations

None new. The two from PR 1 are tracked: #152 (staging runs `ENVIRONMENT=production`) and #122 (Traefik→api mTLS).

## Test plan

- `go build ./...`, `go test -tags=fast -race -short ./...`, `go build -tags=integration ./...` — all green.
- `golangci-lint run` (v2.11.4, stricter than CI v2.8.0) — 0 new issues vs main.
- PLAN-0009 archived (Complete); `make docs-index` regenerated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
