### PR TITLE
feat(calendar): rh-calendar consumer parity — patch-merge, read fields, directory route, per-instance edits (#155)

### DIFF
--- a/api/openapi.gen.yaml
+++ b/api/openapi.gen.yaml
@@ -385,6 +385,21 @@ components:
         description:
           type: string
           description: Free-text description, when set.
+        etag:
+          type: string
+          description: Mirror etag of the source row (trimmed of Google's surrounding quotes); supply as If-Match on updates.
+        recurrence:
+          type: array
+          items:
+            type: string
+          description: Raw RRULE/EXDATE/RDATE lines of the series master when this instance comes from a recurring event; empty for single events.
+        recurring_event_id:
+          type: string
+          description: Google event id of the series master when this instance belongs to a recurring series; omitted for single events.
+        original_start:
+          type: string
+          format: date-time
+          description: The series occurrence this instance corresponds to (RFC 3339 UTC) — set for recurring/override instances; addresses a single occurrence in per-instance writes.
         subjects:
           type: array
           items:

--- a/api/openapi/components/calendar.yaml
+++ b/api/openapi/components/calendar.yaml
@@ -34,6 +34,21 @@ CalendarInstance:
     description:
       type: string
       description: Free-text description, when set.
+    etag:
+      type: string
+      description: Mirror etag of the source row (trimmed of Google's surrounding quotes); supply as If-Match on updates.
+    recurrence:
+      type: array
+      items:
+        type: string
+      description: Raw RRULE/EXDATE/RDATE lines of the series master when this instance comes from a recurring event; empty for single events.
+    recurring_event_id:
+      type: string
+      description: Google event id of the series master when this instance belongs to a recurring series; omitted for single events.
+    original_start:
+      type: string
+      format: date-time
+      description: The series occurrence this instance corresponds to (RFC 3339 UTC) — set for recurring/override instances; addresses a single occurrence in per-instance writes.
     subjects:
       type: array
       items:

--- a/clients/python/models/calendar_instance.py
+++ b/clients/python/models/calendar_instance.py
@@ -47,6 +47,14 @@ class CalendarInstance:
             summary (str | Unset): The event title.
             location (str | Unset): Free-text location, when set.
             description (str | Unset): Free-text description, when set.
+            etag (str | Unset): Mirror etag of the source row (trimmed of Google's surrounding quotes); supply as If-Match
+                on updates.
+            recurrence (list[str] | Unset): Raw RRULE/EXDATE/RDATE lines of the series master when this instance comes from
+                a recurring event; empty for single events.
+            recurring_event_id (str | Unset): Google event id of the series master when this instance belongs to a recurring
+                series; omitted for single events.
+            original_start (datetime.datetime | Unset): The series occurrence this instance corresponds to (RFC 3339 UTC) —
+                set for recurring/override instances; addresses a single occurrence in per-instance writes.
             subjects (list[str] | Unset): Resolved subject person ids (the "FOR" lane) — local overlay, never written to
                 Google.
             childcare (str | Unset): Resolved childcare provider id for this event; omitted when none — local overlay.
@@ -62,6 +70,10 @@ class CalendarInstance:
     summary: str | Unset = UNSET
     location: str | Unset = UNSET
     description: str | Unset = UNSET
+    etag: str | Unset = UNSET
+    recurrence: list[str] | Unset = UNSET
+    recurring_event_id: str | Unset = UNSET
+    original_start: datetime.datetime | Unset = UNSET
     subjects: list[str] | Unset = UNSET
     childcare: str | Unset = UNSET
     attendees: list[CalendarInstanceAttendeesItem] | Unset = UNSET
@@ -88,6 +100,20 @@ class CalendarInstance:
         location = self.location
 
         description = self.description
+
+        etag = self.etag
+
+        recurrence: list[str] | Unset = UNSET
+        if not isinstance(self.recurrence, Unset):
+            recurrence = self.recurrence
+
+
+
+        recurring_event_id = self.recurring_event_id
+
+        original_start: str | Unset = UNSET
+        if not isinstance(self.original_start, Unset):
+            original_start = self.original_start.isoformat()
 
         subjects: list[str] | Unset = UNSET
         if not isinstance(self.subjects, Unset):
@@ -122,6 +148,14 @@ class CalendarInstance:
             field_dict["location"] = location
         if description is not UNSET:
             field_dict["description"] = description
+        if etag is not UNSET:
+            field_dict["etag"] = etag
+        if recurrence is not UNSET:
+            field_dict["recurrence"] = recurrence
+        if recurring_event_id is not UNSET:
+            field_dict["recurring_event_id"] = recurring_event_id
+        if original_start is not UNSET:
+            field_dict["original_start"] = original_start
         if subjects is not UNSET:
             field_dict["subjects"] = subjects
         if childcare is not UNSET:
@@ -159,6 +193,23 @@ class CalendarInstance:
 
         description = d.pop("description", UNSET)
 
+        etag = d.pop("etag", UNSET)
+
+        recurrence = cast(list[str], d.pop("recurrence", UNSET))
+
+
+        recurring_event_id = d.pop("recurring_event_id", UNSET)
+
+        _original_start = d.pop("original_start", UNSET)
+        original_start: datetime.datetime | Unset
+        if isinstance(_original_start,  Unset):
+            original_start = UNSET
+        else:
+            original_start = datetime.datetime.fromisoformat(_original_start)
+
+
+
+
         subjects = cast(list[str], d.pop("subjects", UNSET))
 
 
@@ -185,6 +236,10 @@ class CalendarInstance:
             summary=summary,
             location=location,
             description=description,
+            etag=etag,
+            recurrence=recurrence,
+            recurring_event_id=recurring_event_id,
+            original_start=original_start,
             subjects=subjects,
             childcare=childcare,
             attendees=attendees,

--- a/docs/ARCHITECTURE_DECISIONS.md
+++ b/docs/ARCHITECTURE_DECISIONS.md
@@ -48,3 +48,4 @@ target after adding an ADR. See the individual ADRs for full context.
 | [0041](adr/0041-openapi-lifecycle-and-codegen-governance.md) | OpenAPI Lifecycle & Codegen Governance for the HTTP API | Accepted |
 | [0042](adr/0042-calendar-sync-architecture.md) | Calendar Sync Architecture: Google as Source of Record, Local Durable Mirror | Accepted |
 | [0043](adr/0043-ada-boundary-based-today-rollover.md) | Ada boundary-based "Today" rollover (configurable bedtime, not UTC midnight) | Accepted |
+| [0044](adr/0044-calendar-write-semantics-patch-and-per-instance.md) | Calendar write semantics: patch-merge updates and per-instance recurring edits | Accepted |

--- a/docs/adr/0044-calendar-write-semantics-patch-and-per-instance.md
+++ b/docs/adr/0044-calendar-write-semantics-patch-and-per-instance.md
@@ -1,0 +1,112 @@
+# ADR-0044 - Calendar write semantics: patch-merge updates and per-instance recurring edits
+
+* **Status:** Accepted
+* **Date:** 2026-06-29
+* **Supersedes:** *(none)*
+* **Superseded by:** *(none)*
+
+---
+
+## Context
+
+ADR-0042 established the calendar sync architecture: Home Assistant fires `ruby_home_event`
+write events, the engine's calendar processor writes through to Google Calendar (the
+system of record), and a local Postgres mirror is converged from Google's returned event.
+The MVP write path that ADR-0042 shipped was deliberately series-level only and used Google
+`events.update`.
+
+Two gaps surfaced once the HA `rh-calendar` surface (`homeassistant` repo, PLAN-0034) began
+consuming these seams in earnest (#155):
+
+1. **Lossy updates.** `events.update` is a *full replace*. The engine builds the Google event
+   from the write payload alone, and the HA surface — by design — **omits** fields the user
+   did not touch (notably `recurrence`). The result: editing any field of a recurring event
+   silently strips its RRULE at Google, destroying the series. This is a correctness bug, not
+   a missing feature.
+
+2. **No per-occurrence editing.** A shared family calendar needs "this event only", "this and
+   following", and "all events" when editing or deleting a recurring series. The MVP only
+   offered series-level writes, so the HA surface withholds the scope sheets entirely rather
+   than ship a half-working UI.
+
+Google Calendar already models single-occurrence changes natively (instance *overrides* —
+an event whose `recurringEventId` points at the master and whose `originalStartTime` pins the
+occurrence), and the ruby-core mirror + expansion already understand overrides and cancelled
+occurrences. The decision is how the engine's write path should map HA's edit scopes onto
+Google, and how to stop the data loss.
+
+## Alternatives Considered
+
+**Keep `events.update` and have HA always send the full event (including untouched recurrence).**
+Pushes correctness onto every client and every future caller; one client that forgets a field
+destroys data. The merge belongs on the write-through, not the consumer.
+
+**Read-modify-write merge in the engine (Get the current event, overlay payload fields, Update).**
+Works, but adds a guaranteed extra Google round-trip per edit and re-implements field-level merge
+that Google's `events.patch` already does correctly — including for nested fields.
+
+**Model "this event only" as a brand-new standalone event (not a Google override).** Detaches the
+occurrence from its series: it would not move when the master moves, would not be subtracted from
+the expansion, and breaks "this and following". Rejected — it fights Google's data model and the
+mirror's expansion logic.
+
+**Carry the edit scope implicitly (infer "single occurrence" when `original_start` is present).**
+Ambiguous and unsafe: a present `original_start` cannot distinguish "edit just this one" from
+"edit the whole series starting at this instance". An explicit `scope` is required.
+
+## Decision
+
+1. **Updates MUST use Google `events.patch`, not `events.update`.** The engine builds the Google
+   event from only the fields the write payload carries; fields absent from the serialized event
+   MUST be left unchanged by Google. The existing If-Match etag optimistic-concurrency and the
+   resync-and-retry-once-on-412 behaviour (ADR-0042) are preserved.
+
+2. **Per-instance edits MUST use Google's native override model.** A write whose scope is the
+   single occurrence MUST resolve the occurrence via `events.instances` on the master (matched by
+   `original_start`) and patch that instance's event id — never the master, and never a detached
+   standalone event.
+
+3. **Per-instance delete MUST cancel the occurrence, not the series.** It MUST set the resolved
+   instance's `status` to `cancelled` (an override tombstone), which the mirror and expansion
+   already subtract. Series-level delete remains the existing hard delete of the master.
+
+4. **Edit/delete scope MUST be explicit.** The write payload carries a `scope` of `this`,
+   `this_and_following`, or `all`. `all` (the default, for back-compat with the MVP) keeps the
+   series-level path. `this` uses obligations 2–3.
+
+5. **`this_and_following` (series split) is deferred.** It requires setting `UNTIL` on the
+   master's RRULE at the cut point and creating a new series for the remainder; it is the
+   highest-risk sub-case and is intentionally out of the first delivery. Until it ships, a
+   `this_and_following` write SHOULD be rejected/withheld by the consumer rather than silently
+   downgraded to `all` or `this`.
+
+6. **Explicit recurrence-clearing is deferred.** Because the payload omits untouched fields,
+   "make this series non-recurring" cannot be distinguished from "recurrence untouched" under the
+   current `omitempty` recurrence field. Clearing recurrence MUST be routed through a future
+   scope-aware path (or a presence-typed payload), not inferred from an empty value.
+
+## Consequences
+
+### Positive
+
+* Editing a recurring event no longer destroys its RRULE — the data-loss bug is closed at the
+  write-through, independent of client behaviour.
+* HA can offer real "this / this-and-following*/ all" scope sheets (*minus the deferred split).
+* Per-instance changes ride Google's native override model, so they round-trip cleanly through the
+  existing mirror + expansion with no new local state.
+* No extra Google round-trip for the common edit (patch is a single call).
+
+### Negative
+
+* `events.patch` cannot express "clear this field" by omission, so explicit field-clearing
+  (recurrence especially) is now a known, deferred gap rather than a supported operation.
+* The write path gains scope-dependent branches (series vs instance), increasing its surface area
+  and test matrix.
+* `this_and_following` remaining unimplemented means the consumer must withhold that one option;
+  the model is not yet at full parity with a native calendar client.
+
+### Neutral
+
+* This formalizes Google Calendar's override/instances model as the canonical representation of
+  per-occurrence changes in ruby-core; the mirror remains a converged projection of it.
+* The `scope` field becomes part of the durable `ruby_home_event` calendar write contract.

--- a/docs/plans/PLAN-0038-rh-calendar-consumer-parity.md
+++ b/docs/plans/PLAN-0038-rh-calendar-consumer-parity.md
@@ -1,0 +1,171 @@
+# PLAN-0038 — rh-calendar Consumer Parity (#155)
+
+* **Status:** Draft
+* **Date:** 2026-06-29
+* **Project:** ruby-core
+* **Roadmap Item:** follow-on to [ROADMAP-0012](../roadmap/archived/ROADMAP-0012-home-calendar-api-foundation.md) (Home Calendar + API Foundation, complete)
+* **Branch:** `feat/rh-calendar-consumer-parity`
+* **Related ADRs:** ADR-0042 (calendar sync) — §4b and §2 refine its write-path obligations; a new ADR for the per-instance recurring-edit model is an open question (see below)
+
+---
+
+## Scope
+
+Close the ruby-core-side gaps that block the Home Assistant `rh-calendar` surface from
+**fully and safely** consuming the calendar seams (#155). Delivered as **one PR** covering all
+four asks, ordered data-loss-fix-first:
+
+* **§4b** — calendar event UPDATE must preserve fields the caller omits (esp. `recurrence`).
+* **§1** — expose `etag`, `recurrence`, `recurring_event_id`, `original_start` on read-API instances.
+* **§3** — add a directory-person write route so HA can add/rename people.
+* **§2** — per-instance recurring edit + delete (this-occurrence / this-and-following / all).
+* **§4a** — confirm + document that childcare-provider upsert is insert-or-update by client id.
+
+**Out of scope:** HA-side changes (the `homeassistant` repo owns the surface + `rest_command`s);
+colour storage (HA-local, never synced); any change to the read transport (verified working);
+mTLS for the API (tracked separately in #122).
+
+---
+
+## Pre-conditions
+
+* [ ] Branch `feat/rh-calendar-consumer-parity` cut from `main` (done).
+* [ ] OpenAPI toolchain available locally (`make openapi-bundle/gen/lint`): ogen v1.22.0,
+      redocly 1.34.5, spectral 6.15.0 — already pinned (ROADMAP-0012 Slice A).
+* [ ] No new Vault/secret or migration prerequisites — the `calendar_event`, `directory_person`,
+      and `childcare_provider` tables already carry every column this work reads or writes.
+
+---
+
+## Design decisions
+
+**§4b — patch, not replace.** `update()` currently calls Google `events.update` (full replace)
+with an event built only from the payload, so an omitted `recurrence` is sent as empty and Google
+strips the series. Switch the update path to Google **`events.patch`**: fields absent from the
+serialized event are left unchanged, which matches HA's "omit if untouched" contract. The 412/etag
+resync-and-retry-once behaviour is preserved. Known limitation (documented, not fixed here):
+because `CalendarUpsertData.Recurrence` is `[]string,omitempty`, an *explicit* "make this series
+non-recurring" cannot be distinguished from "untouched" — clearing recurrence is deferred to §2's
+scope-aware editor or a later presence-typed payload.
+
+**§2 — Google's native override model.** Per-instance edits map to Google instance overrides:
+list the master's instances, find the occurrence by `original_start`, and **patch that instance's
+event id**. Per-instance delete patches the instance to `status=cancelled` (the mirror + expansion
+already subtract cancelled overrides — verified in `expand_test.go`). "This and following" is a
+**series split**: set `UNTIL` on the master's RRULE at the cut point and create a new series for
+the remainder. The split is the riskiest sub-part; it is gated behind its own step and can be
+dropped from this PR without blocking the rest (see Open Questions).
+
+**§3 — mirror the childcare-provider path.** The store already has `UpsertPerson` +
+`UpsertPersonEmail` (`ON CONFLICT (id) DO UPDATE`). Only the contract + routing + handler are new.
+
+---
+
+## Steps
+
+### Step 1 — §4b: preserve omitted fields on update (data-loss fix)
+
+**Action:** Add `Patch(ctx, calendarID, eventID, etag string, ev *calendarv3.Event)` to
+`gcal.Service` (Google `events.patch`, If-Match etag, 412 → `ErrConflict`). Change
+`writethrough.go` `update()` to call `Patch` instead of `Update`. Leave `payloadToGoogle` setting
+only the fields the payload carries (recurrence stays `nil` when omitted → omitted from the patch
+body). Keep the resync-and-retry-once-on-412 flow.
+
+**Verification:** New unit test in `services/engine/processors/calendar` using the mockable
+`gcal.Service`: an upsert for an existing recurring event whose payload omits `recurrence` results
+in a `Patch` call whose `ev.Recurrence` is empty/omitted (so Google preserves it), **not** an
+`Update`. `go test -tags=fast ./services/engine/processors/calendar/...` green.
+
+**Notes:** This is the priority — it prevents silent destruction of recurring series on edit.
+
+### Step 2 — §1: expose recurrence/etag/identifiers on read-API instances
+
+**Action:** Add to the `CalendarInstance` schema in `api/openapi/` (non-nullable to avoid the
+known ogen `problem+json` nullable→spectral crash): `etag` (string), `recurrence` (array of
+string), `recurring_event_id` (string), `original_start` (string/date-time). Run
+`make openapi-bundle openapi-gen`. Populate them in `toAPIInstance` (calendar.go) from the source
+`*store.CalendarEvent` row (`etag`, `recurrence`, `recurring_event_id`) and the `expand.Instance`
+(`OriginalStart` for overrides, else the occurrence start).
+
+**Verification:** `make openapi-lint` passes (spectral clean). A handler/unit test asserts a
+recurring-series instance carries the RRULE in `recurrence` and a non-empty `recurring_event_id`,
+and an override instance carries `original_start`. `make openapi-verify` shows no unintended
+breaking diff (additive only). `go build ./... && go test -tags=fast ./services/api/...` green.
+
+### Step 3 — §4a: confirm + document childcare upsert semantics
+
+**Action:** No code change — `UpsertProvider` is already `INSERT … ON CONFLICT (id) DO UPDATE`.
+Add a one-line "upsert = insert-or-update by client-supplied id" note to the calendar runbook
+(or `services/gateway/README.md` `ruby_home_event` table) and record the confirmation to close
+out §4a on #155.
+
+**Verification:** The runbook/README states the semantics; the confirmation is captured in the PR
+description for the #155 reply.
+
+### Step 4 — §3: directory-person write route
+
+**Action:** Add `ha.events.ruby_home.directory.person_upsert` (+ `_delete`) subject constants in
+`pkg/schemas/homecal.go`; register `ruby_home.directory.person.upsert` / `.delete` in the gateway
+`eventRoutes` (`services/gateway/rubyhome/publish.go`); add a `DirectoryPersonData` payload schema;
+add engine `Subscriptions()` patterns + `handlePersonUpsert` / `handlePersonDelete` in
+`overlay_write.go` calling the existing `UpsertPerson` (+ `UpsertPersonEmail` when an email is
+present) and a soft-delete via the `active` flag for `.delete`.
+
+**Verification:** Unit test for the new handlers (fake store) covering insert-by-id, update-by-id,
+and soft-delete. A `rubyhome` publish test confirms the new `event` strings route to the new
+subjects. `go test -tags=fast ./...` green.
+
+### Step 5 — §2: per-instance recurring edit + delete
+
+**Action (5a — gcal capability):** Add `Instances(ctx, calendarID, recurringEventID)` and
+`PatchInstance(ctx, calendarID, instanceEventID, etag, ev)` to `gcal.Service` (Google
+`events.instances` + `events.patch` on the instance id). **(5b — payload):** add `scope`
+(`this` | `this_and_following` | `all`, default `all` for back-compat), `recurring_event_id`, and
+`original_start` to `CalendarUpsertData`/`CalendarDeleteData`. **(5c — write-through):** when
+`scope=this`, resolve the occurrence by `original_start` via `Instances`, then `PatchInstance`
+(edit) or patch `status=cancelled` (delete); `scope=all` keeps today's series-level path. Mirror
+the resulting override row via the existing `UpsertEvent`/overlay reconcile. **(5d — optional)**
+`scope=this_and_following`: split the master (RRULE `UNTIL`) + create the remainder series.
+
+**Verification:** Unit tests over the mockable `gcal.Service`: `scope=this` edit issues a
+`PatchInstance` on the resolved instance id (not the master); `scope=this` delete cancels only that
+instance; `scope=all` is unchanged. Expansion of the mirror after a per-instance cancel omits that
+occurrence (extends existing `expand_test.go` coverage). `go test -tags=fast ./...` green.
+
+**Notes:** Largest step. 5a–5c deliver this-occurrence + all; 5d (this-and-following split) is
+separable — drop it to a follow-up if the diff gets unwieldy (Open Questions).
+
+### Step 6 — Pre-Push + close-out
+
+**Action:** Update the calendar runbook (new directory route, per-instance scopes, patch
+semantics) and `services/gateway/README.md` route table; run `make openapi-verify`, full
+`go build`, `golangci-lint run` (PATH binary v2.11.x), `go test -tags=fast -race -short ./...`;
+draft the #155 reply (per-section answers); archive this plan (status → Complete) as the final
+commit.
+
+**Verification:** Pre-Push checklist clean; `--new-from-rev=origin/main` lint = 0; the PR closes
+issue 155 and the reply answers §1–§4 explicitly.
+
+---
+
+## Rollback
+
+Read-API + payload additions are additive (no removed fields, no breaking OpenAPI diff). No schema
+migration. The §4b update→patch switch is behaviour-only — revert the commit and redeploy
+(`make deploy-prod`, smoke + auto-rollback) to restore the prior path. Per-instance writes touch
+Google as overrides/cancellations exactly as the HA UI requests; rollback is reverting the engine
+image. No stateful/irreversible step.
+
+---
+
+## Open Questions
+
+1. **ADR for the per-instance recurring-edit model (§2)?** The override/`this-and-following`-split
+   semantics are a non-obvious, consciously-traded design — likely warrants an ADR refining
+   ADR-0042. Write it as part of this PR, or as a fast-follow?
+2. **Include `this_and_following` (Step 5d) in this PR, or defer?** It is the riskiest sub-part
+   (series split). Recommendation: implement this-occurrence + all here; defer the split if the PR
+   grows too large — HA already withholds that scope option until it lands.
+3. **Recurrence-clearing** (make a recurring series non-recurring) needs a presence-typed payload or
+   an explicit signal; not expressible under today's `omitempty` recurrence. Confirm this is
+   acceptable to defer (HA's editor can route "remove repeat" through §2 instead).

--- a/docs/plans/PLAN-0038-rh-calendar-consumer-parity.md
+++ b/docs/plans/PLAN-0038-rh-calendar-consumer-parity.md
@@ -1,11 +1,11 @@
 # PLAN-0038 — rh-calendar Consumer Parity (#155)
 
-* **Status:** Draft
+* **Status:** Approved
 * **Date:** 2026-06-29
 * **Project:** ruby-core
 * **Roadmap Item:** follow-on to [ROADMAP-0012](../roadmap/archived/ROADMAP-0012-home-calendar-api-foundation.md) (Home Calendar + API Foundation, complete)
 * **Branch:** `feat/rh-calendar-consumer-parity`
-* **Related ADRs:** ADR-0042 (calendar sync) — §4b and §2 refine its write-path obligations; a new ADR for the per-instance recurring-edit model is an open question (see below)
+* **Related ADRs:** [ADR-0044](../adr/0044-calendar-write-semantics-patch-and-per-instance.md) (calendar write semantics — patch-merge + per-instance recurring edits); refines [ADR-0042](../adr/0042-calendar-sync-architecture.md) (calendar sync)
 
 ---
 
@@ -158,14 +158,11 @@ image. No stateful/irreversible step.
 
 ---
 
-## Open Questions
+## Resolved decisions (2026-06-29)
 
-1. **ADR for the per-instance recurring-edit model (§2)?** The override/`this-and-following`-split
-   semantics are a non-obvious, consciously-traded design — likely warrants an ADR refining
-   ADR-0042. Write it as part of this PR, or as a fast-follow?
-2. **Include `this_and_following` (Step 5d) in this PR, or defer?** It is the riskiest sub-part
-   (series split). Recommendation: implement this-occurrence + all here; defer the split if the PR
-   grows too large — HA already withholds that scope option until it lands.
-3. **Recurrence-clearing** (make a recurring series non-recurring) needs a presence-typed payload or
-   an explicit signal; not expressible under today's `omitempty` recurrence. Confirm this is
-   acceptable to defer (HA's editor can route "remove repeat" through §2 instead).
+1. **ADR written.** [ADR-0044](../adr/0044-calendar-write-semantics-patch-and-per-instance.md)
+   captures the patch-merge update rule and the per-instance override model (Accepted).
+2. **`this_and_following` (Step 5d) is DEFERRED** to a fast-follow (ADR-0044 obligation 5). This PR
+   ships this-occurrence + all; the consumer withholds the split option until it lands.
+3. **Explicit recurrence-clearing is DEFERRED** (ADR-0044 obligation 6) — not expressible under the
+   `omitempty` payload; routed through a future scope-aware path, not inferred from an empty value.

--- a/docs/plans/README.md
+++ b/docs/plans/README.md
@@ -43,5 +43,6 @@ Active plans below are hand-maintained. The **Archived** table is generated from
 | [0035](archived/PLAN-0035-calendar-issue-cleanup.md) | Calendar Issue Cleanup | Complete |
 | [0036](archived/PLAN-0036-docs-index-hygiene.md) | Docs / Index Hygiene | Complete |
 | [0037](archived/PLAN-0037-nats-resilience.md) | Production NATS-Resilience Hardening | Complete |
+| [0038](archived/PLAN-0038-rh-calendar-consumer-parity.md) | rh-calendar Consumer Parity (#155) | Complete |
 
 <!-- END archived -->

--- a/docs/plans/archived/PLAN-0038-rh-calendar-consumer-parity.md
+++ b/docs/plans/archived/PLAN-0038-rh-calendar-consumer-parity.md
@@ -1,6 +1,6 @@
 # PLAN-0038 — rh-calendar Consumer Parity (#155)
 
-* **Status:** Approved
+* **Status:** Complete (2026-06-29 — §4b/§1/§3/§2 shipped; §2 this_and_following + recurrence-clearing deferred per ADR-0044)
 * **Date:** 2026-06-29
 * **Project:** ruby-core
 * **Roadmap Item:** follow-on to [ROADMAP-0012](../roadmap/archived/ROADMAP-0012-home-calendar-api-foundation.md) (Home Calendar + API Foundation, complete)

--- a/pkg/calendar/store/overlay.sql.go
+++ b/pkg/calendar/store/overlay.sql.go
@@ -21,6 +21,17 @@ func (q *Queries) ArchiveProvider(ctx context.Context, id pgtype.UUID) error {
 	return err
 }
 
+const deactivatePerson = `-- name: DeactivatePerson :exec
+UPDATE directory_person SET active = false WHERE id = $1
+`
+
+// DeactivatePerson soft-deletes a person (#155 §3) — the row is retained so historical
+// event associations still resolve.
+func (q *Queries) DeactivatePerson(ctx context.Context, id pgtype.UUID) error {
+	_, err := q.db.Exec(ctx, deactivatePerson, id)
+	return err
+}
+
 const deleteEventChildcare = `-- name: DeleteEventChildcare :exec
 DELETE FROM event_childcare WHERE google_event_id = $1
 `

--- a/pkg/calendar/store/queries/overlay.sql
+++ b/pkg/calendar/store/queries/overlay.sql
@@ -9,6 +9,11 @@ SELECT * FROM directory_person WHERE id = ANY(@ids::uuid[]);
 -- name: GetPersonByEmail :one
 SELECT * FROM directory_person WHERE lower(email) = lower(@email) LIMIT 1;
 
+-- DeactivatePerson soft-deletes a person (#155 §3) — the row is retained so historical
+-- event associations still resolve.
+-- name: DeactivatePerson :exec
+UPDATE directory_person SET active = false WHERE id = @id;
+
 -- name: UpsertPerson :exec
 INSERT INTO directory_person (id, display_name, kind, ha_person_entity_id, email, family, color, active)
 VALUES (@id, @display_name, @kind, @ha_person_entity_id, @email, @family, @color, @active)

--- a/pkg/schemas/homecal.go
+++ b/pkg/schemas/homecal.go
@@ -31,29 +31,45 @@ type CalendarEventDate struct {
 	TimeZone string `json:"timezone,omitempty"` // IANA zone, with DateTime
 }
 
+// Calendar edit/delete scope (ADR-0044). Absent/empty means ScopeAll for back-compat.
+const (
+	ScopeAll              = "all"                // the whole series (or a single event)
+	ScopeThis             = "this"               // only the addressed occurrence
+	ScopeThisAndFollowing = "this_and_following" // deferred (ADR-0044 obligation 5)
+)
+
 // CalendarUpsertData is the payload of a calendar.event.upsert write event
-// (ROADMAP-0012). Absent GoogleEventID means create; present means update.
+// (ROADMAP-0012). Absent GoogleEventID means create; present means update. For a
+// per-occurrence edit (Scope=this) RecurringEventID + OriginalStart address the
+// occurrence (ADR-0044, #155 §2).
 type CalendarUpsertData struct {
-	GoogleEventID  string            `json:"google_event_id,omitempty"`
-	Summary        string            `json:"summary"`
-	Start          CalendarEventDate `json:"start"`
-	End            CalendarEventDate `json:"end"`
-	AllDay         bool              `json:"all_day"`
-	Recurrence     []string          `json:"recurrence,omitempty"`
-	Location       string            `json:"location,omitempty"`
-	Description    string            `json:"description,omitempty"`
-	Subjects       []string          `json:"subjects,omitempty"`  // person_ids — overlay (Slice D)
-	Childcare      *string           `json:"childcare,omitempty"` // provider_id | null — overlay (Slice D)
-	Etag           string            `json:"etag,omitempty"`      // update only → If-Match
-	IdempotencyKey string            `json:"idempotency_key,omitempty"`
-	LoggedBy       string            `json:"logged_by,omitempty"`
+	GoogleEventID    string            `json:"google_event_id,omitempty"`
+	Summary          string            `json:"summary"`
+	Start            CalendarEventDate `json:"start"`
+	End              CalendarEventDate `json:"end"`
+	AllDay           bool              `json:"all_day"`
+	Recurrence       []string          `json:"recurrence,omitempty"`
+	Location         string            `json:"location,omitempty"`
+	Description      string            `json:"description,omitempty"`
+	Subjects         []string          `json:"subjects,omitempty"`  // person_ids — overlay (Slice D)
+	Childcare        *string           `json:"childcare,omitempty"` // provider_id | null — overlay (Slice D)
+	Etag             string            `json:"etag,omitempty"`      // update only → If-Match
+	IdempotencyKey   string            `json:"idempotency_key,omitempty"`
+	LoggedBy         string            `json:"logged_by,omitempty"`
+	Scope            string            `json:"scope,omitempty"`              // all (default) | this | this_and_following
+	RecurringEventID string            `json:"recurring_event_id,omitempty"` // series master, for Scope=this
+	OriginalStart    string            `json:"original_start,omitempty"`     // RFC3339 occurrence, for Scope=this
 }
 
-// CalendarDeleteData is the payload of a calendar.event.delete write event
-// (series-level for MVP).
+// CalendarDeleteData is the payload of a calendar.event.delete write event. Scope=this
+// cancels a single occurrence (RecurringEventID + OriginalStart); Scope=all (default)
+// deletes the whole series (ADR-0044).
 type CalendarDeleteData struct {
-	GoogleEventID string `json:"google_event_id"`
-	LoggedBy      string `json:"logged_by,omitempty"`
+	GoogleEventID    string `json:"google_event_id"`
+	LoggedBy         string `json:"logged_by,omitempty"`
+	Scope            string `json:"scope,omitempty"`
+	RecurringEventID string `json:"recurring_event_id,omitempty"`
+	OriginalStart    string `json:"original_start,omitempty"`
 }
 
 // ChildcareProviderUpsertData is the payload of ruby_home.childcare.provider.upsert

--- a/pkg/schemas/homecal.go
+++ b/pkg/schemas/homecal.go
@@ -14,6 +14,10 @@ const (
 	HomeEventChildcareProviderUpsert = "ha.events.ruby_home.childcare.provider_upsert"
 	HomeEventChildcareProviderDelete = "ha.events.ruby_home.childcare.provider_delete"
 
+	// Household-overlay directory person events (#155 §3): add/rename/deactivate people.
+	HomeEventDirectoryPersonUpsert = "ha.events.ruby_home.directory.person_upsert"
+	HomeEventDirectoryPersonDelete = "ha.events.ruby_home.directory.person_delete"
+
 	// CalendarReminderDue is published by the engine when an event reminder fires.
 	HomeEventCalendarReminderDue = "ha.events.calendar.reminder_due"
 )
@@ -65,5 +69,25 @@ type ChildcareProviderUpsertData struct {
 // ChildcareProviderDeleteData is the payload of ruby_home.childcare.provider.delete
 // (delete = archive, preserving frequency history).
 type ChildcareProviderDeleteData struct {
+	ID string `json:"id"`
+}
+
+// DirectoryPersonUpsertData is the payload of ruby_home.directory.person.upsert
+// (create when ID absent, else update by id — #155 §3). Local overlay only. Unlike
+// calendar events, a person upsert is a full record: the consumer (HA) sends the whole
+// person object, so omitted fields are written as their zero/empty value.
+type DirectoryPersonUpsertData struct {
+	ID               string `json:"id,omitempty"`
+	DisplayName      string `json:"display_name"`
+	Kind             string `json:"kind,omitempty"`                // "person" (default) | "group"
+	Email            string `json:"email,omitempty"`               // primary address; reconciles attendees
+	Family           string `json:"family,omitempty"`              // optional family grouping
+	Color            string `json:"color,omitempty"`               // overlay colour
+	HAPersonEntityID string `json:"ha_person_entity_id,omitempty"` // links to an HA person entity
+}
+
+// DirectoryPersonDeleteData is the payload of ruby_home.directory.person.delete
+// (delete = deactivate; the row is retained so historical associations resolve).
+type DirectoryPersonDeleteData struct {
 	ID string `json:"id"`
 }

--- a/services/api/handlers/calendar.go
+++ b/services/api/handlers/calendar.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"strings"
+	"time"
 
 	rubycal "github.com/primaryrutabaga/ruby-core/pkg/calendar"
 	"github.com/primaryrutabaga/ruby-core/pkg/calendar/expand"
@@ -209,6 +210,42 @@ func toAPIInstance(in expand.Instance, row *store.CalendarEvent) oas.CalendarIns
 		if row.Description.Valid {
 			ci.Description = oas.NewOptString(row.Description.String)
 		}
+		if row.Etag != "" {
+			ci.Etag = oas.NewOptString(row.Etag)
+		}
+		// recurrence (raw RRULE/EXDATE/RDATE) lives on the series master row.
+		if len(row.Recurrence) > 0 {
+			ci.Recurrence = row.Recurrence
+		}
+		// recurring_event_id: explicit on an override row; the master's own id for the
+		// occurrences it expands into (so the consumer can address the series).
+		switch {
+		case row.RecurringEventID.Valid && row.RecurringEventID.String != "":
+			ci.RecurringEventID = oas.NewOptString(row.RecurringEventID.String)
+		case len(row.Recurrence) > 0:
+			ci.RecurringEventID = oas.NewOptString(row.GoogleEventID)
+		}
+		// original_start identifies the occurrence for per-instance writes (§2): the
+		// override's pinned slot, else the occurrence's own scheduled start.
+		if os, ok := originalStart(in, row); ok {
+			ci.OriginalStart = oas.NewOptDateTime(os)
+		}
 	}
 	return ci
+}
+
+// originalStart returns the occurrence's original scheduled start and whether it applies:
+// an override's pinned slot (date or datetime), else the scheduled start of a recurring
+// occurrence. Single events have no original start.
+func originalStart(in expand.Instance, row *store.CalendarEvent) (time.Time, bool) {
+	switch {
+	case row.OriginalStartDatetime.Valid:
+		return row.OriginalStartDatetime.Time.UTC(), true
+	case row.OriginalStartDate.Valid:
+		return row.OriginalStartDate.Time.UTC(), true
+	case len(row.Recurrence) > 0:
+		return in.Start, true
+	default:
+		return time.Time{}, false
+	}
 }

--- a/services/api/handlers/calendar_test.go
+++ b/services/api/handlers/calendar_test.go
@@ -4,9 +4,11 @@ package handlers
 
 import (
 	"testing"
+	"time"
 
 	"github.com/jackc/pgx/v5/pgtype"
 
+	"github.com/primaryrutabaga/ruby-core/pkg/calendar/expand"
 	"github.com/primaryrutabaga/ruby-core/pkg/calendar/store"
 )
 
@@ -42,4 +44,59 @@ func TestBuildEmailIndex(t *testing.T) {
 	if len(idx) != 3 { // mom primary, dad primary, mom alias
 		t.Errorf("index size = %d, want 3 (%v)", len(idx), idx)
 	}
+}
+
+// TestToAPIInstance_RecurrenceFields covers the #155 §1 read-API exposure: recurring
+// occurrences carry recurrence + recurring_event_id + original_start; override instances
+// carry the master id and pinned original slot; single events carry none of them.
+func TestToAPIInstance_RecurrenceFields(t *testing.T) {
+	occ := time.Date(2026, 6, 22, 13, 0, 0, 0, time.UTC)
+
+	t.Run("recurring master occurrence", func(t *testing.T) {
+		row := &store.CalendarEvent{
+			GoogleEventID: "master1", Status: "confirmed", Etag: "etag-m1",
+			Recurrence: []string{"RRULE:FREQ=WEEKLY;BYDAY=MO"},
+		}
+		ci := toAPIInstance(expand.Instance{GoogleEventID: "master1", Start: occ, End: occ.Add(time.Hour)}, row)
+		if ci.Etag.Value != "etag-m1" {
+			t.Errorf("etag = %q", ci.Etag.Value)
+		}
+		if len(ci.Recurrence) != 1 || ci.Recurrence[0] != "RRULE:FREQ=WEEKLY;BYDAY=MO" {
+			t.Errorf("recurrence = %v", ci.Recurrence)
+		}
+		if ci.RecurringEventID.Value != "master1" {
+			t.Errorf("recurring_event_id = %q, want master1", ci.RecurringEventID.Value)
+		}
+		if !ci.OriginalStart.Set || !ci.OriginalStart.Value.Equal(occ) {
+			t.Errorf("original_start = %v (set=%v), want %v", ci.OriginalStart.Value, ci.OriginalStart.Set, occ)
+		}
+	})
+
+	t.Run("override instance", func(t *testing.T) {
+		moved := occ.Add(2 * time.Hour)
+		row := &store.CalendarEvent{
+			GoogleEventID: "ovr1", Status: "confirmed", Etag: "etag-o1",
+			RecurringEventID:      txt("master1"),
+			OriginalStartDatetime: pgtype.Timestamptz{Time: occ, Valid: true},
+		}
+		ci := toAPIInstance(expand.Instance{GoogleEventID: "ovr1", Start: moved, End: moved.Add(time.Hour), IsOverride: true}, row)
+		if ci.RecurringEventID.Value != "master1" {
+			t.Errorf("recurring_event_id = %q, want master1", ci.RecurringEventID.Value)
+		}
+		if !ci.OriginalStart.Set || !ci.OriginalStart.Value.Equal(occ) {
+			t.Errorf("original_start = %v, want pinned slot %v (not the moved time)", ci.OriginalStart.Value, occ)
+		}
+		if len(ci.Recurrence) != 0 {
+			t.Errorf("override must not carry recurrence, got %v", ci.Recurrence)
+		}
+	})
+
+	t.Run("single event", func(t *testing.T) {
+		row := &store.CalendarEvent{GoogleEventID: "s1", Status: "confirmed", Etag: "etag-s1"}
+		ci := toAPIInstance(expand.Instance{GoogleEventID: "s1", Start: occ, End: occ.Add(time.Hour)}, row)
+		if len(ci.Recurrence) != 0 || ci.RecurringEventID.Set || ci.OriginalStart.Set {
+			t.Errorf("single event should carry no recurrence fields: rec=%v rid=%v os=%v",
+				ci.Recurrence, ci.RecurringEventID.Set, ci.OriginalStart.Set)
+		}
+	})
 }

--- a/services/api/oas/oas_json_gen.go
+++ b/services/api/oas/oas_json_gen.go
@@ -5,6 +5,7 @@ package oas
 import (
 	"math/bits"
 	"strconv"
+	"time"
 
 	"github.com/go-faster/errors"
 	"github.com/go-faster/jx"
@@ -60,6 +61,34 @@ func (s *CalendarInstance) encodeFields(e *jx.Encoder) {
 		}
 	}
 	{
+		if s.Etag.Set {
+			e.FieldStart("etag")
+			s.Etag.Encode(e)
+		}
+	}
+	{
+		if s.Recurrence != nil {
+			e.FieldStart("recurrence")
+			e.ArrStart()
+			for _, elem := range s.Recurrence {
+				e.Str(elem)
+			}
+			e.ArrEnd()
+		}
+	}
+	{
+		if s.RecurringEventID.Set {
+			e.FieldStart("recurring_event_id")
+			s.RecurringEventID.Encode(e)
+		}
+	}
+	{
+		if s.OriginalStart.Set {
+			e.FieldStart("original_start")
+			s.OriginalStart.Encode(e, json.EncodeDateTime)
+		}
+	}
+	{
 		if s.Subjects != nil {
 			e.FieldStart("subjects")
 			e.ArrStart()
@@ -87,7 +116,7 @@ func (s *CalendarInstance) encodeFields(e *jx.Encoder) {
 	}
 }
 
-var jsonFieldsNameOfCalendarInstance = [11]string{
+var jsonFieldsNameOfCalendarInstance = [15]string{
 	0:  "google_event_id",
 	1:  "summary",
 	2:  "start",
@@ -96,9 +125,13 @@ var jsonFieldsNameOfCalendarInstance = [11]string{
 	5:  "status",
 	6:  "location",
 	7:  "description",
-	8:  "subjects",
-	9:  "childcare",
-	10: "attendees",
+	8:  "etag",
+	9:  "recurrence",
+	10: "recurring_event_id",
+	11: "original_start",
+	12: "subjects",
+	13: "childcare",
+	14: "attendees",
 }
 
 // Decode decodes CalendarInstance from json.
@@ -199,6 +232,55 @@ func (s *CalendarInstance) Decode(d *jx.Decoder) error {
 				return nil
 			}(); err != nil {
 				return errors.Wrap(err, "decode field \"description\"")
+			}
+		case "etag":
+			if err := func() error {
+				s.Etag.Reset()
+				if err := s.Etag.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"etag\"")
+			}
+		case "recurrence":
+			if err := func() error {
+				s.Recurrence = make([]string, 0)
+				if err := d.Arr(func(d *jx.Decoder) error {
+					var elem string
+					v, err := d.Str()
+					elem = string(v)
+					if err != nil {
+						return err
+					}
+					s.Recurrence = append(s.Recurrence, elem)
+					return nil
+				}); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"recurrence\"")
+			}
+		case "recurring_event_id":
+			if err := func() error {
+				s.RecurringEventID.Reset()
+				if err := s.RecurringEventID.Decode(d); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"recurring_event_id\"")
+			}
+		case "original_start":
+			if err := func() error {
+				s.OriginalStart.Reset()
+				if err := s.OriginalStart.Decode(d, json.DecodeDateTime); err != nil {
+					return err
+				}
+				return nil
+			}(); err != nil {
+				return errors.Wrap(err, "decode field \"original_start\"")
 			}
 		case "subjects":
 			if err := func() error {
@@ -707,6 +789,41 @@ func (s ListDirectoryPeopleOKApplicationJSON) MarshalJSON() ([]byte, error) {
 func (s *ListDirectoryPeopleOKApplicationJSON) UnmarshalJSON(data []byte) error {
 	d := jx.DecodeBytes(data)
 	return s.Decode(d)
+}
+
+// Encode encodes time.Time as json.
+func (o OptDateTime) Encode(e *jx.Encoder, format func(*jx.Encoder, time.Time)) {
+	if !o.Set {
+		return
+	}
+	format(e, o.Value)
+}
+
+// Decode decodes time.Time from json.
+func (o *OptDateTime) Decode(d *jx.Decoder, format func(*jx.Decoder) (time.Time, error)) error {
+	if o == nil {
+		return errors.New("invalid: unable to decode OptDateTime to nil")
+	}
+	o.Set = true
+	v, err := format(d)
+	if err != nil {
+		return err
+	}
+	o.Value = v
+	return nil
+}
+
+// MarshalJSON implements stdjson.Marshaler.
+func (s OptDateTime) MarshalJSON() ([]byte, error) {
+	e := jx.Encoder{}
+	s.Encode(&e, json.EncodeDateTime)
+	return e.Bytes(), nil
+}
+
+// UnmarshalJSON implements stdjson.Unmarshaler.
+func (s *OptDateTime) UnmarshalJSON(data []byte) error {
+	d := jx.DecodeBytes(data)
+	return s.Decode(d, json.DecodeDateTime)
 }
 
 // Encode encodes string as json.

--- a/services/api/oas/oas_schemas_gen.go
+++ b/services/api/oas/oas_schemas_gen.go
@@ -59,6 +59,18 @@ type CalendarInstance struct {
 	Location OptString `json:"location"`
 	// Free-text description, when set.
 	Description OptString `json:"description"`
+	// Mirror etag of the source row (trimmed of Google's surrounding quotes); supply as If-Match on
+	// updates.
+	Etag OptString `json:"etag"`
+	// Raw RRULE/EXDATE/RDATE lines of the series master when this instance comes from a recurring event;
+	// empty for single events.
+	Recurrence []string `json:"recurrence"`
+	// Google event id of the series master when this instance belongs to a recurring series; omitted for
+	// single events.
+	RecurringEventID OptString `json:"recurring_event_id"`
+	// The series occurrence this instance corresponds to (RFC 3339 UTC) — set for recurring/override
+	// instances; addresses a single occurrence in per-instance writes.
+	OriginalStart OptDateTime `json:"original_start"`
 	// Resolved subject person ids (the "FOR" lane) — local overlay, never written to Google.
 	Subjects []string `json:"subjects"`
 	// Resolved childcare provider id for this event; omitted when none — local overlay.
@@ -106,6 +118,26 @@ func (s *CalendarInstance) GetLocation() OptString {
 // GetDescription returns the value of Description.
 func (s *CalendarInstance) GetDescription() OptString {
 	return s.Description
+}
+
+// GetEtag returns the value of Etag.
+func (s *CalendarInstance) GetEtag() OptString {
+	return s.Etag
+}
+
+// GetRecurrence returns the value of Recurrence.
+func (s *CalendarInstance) GetRecurrence() []string {
+	return s.Recurrence
+}
+
+// GetRecurringEventID returns the value of RecurringEventID.
+func (s *CalendarInstance) GetRecurringEventID() OptString {
+	return s.RecurringEventID
+}
+
+// GetOriginalStart returns the value of OriginalStart.
+func (s *CalendarInstance) GetOriginalStart() OptDateTime {
+	return s.OriginalStart
 }
 
 // GetSubjects returns the value of Subjects.
@@ -161,6 +193,26 @@ func (s *CalendarInstance) SetLocation(val OptString) {
 // SetDescription sets the value of Description.
 func (s *CalendarInstance) SetDescription(val OptString) {
 	s.Description = val
+}
+
+// SetEtag sets the value of Etag.
+func (s *CalendarInstance) SetEtag(val OptString) {
+	s.Etag = val
+}
+
+// SetRecurrence sets the value of Recurrence.
+func (s *CalendarInstance) SetRecurrence(val []string) {
+	s.Recurrence = val
+}
+
+// SetRecurringEventID sets the value of RecurringEventID.
+func (s *CalendarInstance) SetRecurringEventID(val OptString) {
+	s.RecurringEventID = val
+}
+
+// SetOriginalStart sets the value of OriginalStart.
+func (s *CalendarInstance) SetOriginalStart(val OptDateTime) {
+	s.OriginalStart = val
 }
 
 // SetSubjects sets the value of Subjects.
@@ -240,6 +292,52 @@ func (*ListChildcareProvidersOKApplicationJSON) listChildcareProvidersRes() {}
 type ListDirectoryPeopleOKApplicationJSON []Person
 
 func (*ListDirectoryPeopleOKApplicationJSON) listDirectoryPeopleRes() {}
+
+// NewOptDateTime returns new OptDateTime with value set to v.
+func NewOptDateTime(v time.Time) OptDateTime {
+	return OptDateTime{
+		Value: v,
+		Set:   true,
+	}
+}
+
+// OptDateTime is optional time.Time.
+type OptDateTime struct {
+	Value time.Time
+	Set   bool
+}
+
+// IsSet returns true if OptDateTime was set.
+func (o OptDateTime) IsSet() bool { return o.Set }
+
+// Reset unsets value.
+func (o *OptDateTime) Reset() {
+	var v time.Time
+	o.Value = v
+	o.Set = false
+}
+
+// SetTo sets value to v.
+func (o *OptDateTime) SetTo(v time.Time) {
+	o.Set = true
+	o.Value = v
+}
+
+// Get returns value and boolean that denotes whether value was set.
+func (o OptDateTime) Get() (v time.Time, ok bool) {
+	if !o.Set {
+		return v, false
+	}
+	return o.Value, true
+}
+
+// Or returns value if set, or given parameter if does not.
+func (o OptDateTime) Or(d time.Time) time.Time {
+	if v, ok := o.Get(); ok {
+		return v
+	}
+	return d
+}
 
 // NewOptString returns new OptString with value set to v.
 func NewOptString(v string) OptString {

--- a/services/engine/processors/calendar/gcal/client.go
+++ b/services/engine/processors/calendar/gcal/client.go
@@ -41,6 +41,11 @@ type Service interface {
 	// is surfaced as ErrAlreadyGone so the caller can treat the absent postcondition
 	// as satisfied rather than failing.
 	Delete(ctx context.Context, calendarID, eventID string) error
+	// InstanceAt resolves the single occurrence of recurringEventID whose original start
+	// equals originalStart (RFC 3339). It returns the instance's own event id (which
+	// per-instance edits/deletes then Patch), or ErrAlreadyGone when no such occurrence
+	// exists (ADR-0044).
+	InstanceAt(ctx context.Context, calendarID, recurringEventID, originalStart string) (*calendarv3.Event, error)
 }
 
 // ListResult is one page from a sync pass.
@@ -171,6 +176,21 @@ func (a *apiService) Patch(ctx context.Context, calendarID, eventID, etag string
 		return nil, fmt.Errorf("gcal: patch: %w", err)
 	}
 	return out, nil
+}
+
+func (a *apiService) InstanceAt(ctx context.Context, calendarID, recurringEventID, originalStart string) (*calendarv3.Event, error) {
+	res, err := a.svc.Events.Instances(calendarID, recurringEventID).OriginalStart(originalStart).Context(ctx).Do()
+	if err != nil {
+		var gerr *googleapi.Error
+		if errors.As(err, &gerr) && (gerr.Code == 404 || gerr.Code == 410) {
+			return nil, ErrAlreadyGone
+		}
+		return nil, fmt.Errorf("gcal: instances: %w", err)
+	}
+	if len(res.Items) == 0 {
+		return nil, ErrAlreadyGone
+	}
+	return res.Items[0], nil
 }
 
 func (a *apiService) Delete(ctx context.Context, calendarID, eventID string) error {

--- a/services/engine/processors/calendar/gcal/client.go
+++ b/services/engine/processors/calendar/gcal/client.go
@@ -32,6 +32,11 @@ type Service interface {
 	// Update modifies an event with If-Match optimistic concurrency. A Google 412
 	// (etag mismatch) is surfaced as ErrConflict.
 	Update(ctx context.Context, calendarID, eventID, etag string, ev *calendarv3.Event) (*calendarv3.Event, error)
+	// Patch partially updates an event (Google events.patch): fields absent from ev are
+	// left unchanged, so a caller that omits untouched fields (e.g. recurrence) does not
+	// strip them — unlike Update's full replace (ADR-0044). Same If-Match etag concurrency
+	// as Update; a Google 412 is surfaced as ErrConflict.
+	Patch(ctx context.Context, calendarID, eventID, etag string, ev *calendarv3.Event) (*calendarv3.Event, error)
 	// Delete removes an event (series-level for MVP). A Google 410/404 (already gone)
 	// is surfaced as ErrAlreadyGone so the caller can treat the absent postcondition
 	// as satisfied rather than failing.
@@ -146,6 +151,24 @@ func (a *apiService) Update(ctx context.Context, calendarID, eventID, etag strin
 			return nil, ErrConflict
 		}
 		return nil, fmt.Errorf("gcal: update: %w", err)
+	}
+	return out, nil
+}
+
+func (a *apiService) Patch(ctx context.Context, calendarID, eventID, etag string, ev *calendarv3.Event) (*calendarv3.Event, error) {
+	call := a.svc.Events.Patch(calendarID, eventID, ev)
+	if etag != "" {
+		// If-Match requires the quoted entity-tag form (see Update); the mirror stores
+		// etags trimmed, so a bare value never matches → Google 412.
+		call.Header().Set("If-Match", quoteEtag(etag))
+	}
+	out, err := call.Context(ctx).Do()
+	if err != nil {
+		var gerr *googleapi.Error
+		if errors.As(err, &gerr) && gerr.Code == 412 {
+			return nil, ErrConflict
+		}
+		return nil, fmt.Errorf("gcal: patch: %w", err)
 	}
 	return out, nil
 }

--- a/services/engine/processors/calendar/overlay_write.go
+++ b/services/engine/processors/calendar/overlay_write.go
@@ -63,6 +63,65 @@ func (p *Processor) handleProviderDelete(ctx context.Context, evt *schemas.Cloud
 	return nil
 }
 
+// handlePersonUpsert applies ruby_home.directory.person.upsert: create (no id) or update
+// a directory person by id (#155 §3). The payload is a full person record — HA owns the
+// person model and sends the whole object — so this is a straight upsert, not a merge.
+// Local overlay only; never written to Google.
+func (p *Processor) handlePersonUpsert(ctx context.Context, evt *schemas.CloudEvent) error {
+	var d schemas.DirectoryPersonUpsertData
+	if err := decodeData(evt.Data, &d); err != nil {
+		p.log.Warn("calendar: bad person upsert payload", slog.String("error", err.Error()))
+		return nil
+	}
+	if d.DisplayName == "" {
+		p.log.Warn("calendar: person upsert missing display_name")
+		return nil
+	}
+	id, err := uuidOrNew(d.ID)
+	if err != nil {
+		p.log.Warn("calendar: invalid person id", slog.String("id", d.ID), slog.String("error", err.Error()))
+		return nil
+	}
+	kind := d.Kind
+	if kind == "" {
+		kind = "person" // directory_person.kind CHECK default
+	}
+	if err := p.q.UpsertPerson(ctx, &store.UpsertPersonParams{
+		ID:               id,
+		DisplayName:      d.DisplayName,
+		Kind:             kind,
+		HaPersonEntityID: textVal(d.HAPersonEntityID),
+		Email:            textVal(d.Email),
+		Family:           textVal(d.Family),
+		Color:            textVal(d.Color),
+		Active:           true,
+	}); err != nil {
+		return fmt.Errorf("calendar: upsert person: %w", err)
+	}
+	p.log.Info("calendar: person upserted", slog.String("display_name", d.DisplayName))
+	return nil
+}
+
+// handlePersonDelete deactivates a person (soft-delete; the row is retained so historical
+// event associations still resolve).
+func (p *Processor) handlePersonDelete(ctx context.Context, evt *schemas.CloudEvent) error {
+	var d schemas.DirectoryPersonDeleteData
+	if err := decodeData(evt.Data, &d); err != nil {
+		p.log.Warn("calendar: bad person delete payload", slog.String("error", err.Error()))
+		return nil
+	}
+	id, err := parseUUID(d.ID)
+	if err != nil {
+		p.log.Warn("calendar: person delete invalid id", slog.String("id", d.ID))
+		return nil
+	}
+	if err := p.q.DeactivatePerson(ctx, id); err != nil {
+		return fmt.Errorf("calendar: deactivate person: %w", err)
+	}
+	p.log.Info("calendar: person deactivated", slog.String("id", d.ID))
+	return nil
+}
+
 // reconcileAssociations syncs an event's subject and childcare overlay rows to match
 // the upsert payload. A nil slice/pointer means "not provided" — leave unchanged; an
 // empty slice / explicit value means "set to this". Called after the mirror upsert.
@@ -144,4 +203,12 @@ func textPtr(s *string) pgtype.Text {
 		return pgtype.Text{}
 	}
 	return pgtype.Text{String: *s, Valid: true}
+}
+
+// textVal maps an optional string field to nullable text — empty becomes SQL NULL.
+func textVal(s string) pgtype.Text {
+	if s == "" {
+		return pgtype.Text{}
+	}
+	return pgtype.Text{String: s, Valid: true}
 }

--- a/services/engine/processors/calendar/processor.go
+++ b/services/engine/processors/calendar/processor.go
@@ -54,6 +54,8 @@ type calStore interface {
 	// Overlay writes (Slice D).
 	UpsertProvider(ctx context.Context, arg *store.UpsertProviderParams) error
 	ArchiveProvider(ctx context.Context, id pgtype.UUID) error
+	UpsertPerson(ctx context.Context, arg *store.UpsertPersonParams) error
+	DeactivatePerson(ctx context.Context, id pgtype.UUID) error
 	DeleteEventSubjects(ctx context.Context, googleEventID string) error
 	InsertEventSubject(ctx context.Context, arg *store.InsertEventSubjectParams) error
 	DeleteEventChildcare(ctx context.Context, googleEventID string) error
@@ -95,6 +97,8 @@ func (p *Processor) Subscriptions() []string {
 		schemas.HomeEventCalendarDelete,
 		schemas.HomeEventChildcareProviderUpsert,
 		schemas.HomeEventChildcareProviderDelete,
+		schemas.HomeEventDirectoryPersonUpsert,
+		schemas.HomeEventDirectoryPersonDelete,
 	}
 }
 
@@ -194,6 +198,10 @@ func (p *Processor) ProcessEvent(ctx context.Context, subject string, data []byt
 		return p.handleProviderUpsert(ctx, &evt)
 	case schemas.HomeEventChildcareProviderDelete:
 		return p.handleProviderDelete(ctx, &evt)
+	case schemas.HomeEventDirectoryPersonUpsert:
+		return p.handlePersonUpsert(ctx, &evt)
+	case schemas.HomeEventDirectoryPersonDelete:
+		return p.handlePersonDelete(ctx, &evt)
 	default:
 		return nil
 	}

--- a/services/engine/processors/calendar/processor_test.go
+++ b/services/engine/processors/calendar/processor_test.go
@@ -124,10 +124,12 @@ type fakeStore struct {
 	upserts     int
 	fullResyncs int
 
-	providers []*store.UpsertProviderParams
-	archived  []pgtype.UUID
-	subjects  map[string][]pgtype.UUID
-	childcare map[string]pgtype.UUID
+	providers   []*store.UpsertProviderParams
+	archived    []pgtype.UUID
+	people      []*store.UpsertPersonParams
+	deactivated []pgtype.UUID
+	subjects    map[string][]pgtype.UUID
+	childcare   map[string]pgtype.UUID
 }
 
 func newFakeStore() *fakeStore {
@@ -144,6 +146,14 @@ func (s *fakeStore) UpsertProvider(_ context.Context, arg *store.UpsertProviderP
 }
 func (s *fakeStore) ArchiveProvider(_ context.Context, id pgtype.UUID) error {
 	s.archived = append(s.archived, id)
+	return nil
+}
+func (s *fakeStore) UpsertPerson(_ context.Context, arg *store.UpsertPersonParams) error {
+	s.people = append(s.people, arg)
+	return nil
+}
+func (s *fakeStore) DeactivatePerson(_ context.Context, id pgtype.UUID) error {
+	s.deactivated = append(s.deactivated, id)
 	return nil
 }
 func (s *fakeStore) DeleteEventSubjects(_ context.Context, eid string) error {
@@ -601,5 +611,59 @@ func googleTimed(id, etag string) *calendarv3.Event {
 		Id: id, Etag: etag, Status: "confirmed",
 		Start: &calendarv3.EventDateTime{DateTime: "2026-06-26T09:00:00-04:00"},
 		End:   &calendarv3.EventDateTime{DateTime: "2026-06-26T10:00:00-04:00"},
+	}
+}
+
+// TestHandlePersonUpsert_GeneratesIDAndDefaultsKind covers #155 §3 create: an absent id is
+// generated, kind defaults to "person", and the full record is upserted.
+func TestHandlePersonUpsert_GeneratesIDAndDefaultsKind(t *testing.T) {
+	p, _, st := newTestProcessor()
+	evt := cloudEvent(t, schemas.DirectoryPersonUpsertData{DisplayName: "Junior", Color: "#ff0", Email: "junior@example.com"})
+	if err := p.handlePersonUpsert(context.Background(), evt); err != nil {
+		t.Fatalf("person upsert: %v", err)
+	}
+	if len(st.people) != 1 {
+		t.Fatalf("people recorded = %d, want 1", len(st.people))
+	}
+	got := st.people[0]
+	if !got.ID.Valid {
+		t.Error("expected a generated person id")
+	}
+	if got.DisplayName != "Junior" || got.Kind != "person" || !got.Active {
+		t.Errorf("person = %+v, want display=Junior kind=person active=true", got)
+	}
+	if got.Color.String != "#ff0" || got.Email.String != "junior@example.com" {
+		t.Errorf("color/email not mapped: %+v", got)
+	}
+}
+
+// TestHandlePersonUpsert_UpdatesByID covers rename: a supplied id is preserved (update path).
+func TestHandlePersonUpsert_UpdatesByID(t *testing.T) {
+	p, _, st := newTestProcessor()
+	const id = "11111111-1111-4111-8111-111111111111"
+	evt := cloudEvent(t, schemas.DirectoryPersonUpsertData{ID: id, DisplayName: "Renamed", Kind: "group"})
+	if err := p.handlePersonUpsert(context.Background(), evt); err != nil {
+		t.Fatalf("person upsert: %v", err)
+	}
+	if len(st.people) != 1 || st.people[0].Kind != "group" {
+		t.Fatalf("expected one upsert with kind=group, got %+v", st.people)
+	}
+	var want pgtype.UUID
+	_ = want.Scan(id)
+	if st.people[0].ID != want {
+		t.Errorf("id = %v, want supplied %s", st.people[0].ID, id)
+	}
+}
+
+// TestHandlePersonDelete_Deactivates covers soft-delete by id.
+func TestHandlePersonDelete_Deactivates(t *testing.T) {
+	p, _, st := newTestProcessor()
+	const id = "22222222-2222-4222-8222-222222222222"
+	evt := cloudEvent(t, schemas.DirectoryPersonDeleteData{ID: id})
+	if err := p.handlePersonDelete(context.Background(), evt); err != nil {
+		t.Fatalf("person delete: %v", err)
+	}
+	if len(st.deactivated) != 1 {
+		t.Fatalf("deactivated = %d, want 1", len(st.deactivated))
 	}
 }

--- a/services/engine/processors/calendar/processor_test.go
+++ b/services/engine/processors/calendar/processor_test.go
@@ -25,6 +25,7 @@ import (
 
 type fakeGCal struct {
 	events            map[string]*calendarv3.Event
+	instances         map[string]string // "recurringEventID|originalStart" -> instance event id
 	inserts, updates  int
 	patches           int
 	lastPatch         *calendarv3.Event // event arg of the most recent Patch
@@ -35,7 +36,9 @@ type fakeGCal struct {
 	listIdx           int
 }
 
-func newFakeGCal() *fakeGCal { return &fakeGCal{events: map[string]*calendarv3.Event{}} }
+func newFakeGCal() *fakeGCal {
+	return &fakeGCal{events: map[string]*calendarv3.Event{}, instances: map[string]string{}}
+}
 
 func (f *fakeGCal) Get(_ context.Context, _, id string) (*calendarv3.Event, error) {
 	f.gets++
@@ -98,6 +101,18 @@ func (f *fakeGCal) Patch(_ context.Context, _, id, _ string, ev *calendarv3.Even
 	out.Etag = `"etag-patched"`
 	f.events[id] = &out
 	return &out, nil
+}
+
+func (f *fakeGCal) InstanceAt(_ context.Context, _, recurringEventID, originalStart string) (*calendarv3.Event, error) {
+	id, ok := f.instances[recurringEventID+"|"+originalStart]
+	if !ok {
+		return nil, gcal.ErrAlreadyGone
+	}
+	ev, ok := f.events[id]
+	if !ok {
+		return nil, gcal.ErrAlreadyGone
+	}
+	return ev, nil
 }
 
 func (f *fakeGCal) Delete(_ context.Context, _, id string) error {
@@ -665,5 +680,71 @@ func TestHandlePersonDelete_Deactivates(t *testing.T) {
 	}
 	if len(st.deactivated) != 1 {
 		t.Fatalf("deactivated = %d, want 1", len(st.deactivated))
+	}
+}
+
+// TestHandleUpsert_PerInstanceEditPatchesInstance covers ADR-0044 §2: Scope=this resolves
+// the occurrence and patches the instance's own id (an override), never the master.
+func TestHandleUpsert_PerInstanceEditPatchesInstance(t *testing.T) {
+	p, g, st := newTestProcessor()
+	start, end := timedEvent(t)
+	// Seed the resolvable instance.
+	g.events["g1_20260622"] = &calendarv3.Event{Id: "g1_20260622", Etag: `"inst-etag"`}
+	g.instances["g1|2026-06-22T13:00:00Z"] = "g1_20260622"
+
+	evt := cloudEvent(t, schemas.CalendarUpsertData{
+		Scope: schemas.ScopeThis, RecurringEventID: "g1", OriginalStart: "2026-06-22T13:00:00Z",
+		Summary: "Just this one", Start: start, End: end,
+	})
+	if err := p.handleUpsert(context.Background(), evt); err != nil {
+		t.Fatalf("per-instance edit: %v", err)
+	}
+	if g.patches != 1 {
+		t.Fatalf("expected 1 instance patch, got %d", g.patches)
+	}
+	if g.lastPatch.Recurrence != nil {
+		t.Errorf("an override instance must not carry recurrence, got %v", g.lastPatch.Recurrence)
+	}
+	if st.upserts == 0 {
+		t.Error("expected the override to be mirrored")
+	}
+}
+
+// TestHandleDelete_PerInstanceCancelsOccurrence covers ADR-0044 §2 delete: Scope=this
+// cancels the resolved instance (status=cancelled), not the series.
+func TestHandleDelete_PerInstanceCancelsOccurrence(t *testing.T) {
+	p, g, _ := newTestProcessor()
+	g.events["g1_20260622"] = &calendarv3.Event{Id: "g1_20260622", Etag: `"inst-etag"`}
+	g.instances["g1|2026-06-22T13:00:00Z"] = "g1_20260622"
+
+	evt := cloudEvent(t, schemas.CalendarDeleteData{
+		Scope: schemas.ScopeThis, RecurringEventID: "g1", OriginalStart: "2026-06-22T13:00:00Z",
+	})
+	if err := p.handleDelete(context.Background(), evt); err != nil {
+		t.Fatalf("per-instance delete: %v", err)
+	}
+	if g.patches != 1 || g.deletes != 0 {
+		t.Fatalf("expected 1 cancel-patch and 0 series deletes, got patches=%d deletes=%d", g.patches, g.deletes)
+	}
+	if g.lastPatch.Status != "cancelled" {
+		t.Errorf("instance status = %q, want cancelled", g.lastPatch.Status)
+	}
+}
+
+// TestHandleUpsert_ThisAndFollowingIsIgnored covers ADR-0044 obligation 5: the deferred
+// scope is a no-op (not silently downgraded), touching neither Google nor the mirror.
+func TestHandleUpsert_ThisAndFollowingIsIgnored(t *testing.T) {
+	p, g, st := newTestProcessor()
+	start, end := timedEvent(t)
+	evt := cloudEvent(t, schemas.CalendarUpsertData{
+		Scope: schemas.ScopeThisAndFollowing, RecurringEventID: "g1", OriginalStart: "2026-06-22T13:00:00Z",
+		Summary: "nope", Start: start, End: end,
+	})
+	if err := p.handleUpsert(context.Background(), evt); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if g.patches != 0 || g.inserts != 0 || g.updates != 0 || st.upserts != 0 {
+		t.Errorf("this_and_following must be a no-op, got patches=%d inserts=%d updates=%d upserts=%d",
+			g.patches, g.inserts, g.updates, st.upserts)
 	}
 }

--- a/services/engine/processors/calendar/processor_test.go
+++ b/services/engine/processors/calendar/processor_test.go
@@ -26,6 +26,8 @@ import (
 type fakeGCal struct {
 	events            map[string]*calendarv3.Event
 	inserts, updates  int
+	patches           int
+	lastPatch         *calendarv3.Event // event arg of the most recent Patch
 	deletes, gets     int
 	nextID            int
 	failNextUpdate412 bool
@@ -71,6 +73,29 @@ func (f *fakeGCal) Update(_ context.Context, _, id, _ string, ev *calendarv3.Eve
 	out := *ev
 	out.Id = id
 	out.Etag = `"etag-upd"`
+	f.events[id] = &out
+	return &out, nil
+}
+
+func (f *fakeGCal) Patch(_ context.Context, _, id, _ string, ev *calendarv3.Event) (*calendarv3.Event, error) {
+	if f.failNextUpdate412 {
+		f.failNextUpdate412 = false
+		return nil, gcal.ErrConflict
+	}
+	f.patches++
+	f.lastPatch = ev
+	// Patch merges: preserve fields the caller omitted (nil) from the stored event.
+	out := *ev
+	if cur, ok := f.events[id]; ok {
+		if out.Recurrence == nil {
+			out.Recurrence = cur.Recurrence
+		}
+		if out.Summary == "" {
+			out.Summary = cur.Summary
+		}
+	}
+	out.Id = id
+	out.Etag = `"etag-patched"`
 	f.events[id] = &out
 	return &out, nil
 }
@@ -329,8 +354,41 @@ func TestHandleUpsert_Update412ResyncsAndRetries(t *testing.T) {
 	if g.gets != 1 {
 		t.Errorf("expected 1 resync Get after 412, got %d", g.gets)
 	}
-	if g.updates != 1 {
-		t.Errorf("expected 1 successful update after retry, got %d", g.updates)
+	if g.patches != 1 {
+		t.Errorf("expected 1 successful patch after retry, got %d", g.patches)
+	}
+}
+
+// TestHandleUpsert_UpdatePreservesOmittedRecurrence is the ADR-0044 §4b guarantee: editing a
+// field of a recurring event while omitting recurrence must NOT strip the series. The update
+// path goes through events.patch, and the patched event carries no recurrence (so Google
+// preserves it) — the legacy events.update full-replace would have cleared it.
+func TestHandleUpsert_UpdatePreservesOmittedRecurrence(t *testing.T) {
+	p, g, st := newTestProcessor()
+	start, end := timedEvent(t)
+	rrule := []string{"RRULE:FREQ=WEEKLY;BYDAY=MO"}
+	g.events["g1"] = &calendarv3.Event{
+		Id: "g1", Etag: `"fresh"`, Summary: "Standup", Recurrence: rrule,
+		Start: &calendarv3.EventDateTime{DateTime: "2026-06-22T09:00:00-04:00"},
+		End:   &calendarv3.EventDateTime{DateTime: "2026-06-22T10:00:00-04:00"},
+	}
+	st.events["g1"] = &store.CalendarEvent{GoogleEventID: "g1", Etag: "fresh"}
+
+	// Edit only the summary; recurrence omitted (HA's "untouched" contract).
+	evt := cloudEvent(t, schemas.CalendarUpsertData{
+		GoogleEventID: "g1", Summary: "Standup (moved)", Start: start, End: end, Etag: "fresh",
+	})
+	if err := p.handleUpsert(context.Background(), evt); err != nil {
+		t.Fatalf("update: %v", err)
+	}
+	if g.patches != 1 || g.updates != 0 {
+		t.Fatalf("expected exactly 1 patch and 0 updates, got patches=%d updates=%d", g.patches, g.updates)
+	}
+	if len(g.lastPatch.Recurrence) != 0 {
+		t.Errorf("patch must omit recurrence so Google preserves it, got %v", g.lastPatch.Recurrence)
+	}
+	if got := g.events["g1"].Recurrence; len(got) != 1 || got[0] != rrule[0] {
+		t.Errorf("series recurrence not preserved after edit: %v", got)
 	}
 }
 

--- a/services/engine/processors/calendar/writethrough.go
+++ b/services/engine/processors/calendar/writethrough.go
@@ -28,9 +28,17 @@ func (p *Processor) handleUpsert(ctx context.Context, evt *schemas.CloudEvent) e
 
 	var result *calendarv3.Event
 	var err error
-	if d.GoogleEventID == "" {
+	switch {
+	case d.Scope == schemas.ScopeThisAndFollowing:
+		// Deferred (ADR-0044 obligation 5). Do not silently downgrade to all/this.
+		p.log.Warn("calendar: scope=this_and_following not yet supported — ignoring edit",
+			slog.String("recurring_event_id", d.RecurringEventID))
+		return nil
+	case d.Scope == schemas.ScopeThis:
+		result, err = p.updateInstance(ctx, &d, gev)
+	case d.GoogleEventID == "":
 		result, err = p.create(ctx, evt.ID, &d, gev)
-	} else {
+	default:
 		result, err = p.update(ctx, &d, gev)
 	}
 	if err != nil {
@@ -120,6 +128,60 @@ func (p *Processor) update(ctx context.Context, d *schemas.CalendarUpsertData, g
 	return out, nil
 }
 
+// updateInstance edits a single occurrence of a recurring series (Scope=this, ADR-0044):
+// resolve the occurrence by original_start, then patch that instance's own event id — an
+// instance override at Google. Recurrence is cleared (an instance cannot carry an RRULE).
+func (p *Processor) updateInstance(ctx context.Context, d *schemas.CalendarUpsertData, gev *calendarv3.Event) (*calendarv3.Event, error) {
+	inst, err := p.gcal.InstanceAt(ctx, p.calendarID, d.RecurringEventID, d.OriginalStart)
+	if errors.Is(err, gcal.ErrAlreadyGone) {
+		p.log.Warn("calendar: per-instance edit — occurrence not found, skipping",
+			slog.String("recurring_event_id", d.RecurringEventID), slog.String("original_start", d.OriginalStart))
+		return nil, nil
+	}
+	if err != nil {
+		return nil, fmt.Errorf("calendar: resolve instance: %w", err)
+	}
+	gev.Recurrence = nil // an override instance cannot hold an RRULE
+
+	out, perr := p.gcal.Patch(ctx, p.calendarID, inst.Id, trimEtag(inst.Etag), gev)
+	if errors.Is(perr, gcal.ErrConflict) {
+		fresh, rerr := p.gcal.Get(ctx, p.calendarID, inst.Id)
+		if rerr != nil {
+			return nil, fmt.Errorf("calendar: resync instance after 412: %w", rerr)
+		}
+		out, perr = p.gcal.Patch(ctx, p.calendarID, inst.Id, trimEtag(fresh.Etag), gev)
+	}
+	if perr != nil {
+		return nil, fmt.Errorf("calendar: patch instance: %w", perr)
+	}
+	return out, nil
+}
+
+// deleteInstance cancels a single occurrence (Scope=this, ADR-0044): patch the resolved
+// instance's status to cancelled — an override tombstone the mirror + expansion subtract.
+func (p *Processor) deleteInstance(ctx context.Context, d *schemas.CalendarDeleteData) error {
+	inst, err := p.gcal.InstanceAt(ctx, p.calendarID, d.RecurringEventID, d.OriginalStart)
+	if errors.Is(err, gcal.ErrAlreadyGone) {
+		p.log.Info("calendar: per-instance delete — occurrence already gone, skipping",
+			slog.String("recurring_event_id", d.RecurringEventID), slog.String("original_start", d.OriginalStart))
+		return nil
+	}
+	if err != nil {
+		return fmt.Errorf("calendar: resolve instance: %w", err)
+	}
+	out, perr := p.gcal.Patch(ctx, p.calendarID, inst.Id, trimEtag(inst.Etag), &calendarv3.Event{Status: "cancelled"})
+	if perr != nil {
+		return fmt.Errorf("calendar: cancel instance: %w", perr)
+	}
+	// Mirror the cancelled override immediately so the read expansion subtracts it.
+	if params, mperr := googleToParams(out, p.calendarID); mperr == nil {
+		_ = p.q.UpsertEvent(ctx, params)
+	}
+	p.log.Info("calendar: occurrence cancelled",
+		slog.String("recurring_event_id", d.RecurringEventID), slog.String("original_start", d.OriginalStart))
+	return nil
+}
+
 // handleDelete applies a calendar.event.delete (series-level for MVP): delete in
 // Google, then remove the mirror row. Overlay rows cascade via the FK.
 //
@@ -136,6 +198,16 @@ func (p *Processor) handleDelete(ctx context.Context, evt *schemas.CloudEvent) e
 		p.log.Warn("calendar: bad delete payload", slog.String("error", err.Error()))
 		return nil
 	}
+
+	switch d.Scope {
+	case schemas.ScopeThisAndFollowing:
+		p.log.Warn("calendar: scope=this_and_following not yet supported — ignoring delete",
+			slog.String("recurring_event_id", d.RecurringEventID))
+		return nil
+	case schemas.ScopeThis:
+		return p.deleteInstance(ctx, &d)
+	}
+
 	if d.GoogleEventID == "" {
 		p.log.Warn("calendar: delete missing google_event_id")
 		return nil

--- a/services/engine/processors/calendar/writethrough.go
+++ b/services/engine/processors/calendar/writethrough.go
@@ -96,8 +96,11 @@ func (p *Processor) create(ctx context.Context, eventID string, d *schemas.Calen
 	return out, nil
 }
 
+// update uses Google events.patch (not update/replace) so fields the caller omits — notably
+// recurrence, which the HA surface drops when untouched — are preserved rather than stripped
+// (ADR-0044). Optimistic concurrency and the resync-and-retry-once-on-412 flow are unchanged.
 func (p *Processor) update(ctx context.Context, d *schemas.CalendarUpsertData, gev *calendarv3.Event) (*calendarv3.Event, error) {
-	out, err := p.gcal.Update(ctx, p.calendarID, d.GoogleEventID, d.Etag, gev)
+	out, err := p.gcal.Patch(ctx, p.calendarID, d.GoogleEventID, d.Etag, gev)
 	if errors.Is(err, gcal.ErrConflict) {
 		// Stale etag: fetch the current event, refresh the mirror, retry once with
 		// the fresh etag rather than clobbering a concurrent edit.
@@ -109,7 +112,7 @@ func (p *Processor) update(ctx context.Context, d *schemas.CalendarUpsertData, g
 		if params, perr := googleToParams(fresh, p.calendarID); perr == nil {
 			_ = p.q.UpsertEvent(ctx, params)
 		}
-		out, err = p.gcal.Update(ctx, p.calendarID, d.GoogleEventID, trimEtag(fresh.Etag), gev)
+		out, err = p.gcal.Patch(ctx, p.calendarID, d.GoogleEventID, trimEtag(fresh.Etag), gev)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("calendar: google update: %w", err)

--- a/services/gateway/README.md
+++ b/services/gateway/README.md
@@ -23,8 +23,14 @@ Fire `ruby_home_event` with the caller's payload wrapped under a `payload` key (
 | `calendar.event.delete` | `ha.events.calendar.event_delete` | calendar processor (Slice C) |
 | `ruby_home.childcare.provider.upsert` | `ha.events.ruby_home.childcare.provider_upsert` | overlay (Slice D) |
 | `ruby_home.childcare.provider.delete` | `ha.events.ruby_home.childcare.provider_delete` | overlay (Slice D) |
+| `ruby_home.directory.person.upsert` | `ha.events.ruby_home.directory.person_upsert` | overlay (#155 §3) |
+| `ruby_home.directory.person.delete` | `ha.events.ruby_home.directory.person_delete` | overlay (#155 §3) |
 
 Example HA event data: `{"payload": {"event": "calendar.event.upsert", "summary": "Dentist", "start": {...}, "idempotency_key": "…"}}`. Full payload field contracts are in ROADMAP-0012.
+
+**Overlay upsert semantics (#155 §4a):** both `ruby_home.childcare.provider.upsert` and `ruby_home.directory.person.upsert` are **insert-or-update by the client-supplied `id`** (`ON CONFLICT (id) DO UPDATE`). A producer may generate a UUID, send it on the upsert, and attach it to a draft immediately — an unknown id inserts rather than no-ops. A directory person upsert is a **full record** (HA owns the person model and sends the whole object); a childcare provider upsert likewise carries the full provider.
+
+**Calendar edit/delete scope (#155 §2, ADR-0044):** calendar upsert/delete carry an optional `scope` — `all` (default; the whole series or a single event) or `this` (one occurrence, addressed by `recurring_event_id` + `original_start`). `this` writes a Google instance override (edit) or cancels the occurrence (delete). `this_and_following` is **not yet supported** — the engine logs and ignores it; consumers should withhold that option. Calendar **updates are patch-merge** (Google `events.patch`): fields omitted from the payload — notably `recurrence` — are preserved, so editing one field of a recurring event never strips its RRULE.
 
 Calendar creates are made idempotent at Google via a deterministic event id derived from `idempotency_key` (ADR-0042). The HA producer **SHOULD** supply a unique-per-action `idempotency_key`; if it doesn't, the gateway derives one from the stable content fields so a re-published create cannot double-insert (#138). Supplying your own key is preferred when two same-time/same-summary events could be legitimately distinct.
 

--- a/services/gateway/rubyhome/publish.go
+++ b/services/gateway/rubyhome/publish.go
@@ -29,6 +29,8 @@ var eventRoutes = map[string]string{
 	"calendar.event.delete":               schemas.HomeEventCalendarDelete,
 	"ruby_home.childcare.provider.upsert": schemas.HomeEventChildcareProviderUpsert,
 	"ruby_home.childcare.provider.delete": schemas.HomeEventChildcareProviderDelete,
+	"ruby_home.directory.person.upsert":   schemas.HomeEventDirectoryPersonUpsert,
+	"ruby_home.directory.person.delete":   schemas.HomeEventDirectoryPersonDelete,
 }
 
 // Publish wraps payload in a CloudEvent and publishes it to the ha.events.* subject

--- a/services/gateway/rubyhome/publish_test.go
+++ b/services/gateway/rubyhome/publish_test.go
@@ -21,6 +21,8 @@ func TestEventRoutes(t *testing.T) {
 		"calendar.event.delete":               schemas.HomeEventCalendarDelete,
 		"ruby_home.childcare.provider.upsert": schemas.HomeEventChildcareProviderUpsert,
 		"ruby_home.childcare.provider.delete": schemas.HomeEventChildcareProviderDelete,
+		"ruby_home.directory.person.upsert":   schemas.HomeEventDirectoryPersonUpsert,
+		"ruby_home.directory.person.delete":   schemas.HomeEventDirectoryPersonDelete,
 	}
 	if len(eventRoutes) != len(want) {
 		t.Fatalf("eventRoutes has %d entries, want %d", len(eventRoutes), len(want))


### PR DESCRIPTION
## Summary

Closes the four ruby-core-side gaps that blocked the Home Assistant `rh-calendar` surface from fully and safely consuming the calendar seams (#155), as one PR. Governed by **ADR-0044** (calendar write semantics — patch-merge + per-instance recurring edits).

A finding that shrank the work: the `calendar_event` table already stored recurrence/etag/recurring_event_id/original_start, the store already had `UpsertPerson`, and the childcare upsert was already insert-or-update by id — so §1 was pure exposure and §4a needed no code.

Closes #155.

## What's in it (ordered data-loss-fix-first)

- **§4b — data-loss fix.** Calendar updates now use Google `events.patch` (new `gcal.Patch`) instead of `events.update` (full replace). An edit that omits `recurrence` (HA's untouched-field contract) no longer strips the series' RRULE. Test proves a summary-only edit preserves recurrence.
- **§1 — read fields.** Added `etag`, `recurrence`, `recurring_event_id`, `original_start` to the `CalendarInstance` OpenAPI schema (non-nullable; regen ogen + python client) and mapped them in `toAPIInstance`: recurrence/etag from the source row; `recurring_event_id` explicit on override rows, else the master's own id for its occurrences; `original_start` from an override's pinned slot, else the recurring occurrence's scheduled start.
- **§3 — directory write route.** `ruby_home.directory.person.upsert/.delete`: schema subject consts + `DirectoryPersonData` payloads, gateway `eventRoutes`, engine `handlePersonUpsert/handlePersonDelete`, and a new `DeactivatePerson` soft-delete query. Insert-or-update by client id (full record).
- **§2 — per-instance edit/delete.** A `scope` field (`all` default / `this` / `this_and_following`); `this` resolves the occurrence via `gcal.InstanceAt` (Google `events.instances` by `original_start`) and patches the instance override (edit) or cancels it (delete) — never the master. **`this_and_following` is a logged no-op (deferred, ADR-0044 obligation 5).**
- **§4a — confirmed + documented** (no code): the overlay upserts are insert-or-update by the client-supplied id.

## Deferred (ADR-0044)

- `this_and_following` (series split) — consumers should keep withholding that scope option.
- Explicit recurrence-clearing (make a recurring series non-recurring) — not expressible under the omit-untouched payload; route through a future scope-aware path.

## Release-please

5 `feat`/`fix` + 2 `docs` commits → next **minor** bump (`0.29.0 → 0.30.0`). No breaking changes.

## Drift Observations

None new.

## Test plan

- `go build ./...`, `go test -tags=fast -race -short ./...`, `go build -tags=integration ./...` — all green.
- `make openapi-verify` clean (artifacts regenerated + committed); spectral lint clean.
- `golangci-lint run --new-from-rev=origin/main` (v2.11.4) — 0 issues.
- New unit tests: patch-preserves-recurrence; read-field mapping (recurring/override/single); directory upsert/rename/deactivate; per-instance edit/cancel; deferred this_and_following no-op.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
